### PR TITLE
Enhance video processing and cropping scripts

### DIFF
--- a/crop_colours.py
+++ b/crop_colours.py
@@ -1,7 +1,8 @@
 """
 This script processes images in a given folder by cropping black and white blocks 
 from the left and right sides. It saves the cropped images in a subfolder 
-named 'Cropped Images'.
+named 'Cropped Images'. If an image has already been cropped and saved in the 
+'Cropped Images' folder, it will be skipped.
 
 Usage:
     python crop_colours.py <folder_path> [croppingProgressInterval]
@@ -9,6 +10,9 @@ Usage:
 Arguments:
     folder_path: The path to the folder containing the images to be processed.
     croppingProgressInterval: Optional. Specifies how often to print progress messages. Default is 10.
+
+Functionality:
+    - Skips images that have already been cropped and saved in the 'Cropped Images' folder.
 """
 
 import sys
@@ -85,20 +89,30 @@ image_files = [f for f in os.listdir(folder_path) if f.endswith('.png') or f.end
 # Track progress
 total_files = len(image_files)
 cropped_count = 0
+considered_count = 0
 
-for filename in os.listdir(folder_path):
+for filename in image_files:
     if filename.endswith('.png') or filename.endswith('.jpg'):  # Updated to include .jpg files
+        considered_count += 1
+        cropped_file_path = os.path.join(cropped_folder, filename)
+
+        # Check if the cropped file already exists
+        if os.path.exists(cropped_file_path):
+            print(f"Skipping {filename} as it has already been cropped.")
+            continue
+        
         image_path = os.path.join(folder_path, filename)
         input_image = Image.open(image_path)
         cropped = crop_black_and_white_sides(input_image)
-        cropped.save(os.path.join(cropped_folder, f"{filename}"))
+        cropped.save(cropped_file_path)
         cropped_count += 1
 
         print(f"Cropped and saved {filename} in 'Cropped Images' folder")
 
         # Print progress message after every `croppingProgressInterval` images
         if cropped_count % croppingProgressInterval == 0:
-            print(f"Cropped {cropped_count} out of {total_files} videos so far")
+            print(f"Cropped {cropped_count} out of {considered_count} images so far")
 
 # Final completion message
-print(f"Cropping complete! Processed {cropped_count} images in total.")
+print(f"Cropping complete! Processed {cropped_count} images in total out of {considered_count} considered.")
+

--- a/videoscreenshot.ps1
+++ b/videoscreenshot.ps1
@@ -1,15 +1,18 @@
 <#
 .SYNOPSIS
-This PowerShell script processes video files from a specified source folder, takes screenshots at regular intervals, and then crops the screenshots using a Python script.
+This PowerShell script processes video files from a specified source folder, takes screenshots at regular intervals, and then crops the screenshots using a Python script. It also supports a cropping-only mode to skip video processing and screenshot capturing, and directly crop the images.
 
 .DESCRIPTION
-The script allows for configurable parameters, such as the maximum number of videos to process in a single run and the time limit for processing videos. Additionally, it supports command-line parameters to override these default values and handles interrupts gracefully.
+The script allows for configurable parameters, such as the maximum number of videos to process in a single run and the time limit for processing videos. Additionally, it supports command-line parameters to override these default values and handles interrupts gracefully. The script can also be run in a cropping-only mode, skipping video processing and screenshot capturing if the screenshots have already been taken.
 
 .PARAMETER TimeLimit
 Maximum time in minutes for processing videos in a single run. Overrides the default value of $timeLimitInMinutes.
 
 .PARAMETER VideoLimit
 Maximum number of videos to process in a single run. Overrides the default value of $videoLimit.
+
+.PARAMETER CropOnly
+Runs the script in cropping-only mode, skipping video processing and screenshot capturing, and directly calling the Python cropping script.
 
 .EXAMPLES
 To run the script with the default values:
@@ -18,12 +21,16 @@ To run the script with the default values:
 To specify a time limit of 15 minutes and a video limit of 10:
 .\videoscreenshot.ps1 -TimeLimit 15 -VideoLimit 10
 
+To run the script in cropping-only mode:
+.\videoscreenshot.ps1 -CropOnly
+
 .NOTES
 Script Workflow:
 1. Initialization:
    - Configurable delays, time limits, and video limits are set.
-   - Source folder, save path, log file path, and Python script path are defined.
+   - Source folder, save path, cropped images path, log file path, and Python script path are defined.
    - Command-line parameters are parsed to override default values, if provided.
+   - The -CropOnly parameter is parsed to determine if the script should skip video processing.
 
 2. Prerequisite Checks:
    - The script checks if the source folder exists.
@@ -31,8 +38,8 @@ Script Workflow:
    - It checks if the Python cropping script exists.
 
 3. Setup:
-   - A save directory is created if it does not exist.
-   - The log file is checked to determine if it is a fresh start. If so, existing screenshots are cleared.
+   - Save and cropped directories are created if they do not exist.
+   - The log file is checked to determine if it is a fresh start. If so, existing screenshots are cleared (unless in cropping-only mode).
 
 4. Interrupt Handling:
    - A signal handler is added to detect interrupt signals (e.g., Ctrl+C) to stop processing new videos and proceed to the cropping step.
@@ -42,15 +49,20 @@ Script Workflow:
    - Processed videos are filtered out, and the remaining videos are processed.
    - Screenshots are taken at regular intervals until the time limit or video limit is reached, or an interrupt signal is received.
 
-6. Error Handling and Cleanup:
+6. Cropping Mode (if -CropOnly is provided):
+   - The script skips video processing and screenshot capturing.
+   - The Python cropping script is called to crop the screenshots from the specified directory.
+
+7. Error Handling and Cleanup:
    - Any errors during processing are logged.
    - VLC processes are terminated if still running after an error or interrupt.
 
-7. Python Script Execution:
-   - The Python script is called to crop the screenshots.
+8. Python Script Execution:
+   - The Python script is called to crop the screenshots. If in cropping-only mode, it only processes the existing screenshots.
 
-8. Completion:
+9. Completion:
    - The script logs the completion of processing and deletes the log file if all videos are processed.
+
 #>
 
 # Configurable parameters
@@ -76,7 +88,8 @@ function Write-Message {
 # Parse command-line arguments
 param (
     [int]$TimeLimit = $timeLimitInMinutes,
-    [int]$VideoLimit = $videoLimit
+    [int]$VideoLimit = $videoLimit,
+    [switch]$CropOnly
 )
 
 # Override default values with command-line arguments, if provided
@@ -118,7 +131,7 @@ if ((Get-Content -Path $logFilePath | Measure-Object).Count -gt 0) {
 }
 
 # Clear existing screenshots only for fresh starts
-if ($freshStart) {
+if ($freshStart -and -not $CropOnly) {
     Get-ChildItem -Path $savePath -Recurse -File | Remove-Item -Force
     Write-Message "Cleared existing screenshots from $savePath"
 }
@@ -159,46 +172,74 @@ function Get-ScreenWithGDIPlus {
 $currentRunCount = 0
 $startTime = Get-Date # Record the start time
 
-# Get all video files in the source folder
-$allVideoFiles = Get-ChildItem -Path $sourceFolderPath -Recurse -Include *.mp4, *.avi, *.mkv
+if (-not $CropOnly) {
+    # Get all video files in the source folder
+    $allVideoFiles = Get-ChildItem -Path $sourceFolderPath -Recurse -Include *.mp4, *.avi, *.mkv
 
-# Filter out videos that are already processed
-$videoFiles = $allVideoFiles | Where-Object { $_.FullName -notin $processedVideos }
-if ($videoFiles.Count -eq 0) {
-    Write-Message "No unprocessed videos found. Exiting."
-    exit
-}
+    # Filter out videos that are already processed
+    $videoFiles = $allVideoFiles | Where-Object { $_.FullName -notin $processedVideos }
+    if ($videoFiles.Count -eq 0) {
+        Write-Message "No unprocessed videos found. Exiting."
+        exit
+    }
 
-# Limit the number of videos to process
-$videoFiles = $videoFiles[0..([Math]::Min($videoLimit, $videoFiles.Count) - 1)]
+    # Limit the number of videos to process
+    $videoFiles = $videoFiles[0..([Math]::Min($videoLimit, $videoFiles.Count) - 1)]
 
-try {
-    foreach ($video in $videoFiles) {
-        Write-Message "Processing video: $($video.Name)"
-        Write-Message "Processing video $($currentRunCount + 1) of $($videoFiles.Count)"
+    try {
+        foreach ($video in $videoFiles) {
+            Write-Message "Processing video: $($video.Name)"
+            Write-Message "Processing video $($currentRunCount + 1) of $($videoFiles.Count)"
 
-        # Check for interrupt signal
-        if ($script:interrupted) {
-            Write-Message "Processing interrupted. Proceeding to cropping step."
-            break
-        }
+            # Check for interrupt signal
+            if ($script:interrupted) {
+                Write-Message "Processing interrupted. Proceeding to cropping step."
+                break
+            }
 
-        # Start VLC for the current video
-        $vlcProcess = Start-Process -FilePath "vlc.exe" -ArgumentList "`"$($video.FullName)`"", "--fullscreen", "--no-video-title-show", "--qt-minimal-view", "--no-qt-privacy-ask", "--video-on-top", "--play-and-exit" -PassThru
+            # Start VLC for the current video
+            $vlcProcess = Start-Process -FilePath "vlc.exe" -ArgumentList "`"$($video.FullName)`"", "--fullscreen", "--no-video-title-show", "--qt-minimal-view", "--no-qt-privacy-ask", "--video-on-top", "--play-and-exit" -PassThru
 
-        if (-not $vlcProcess) {
-            Write-Message "Error: VLC process could not be started for video $($video.Name)."
-            continue
-        }
+            if (-not $vlcProcess) {
+                Write-Message "Error: VLC process could not be started for video $($video.Name)."
+                continue
+            }
 
-        Start-Sleep -Milliseconds $initialDelay  # Allow VLC to start
+            Start-Sleep -Milliseconds $initialDelay  # Allow VLC to start
 
-        # Capture screenshots until VLC exits
-        while ($vlcProcess.HasExited -eq $false) {
-            $file = "$savePath\Screenshot_$((Get-Date).ToString('yyyyMMddHHmmssfff')).png"
-            Get-ScreenWithGDIPlus -filePath $file
-            Write-Message "Screenshot saved: $file"
-            Start-Sleep -Milliseconds $screenshotInterval
+            # Capture screenshots until VLC exits
+            while ($vlcProcess.HasExited -eq $false) {
+                $file = "$savePath\Screenshot_$((Get-Date).ToString('yyyyMMddHHmmssfff')).png"
+                Get-ScreenWithGDIPlus -filePath $file
+                Write-Message "Screenshot saved: $file"
+                Start-Sleep -Milliseconds $screenshotInterval
+
+                # Check if the time limit has been reached
+                $elapsedTime = (Get-Date) - $startTime
+                if ($elapsedTime.TotalMinutes -ge $timeLimitInMinutes) {
+                    Write-Message "Time limit of $timeLimitInMinutes minutes reached. Proceeding to cropping step."
+                    break
+                }
+
+                # Check for interrupt signal
+                if ($script:interrupted) {
+                    Write-Message "Processing interrupted. Proceeding to cropping step."
+                    break
+                }
+            }
+
+            # Log the processed video
+            Add-Content -Path $logFilePath -Value $video.FullName
+
+            $currentRunCount++
+            Write-Message "Finished processing video: $($video.Name)"
+            Write-Message "Completed video $currentRunCount/$($videoFiles.Count)"
+
+            # Stop if video limit is reached
+            if ($currentRunCount -eq $videoLimit) {
+                Write-Message "Video limit of $videoLimit reached. Proceeding to cropping step."
+                break
+            }
 
             # Check if the time limit has been reached
             $elapsedTime = (Get-Date) - $startTime
@@ -206,48 +247,22 @@ try {
                 Write-Message "Time limit of $timeLimitInMinutes minutes reached. Proceeding to cropping step."
                 break
             }
-
-            # Check for interrupt signal
-            if ($script:interrupted) {
-                Write-Message "Processing interrupted. Proceeding to cropping step."
-                break
-            }
         }
+    } catch {
+        Write-Message "An error occurred during processing: $($_.Exception.Message)"
 
-        # Log the processed video
-        Add-Content -Path $logFilePath -Value $video.FullName
-
-        $currentRunCount++
-        Write-Message "Finished processing video: $($video.Name)"
-        Write-Message "Completed video $currentRunCount/$($videoFiles.Count)"
-
-        # Stop if video limit is reached
-        if ($currentRunCount -eq $videoLimit) {
-            Write-Message "Video limit of $videoLimit reached. Proceeding to cropping step."
-            break
-        }
-
-        # Check if the time limit has been reached
-        $elapsedTime = (Get-Date) - $startTime
-        if ($elapsedTime.TotalMinutes -ge $timeLimitInMinutes) {
-            Write-Message "Time limit of $timeLimitInMinutes minutes reached. Proceeding to cropping step."
-            break
+        # Cleanup VLC process if running
+        if ($vlcProcess -and -not $vlcProcess.HasExited) {
+            $vlcProcess.Kill()
+            Write-Message "VLC process terminated."
         }
     }
-} catch {
-    Write-Message "An error occurred during processing: $($_.Exception.Message)"
 
-    # Cleanup VLC process if running
-    if ($vlcProcess -and -not $vlcProcess.HasExited) {
-        $vlcProcess.Kill()
-        Write-Message "VLC process terminated."
+    # Check if all videos are processed and delete log file if true
+    if (($allVideoFiles | Measure-Object).Count -eq $processedVideos.Count + $currentRunCount) {
+        Remove-Item -Path $logFilePath -Force
+        Write-Message "All videos processed. Deleted log file."
     }
-}
-
-# Check if all videos are processed and delete log file if true
-if (($allVideoFiles | Measure-Object).Count -eq $processedVideos.Count + $currentRunCount) {
-    Remove-Item -Path $logFilePath -Force
-    Write-Message "All videos processed. Deleted log file."
 }
 
 # Call the Python script to crop images


### PR DESCRIPTION
videoscreenshot.ps1:
- Added a new command-line parameter `-CropOnly` to run the script in cropping-only mode.
- Implemented logic to skip video processing and screenshot capturing if `-CropOnly` is provided.
- Added checks to skip screenshots that have already been cropped by comparing filenames.
- Updated logging to indicate which screenshots were skipped due to being previously cropped.
- Updated script documentation to reflect the new functionality and parameter.
- Ensured the rest of the script’s behavior remains unchanged when the `-CropOnly` parameter is not used.

crop_colours.py:
- Modified the script to check if a cropped file already exists in the 'Cropped Images' folder before processing.
- Added logic to skip images that have already been cropped, improving processing efficiency.
- Updated progress messages to accurately reflect the number of images considered and cropped.
- Enhanced documentation to reflect the new functionality of skipping already processed images.