### PR TITLE
Enhance post-commit script to exclude .gitignore and ignored files fr…

### DIFF
--- a/post-commit-my-scripts.ps1
+++ b/post-commit-my-scripts.ps1
@@ -5,13 +5,43 @@ $destinationFolder = "C:\Users\manoj\Documents\Scripts"
 # Get list of modified files in the latest commit
 $modifiedFiles = git -C $repoPath diff-tree --no-commit-id --name-only -r HEAD
 
-# Copy only files modified in the latest commit
+# Read .gitignore file
+$gitignorePath = Join-Path -Path $repoPath -ChildPath ".gitignore"
+$ignoredPatterns = @()
+
+# Check if .gitignore exists and read its contents
+if (Test-Path $gitignorePath) {
+    $ignoredPatterns = Get-Content -Path $gitignorePath
+}
+
+# Function to check if a file matches any ignored patterns
+function Is-Ignored {
+    param (
+        [string]$fileName
+    )
+
+    # Check if the file is .gitignore itself
+    if ($fileName -eq ".gitignore") {
+        return $true
+    }
+
+    # Check against patterns in .gitignore
+    foreach ($pattern in $ignoredPatterns) {
+        # Use -like for wildcard matching, if applicable
+        if ($fileName -like $pattern) {
+            return $true
+        }
+    }
+    return $false
+}
+
+# Copy only files modified in the latest commit, excluding .gitignore and ignored files
 $modifiedFiles | ForEach-Object {
     $sourceFilePath = Join-Path -Path $repoPath -ChildPath $_
     $destinationFilePath = Join-Path -Path $destinationFolder -ChildPath $_
 
-    # Only copy if the source file exists
-    if (Test-Path $sourceFilePath) {
+    # Only copy if the source file exists and is not in .gitignore
+    if (Test-Path $sourceFilePath -and -not (Is-Ignored $_)) {
         Copy-Item -Path $sourceFilePath -Destination $destinationFolder -Force
     }
 }


### PR DESCRIPTION
…om propagation

This commit modifies the post-commit script for the My Scripts repository to ensure that the .gitignore file and any files specified within it are excluded from being propagated to C:\Users\manoj\Documents\Scripts.

Changes Made:
Implemented a check in the script to skip copying the .gitignore file itself. Added functionality to read the contents of the .gitignore file and exclude any files listed within it from being propagated. Created a helper function, Is-Ignored, to streamline the logic for checking against the .gitignore patterns. These changes improve the integrity of the repository by preventing unintended propagation of files that should remain local and ensuring that the .gitignore file is not included in the destination folder.