### PR TITLE
Add command-line parameter for file path in handle.ps1

### DIFF
--- a/handle.ps1
+++ b/handle.ps1
@@ -1,8 +1,25 @@
+<#
+.SYNOPSIS
+    This script checks which processes are holding a specified file using Handle.exe.
+
+.DESCRIPTION
+    The script uses the Sysinternals Handle utility to determine which processes are holding a specified file.
+    The path to the file to be checked must be provided as a mandatory command-line parameter.
+
+.PARAMETER FileToCheck
+    The path to the file you want to check for open handles.
+
+.EXAMPLE
+    .\handle.ps1 -FileToCheck "D:\Path\To\Your\File.jar"
+#>
+
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$FileToCheck
+)
+
 # Define the path to the Handle.exe utility
 $handlePath = "C:\Users\manoj\Documents\Scripts\Handle\handle.exe"  # Update this path to where you have handle.exe
-
-# Define the file you want to check
-$fileToCheck = "D:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2024.1.4\plugins\java-coverage\lib\java-coverage.jar"  # Update this path to the file you want to check
 
 # Check if handle.exe exists at the specified path
 if (-not (Test-Path $handlePath)) {
@@ -13,13 +30,13 @@ if (-not (Test-Path $handlePath)) {
 # Run Handle.exe with the file path
 try {
     # Invoke the handle.exe process
-    $handleOutput = & "$handlePath " $fileToCheck 2>&1
+    $handleOutput = & "$handlePath " $FileToCheck 2>&1
 
     # Check if handle.exe returned any output
     if ($handleOutput -match "No matching handles found") {
-        Write-Host "No processes are holding the file $fileToCheck."
+        Write-Host "No processes are holding the file $FileToCheck."
     } else {
-        Write-Host "Processes holding the file ${fileToCheck}:"
+        Write-Host "Processes holding the file ${FileToCheck}:"
         Write-Host $handleOutput
     }
 } catch {


### PR DESCRIPTION
- Updated the script to accept the file path as a mandatory command-line parameter.
- Added documentation for the script, including parameter description and usage example.