### PR TITLE
Add progress message during video processing

### DIFF
--- a/videoscreenshot.ps1
+++ b/videoscreenshot.ps1
@@ -219,6 +219,7 @@ try {
 
         $currentRunCount++
         Write-Message "Finished processing video: $($video.Name)"
+        Write-Message "Completed video $currentRunCount/$($videoFiles.Count)"
 
         # Stop if video limit is reached
         if ($currentRunCount -eq $videoLimit) {


### PR DESCRIPTION
- Reused the existing `currentRunCount` variable to track the number of videos processed.
- Added a progress message in the format `Completed video xxx/yyy`, where `xxx` is the current run count, and `yyy` is the total number of videos to be processed.
- Ensured the message is printed after each video is processed and logged.