### PR TITLE
fix(logging): Correct date-time format in logging configuration

### DIFF
--- a/crop_colours.py
+++ b/crop_colours.py
@@ -56,7 +56,12 @@ os.makedirs(cropped_folder, exist_ok=True)
 
 # Set up logging
 log_file_path = "C:\\Users\\manoj\\Documents\\Scripts\\crop_colours.log"
-logging.basicConfig(filename=log_file_path, level=logging.INFO, format='%(Y-%m-%d %H:%M:%S) : %(message)s')
+logging.basicConfig(
+    filename=log_file_path, 
+    level=logging.INFO, 
+    format='%(asctime)s : %(message)s', 
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 logger = logging.getLogger()
 
 def load_image(image_path):


### PR DESCRIPTION
- Fixed invalid date-time format string in `logging.basicConfig`.
- Replaced `%(Y-%m-%d %H:%M:%S)` with `%(asctime)s` for proper timestamp formatting.
- Added `datefmt='%Y-%m-%d %H:%M:%S'` to ensure consistent and readable timestamps in logs.
- Resolved KeyError caused by incorrect format, ensuring smooth execution of logging.

This change ensures that the logging functionality works as intended and prevents runtime errors.