### PR TITLE
Update SCOPES to allow full Drive access for trash clearance

### DIFF
--- a/drive_space_monitor.py
+++ b/drive_space_monitor.py
@@ -28,7 +28,7 @@ def setup_logging(debug):
     )
 
 # Define the scope for Drive API access
-SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly']
+SCOPES = ['https://www.googleapis.com/auth/drive']
 
 def authenticate_and_get_drive_service():
     creds = None


### PR DESCRIPTION
- Changed SCOPES in drive_space.py to 'https://www.googleapis.com/auth/drive'
- This is required to fix the 403 Forbidden error when calling clear_trash()
- Existing token.json must be deleted and reauthorized to apply new permissions