### PR TITLE
Fix: Remove extra space after timestamp in log messages

### DIFF
--- a/FileDistributor.ps1
+++ b/FileDistributor.ps1
@@ -140,7 +140,7 @@ function LogMessage {
     )
     # Get the timestamp and format the log entry
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp : $Message"
+    $logEntry = "$timestamp: $Message" # Removed the extra space after the timestamp
 
     # Append the log entry to the log file
     $logEntry | Add-Content -Path $LogFilePath


### PR DESCRIPTION
- Updated the `LogMessage` function to ensure the colon directly follows the timestamp without an extra space.