### PR TITLE
Aligned PNG file handling with JPG file logic in picconvert.ps1

### DIFF
--- a/picconvert.ps1
+++ b/picconvert.ps1
@@ -37,6 +37,9 @@ foreach ($file in $files) {
             $notCopiedJpgCount++
             continue
         }
+    } elseif ($extension -eq "png") {
+        # Skip copying PNG files by default
+        continue
     }
 
     # Initialize counters if not already done


### PR DESCRIPTION
- Updated the script to skip copying PNG files by default, similar to the handling of JPG files not starting with 'img'.
- Ensured existing JPG file handling logic remains unaffected.
- Updated comments to reflect the changes in PNG file processing.