### PR TITLE
fix: exclude hidden and system files from target folder validation

### DIFF
--- a/SelObj.ps1
+++ b/SelObj.ps1
@@ -43,7 +43,7 @@ param(
 $subfolders = Get-ChildItem -Path $FilePath -Directory -Force
 
 # Check if there are any files in the main target folder
-$mainFolderFiles = Get-ChildItem -Path $FilePath -File -Force
+$mainFolderFiles = Get-ChildItem -Path $FilePath -File | Where-Object { -not $_.Attributes.HasFlag([System.IO.FileAttributes]::Hidden) -and -not $_.Attributes.HasFlag([System.IO.FileAttributes]::System) }
 if ($mainFolderFiles.Count -gt 0) {
     # Add the main target folder to the list of subfolders
     $subfolders += Get-Item -Path $FilePath


### PR DESCRIPTION
- Updated the file validation logic to exclude hidden and system files when determining if the main target folder should be added to the list of subfolders.
- Removed the `-Force` flag from `Get-ChildItem` and added a filter using `.Attributes.HasFlag` to exclude hidden and system files.
- Ensures that only folders with eligible files are included in the selection process.

Addresses a bug where folders containing only hidden or system files were incorrectly added to the subfolder list, causing issues in the final selection process.