### PR TITLE
refactor(scripts): reduce output noise in Sync-Directory.ps1

### DIFF
--- a/scripts/Sync-Directory.ps1
+++ b/scripts/Sync-Directory.ps1
@@ -206,9 +206,7 @@ if ($PreviewOnly) {
 
     if ($excludedFiles.Count -gt 0) {
         Write-Host "=== Files excluded from deletion (preserved in Destination) ===" -ForegroundColor Yellow
-        $excludedFiles | ForEach-Object {
-            Write-Host "[KEEP]    $($_.RelativePath)" -ForegroundColor Yellow
-        }
+        Write-Host "Total: $($excludedFiles.Count) files will be preserved (matching exclusion patterns)" -ForegroundColor Yellow
         Write-Host ""
     }
 


### PR DESCRIPTION
Changed preview mode to show summary count of excluded files instead of listing every single file. Prevents output flooding when thousands of files match exclusion patterns (e.g., .venv, logs).

Before: Listed all excluded files individually
After: Shows "Total: X files will be preserved" summary

Makes preview output much more readable while retaining important info.