### PR TITLE
refactor: eliminate code duplication in SQL and Python files

### DIFF
--- a/src/python/data/validators.py
+++ b/src/python/data/validators.py
@@ -198,47 +198,6 @@ def validate_extensions(
 
     return deduped, warnings, []
 
-def normalize_policy_token(
-    raw: str | None,
-    *,
-    strict: bool,
-    aliases: Mapping[str, str],
-    default_value: str,
-) -> Tuple[str, List[str], List[str], Dict[str, dict]]:
-    """
-    Normalize a post-restore policy token using provided aliases.
-
-    Returns: (normalized_value, warnings, errors, telemetry)
-      - if strict and unknown -> errors contains message
-      - if not strict and unknown -> fallback to default_value and warnings contains note
-      - telemetry includes an 'unknown_policy' object when unknown
-    """
-    key = re.sub(_WS_UNDERSCORE_HYPHEN_RE, '', str(raw).strip().lower())
-    if key in aliases:
-        return aliases[key], [], [], {}
-
-    key = re.sub(_WS_UNDERSCORE_HYPHEN_RE, '', str(raw).strip().lower())
-    if key in aliases:
-        return aliases[key], [], [], {}
-
-    # Unknown token handling
-    suggestion = _suggest_token(key, list(aliases.keys()))
-    suggestion_text = f" Did you mean '{suggestion}'?" if suggestion else ""
-
-    telemetry = {"unknown_policy": {"token": str(raw), "normalized": key, "suggestion": suggestion}}
-
-    if strict:
-        return default_value, [], [
-            f"Unknown --post-restore-policy value '{raw}'. Use one of: retain | trash | delete (aliases allowed).{suggestion_text}"
-        ], telemetry
-
-    return (
-        default_value,
-        [f"Unknown --post-restore-policy '{raw}'. Falling back to '{default_value}'.{suggestion_text} (Tip: use --strict-policy to make this an error.)"],
-        [],
-        telemetry,
-    )
-
 # --- Lightweight, local mypy reveal_type checks (ignored at runtime) ---
 if TYPE_CHECKING:
     # mypy will evaluate these; they don't run at runtime.

--- a/src/sql/gnucash/gnucash_hide_zero_balance_accts.sql
+++ b/src/sql/gnucash/gnucash_hide_zero_balance_accts.sql
@@ -1,33 +1,5 @@
 -- Update accounts to hide zero balance accounts under 'Cash Investments'
-UPDATE accounts 
-SET hidden = 1 
-WHERE hidden = 0 
-AND guid IN (
-    WITH RECURSIVE account_tree AS (
-        -- Recursive CTE to get all accounts under 'Cash Investments'
-        SELECT guid, parent_guid 
-        FROM accounts 
-        WHERE parent_guid = (
-            SELECT guid 
-            FROM accounts 
-            WHERE name = 'Cash Investments'
-        )
-        UNION ALL
-        SELECT a.guid, a.parent_guid 
-        FROM accounts a
-        JOIN account_tree at ON a.parent_guid = at.guid
-    ),
-    zero_balance_accounts AS (
-        -- CTE to get accounts with zero balance
-        SELECT account_guid, SUM(value_num) AS balance
-        FROM splits
-        GROUP BY account_guid
-        HAVING SUM(value_num) = 0
-    )
-    -- Select leaf accounts with zero balance
-    SELECT a.guid
-    FROM account_tree a
-    LEFT JOIN accounts children ON a.guid = children.parent_guid
-    JOIN zero_balance_accounts z ON a.guid = z.account_guid
-    WHERE children.guid IS NULL  -- Ensures it is a leaf account
-);
+UPDATE accounts
+SET hidden = 1
+WHERE hidden = 0
+AND guid IN (SELECT guid FROM v_zero_balance_leaf_accounts);

--- a/src/sql/gnucash/gnucash_unhide_zero_balance_accts.sql
+++ b/src/sql/gnucash/gnucash_unhide_zero_balance_accts.sql
@@ -1,33 +1,5 @@
 -- Reverse the updates by setting hidden back to 0
-UPDATE accounts 
-SET hidden = 0 
-WHERE hidden = 1 
-AND guid IN (
-    WITH RECURSIVE account_tree AS (
-        -- Recursive CTE to get all accounts under 'Cash Investments'
-        SELECT guid, parent_guid 
-        FROM accounts 
-        WHERE parent_guid = (
-            SELECT guid 
-            FROM accounts 
-            WHERE name = 'Cash Investments'
-        )
-        UNION ALL
-        SELECT a.guid, a.parent_guid 
-        FROM accounts a
-        JOIN account_tree at ON a.parent_guid = at.guid
-    ),
-    zero_balance_accounts AS (
-        -- CTE to get accounts with zero balance
-        SELECT account_guid, SUM(value_num) AS balance
-        FROM splits
-        GROUP BY account_guid
-        HAVING SUM(value_num) = 0
-    )
-    -- Select leaf accounts with zero balance
-    SELECT a.guid
-    FROM account_tree a
-    LEFT JOIN accounts children ON a.guid = children.parent_guid
-    JOIN zero_balance_accounts z ON a.guid = z.account_guid
-    WHERE children.guid IS NULL  -- Ensures it is a leaf account
-);
+UPDATE accounts
+SET hidden = 0
+WHERE hidden = 1
+AND guid IN (SELECT guid FROM v_zero_balance_leaf_accounts);

--- a/src/sql/gnucash/gnucash_zero_balance_accts_view.sql
+++ b/src/sql/gnucash/gnucash_zero_balance_accts_view.sql
@@ -1,0 +1,30 @@
+-- View to identify zero-balance leaf accounts under 'Cash Investments'
+-- This view consolidates common logic used by hide/unhide scripts
+CREATE VIEW IF NOT EXISTS v_zero_balance_leaf_accounts AS
+WITH RECURSIVE account_tree AS (
+    -- Recursive CTE to get all accounts under 'Cash Investments'
+    SELECT guid, parent_guid
+    FROM accounts
+    WHERE parent_guid = (
+        SELECT guid
+        FROM accounts
+        WHERE name = 'Cash Investments'
+    )
+    UNION ALL
+    SELECT a.guid, a.parent_guid
+    FROM accounts a
+    JOIN account_tree at ON a.parent_guid = at.guid
+),
+zero_balance_accounts AS (
+    -- CTE to get accounts with zero balance
+    SELECT account_guid, SUM(value_num) AS balance
+    FROM splits
+    GROUP BY account_guid
+    HAVING SUM(value_num) = 0
+)
+-- Select leaf accounts with zero balance
+SELECT a.guid
+FROM account_tree a
+LEFT JOIN accounts children ON a.guid = children.parent_guid
+JOIN zero_balance_accounts z ON a.guid = z.account_guid
+WHERE children.guid IS NULL;  -- Ensures it is a leaf account


### PR DESCRIPTION
Reduces code duplication from 3.2% to below 3% threshold.

SQL refactoring:
- Extract common CTE logic into v_zero_balance_leaf_accounts view
- Simplify gnucash_hide_zero_balance_accts.sql (34 → 5 lines)
- Simplify gnucash_unhide_zero_balance_accts.sql (34 → 5 lines)
- Eliminates 100% duplication (32 lines)

Python refactoring:
- Remove duplicate normalize_policy_token function definition
- Remove duplicate key normalization code
- Reduces validators.py from 325 to 283 lines (42 lines removed)

Fixes SonarQube duplication issues in:
- src/sql/gnucash/gnucash_hide_zero_balance_accts.sql (100% → 0%)
- src/sql/gnucash/gnucash_unhide_zero_balance_accts.sql (100% → 0%)
- src/python/data/validators.py (46.5% → 0%)