### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   auto-update:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/manoj-bhaskaran/My-Scripts/security/code-scanning/7](https://github.com/manoj-bhaskaran/My-Scripts/security/code-scanning/7)

To fix the problem, we need to add a `permissions` block to restrict the GITHUB_TOKEN for this workflow/job. The least privilege principle dictates we only provide the specific permissions required. Since the workflow creates a pull request and commits changes to the repository, it needs `contents: write` (for pushing commits and making changes to files) and `pull-requests: write` (for opening/managing pull requests). The block should be added at the job (`auto-update:`) level to ensure it applies to this job (unless you want it at workflow root for all jobs). Concretely: insert a `permissions:` section inside the `auto-update` job block, right before `runs-on`.

No imports or definitions are needed—just the new YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
