### PR TITLE
fix: exclude hidden and system files (e.g., desktop.ini) from file se…

### DIFF
--- a/SelObj.ps1
+++ b/SelObj.ps1
@@ -52,8 +52,8 @@ if ($mainFolderFiles.Count -gt 0) {
 # Select a random folder (including the main target folder if applicable)
 $randomFolder = $subfolders | Get-Random
 
-# Get all files from the random folder
-$files = Get-ChildItem -Path $randomFolder.FullName -File -Force
+# Get all files from the random folder excluding hidden and system files
+$files = Get-ChildItem -Path $randomFolder.FullName -File -Force | Where-Object { -not ($_.Attributes -band [IO.FileAttributes]::Hidden) -and -not ($_.Attributes -band [IO.FileAttributes]::System) }
 
 # Check if there are any files in the selected folder
 if ($files.Count -gt 0) {


### PR DESCRIPTION
…lection

This update ensures that hidden and system files, such as desktop.ini, are excluded when selecting a random file from a folder. The issue occurred due to the inclusion of hidden/system files by Get-ChildItem when using the -Force parameter.

- Modified the file enumeration logic to filter out hidden and system files.
- Added checks for file attributes to exclude unwanted files.

This fix resolves an intermittent bug where desktop.ini was sometimes opened instead of a valid file.