### PR TITLE
Remove debug output of file paths from FileDistributor script

### DIFF
--- a/FileDistributor.ps1
+++ b/FileDistributor.ps1
@@ -640,7 +640,6 @@ function Main {
                 
                 # Attempt to delete each file in $FilesToDelete
                 foreach ($file in $FilesToDelete) {
-                    Write-Host "file: $file"
                     try {
                         if (Test-Path -Path $file) {
                             Remove-File -FilePath $file


### PR DESCRIPTION
Removed the line Write-Host "file: $file" from the FileDistributor script to eliminate unwanted debug messages printing file paths during script execution.