### PR TITLE
Fix issue with state file deletion when restart is not requested

### DIFF
--- a/FileDistributor.ps1
+++ b/FileDistributor.ps1
@@ -659,7 +659,11 @@ function Main {
             # Check if a restart state file exists
             if (Test-Path -Path $StateFilePath) {
                 LogMessage -Message "Restart state file found but restart not requested. Deleting state file..." -IsWarning
+                # Release the file lock before deleting the state file
+                ReleaseFileLock -FileStream $fileLock
                 Remove-Item -Path $StateFilePath -Force
+                # Re-acquire the file lock after deleting the state file
+                $fileLock = AcquireFileLock -FilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount
             }
         }
 


### PR DESCRIPTION
- Release the file lock before attempting to delete the state file when the restart is not requested.
- Re-acquire the file lock after deleting the state file to ensure proper handling.
- This prevents the error where the state file cannot be accessed because it is being used by another process.