### PR TITLE
Add comprehensive error handling and logging to DeleteOldDownloads.ps1

### DIFF
--- a/src/powershell/DeleteOldDownloads.ps1
+++ b/src/powershell/DeleteOldDownloads.ps1
@@ -1,20 +1,33 @@
-#Deletes old download files from the Downloads folder
+# Delete old download files from the Downloads folder
+
+Start-Transcript -Path "C:\Temp\DeleteOldDownloadsTranscript.log" -Append -Force
 
 $FolderPath = "C:\Users\manoj\Downloads"
 $Days = 14
 $CurrentDate = Get-Date
-$LogFilePath = "C:\Users\manoj\Documents\Scripts\DeletedDownloadsLog.txt"  # Change to desired log file path
-
-# Ensure the log file directory exists
-$LogFileDir = Split-Path -Parent $LogFilePath
-if (!(Test-Path $LogFileDir)) {
-    New-Item -Path $LogFileDir -ItemType Directory -Force
-}
-
-# Append a log header with the date
-Add-Content -Path $LogFilePath -Value "Log Date: $CurrentDate`r`n"
+$LogFilePath = "C:\Users\manoj\Documents\Scripts\DeletedDownloadsLog.txt"
+$ErrorLogPath = "C:\Temp\DeleteOldDownloadsError.log"
 
 try {
+    # Test log file path access
+    Write-Output "Testing log path: $LogFilePath" | Out-File $ErrorLogPath -Append
+    if (Test-Path $LogFilePath) {
+        Write-Output "Log file exists" | Out-File $ErrorLogPath -Append
+    } else {
+        Write-Output "Log file does not exist" | Out-File $ErrorLogPath -Append
+    }
+
+    # Ensure the log file directory exists
+    $LogFileDir = Split-Path -Parent $LogFilePath
+    if (!(Test-Path $LogFileDir)) {
+        New-Item -Path $LogFileDir -ItemType Directory -Force
+        Write-Output "Created log directory: $LogFileDir" | Out-File $ErrorLogPath -Append
+    }
+
+    # Append a log header with the date
+    Add-Content -Path $LogFilePath -Value "Log Date: $CurrentDate`r`n"
+
+    # Process files
     $Files = Get-ChildItem -Path $FolderPath -File | Where-Object {
         ($CurrentDate - $_.LastWriteTime).Days -gt $Days
     }
@@ -25,30 +38,27 @@ try {
         Add-Content -Path $LogFilePath -Value "No files to delete.`r`n"
     } else {
         foreach ($File in $Files) {
-            # Log the file being deleted along with its last modified date
             $LastModified = $File.LastWriteTime
             Add-Content -Path $LogFilePath -Value "Deleting: $($File.FullName), Last Modified: $LastModified"
-            
-            # Delete the file
             Remove-Item -Path $File.FullName -Force
-            
-            # Increment the deleted files count
             $DeletedFilesCount++
         }
-
-        # Log the total number of files deleted
         Add-Content -Path $LogFilePath -Value "Total files deleted: $DeletedFilesCount"
     }
 
     # Add a footer to the log
     Add-Content -Path $LogFilePath -Value "Log Ended: $(Get-Date)`r`n`r`n"
+    Write-Output "Script completed successfully" | Out-File $ErrorLogPath -Append
     exit 0
 } catch {
-    # Log detailed error information
     $ErrorMessage = $_.Exception.Message
     $ErrorDetails = $_.Exception | Out-String
-    Add-Content -Path $LogFilePath -Value "Error: $ErrorMessage`r`nDetails: $ErrorDetails`r`n"
-
-    # Exit with an error code to trigger Task Scheduler's failure actions
+    $ErrorOutput = "Error: $ErrorMessage`r`nDetails: $ErrorDetails`r`n"
+    Write-Output $ErrorOutput | Out-File $ErrorLogPath -Append
+    if (Test-Path $LogFilePath) {
+        Add-Content -Path $LogFilePath -Value $ErrorOutput
+    }
     exit 1
+} finally {
+    Stop-Transcript
 }


### PR DESCRIPTION
- Wrapped entire script in try-catch to capture initialization errors
- Added Start-Transcript to log console output to C:\Temp\DeleteOldDownloadsTranscript.log
- Introduced secondary error log at C:\Temp\DeleteOldDownloadsError.log
- Added debug output to verify log file path accessibility
- Addresses issue where script fails without generating logs in scheduled task