### PR TITLE
feat(git-hooks): add hook installation script and fix config format

### DIFF
--- a/config/DEPLOYMENT-SETUP.md
+++ b/config/DEPLOYMENT-SETUP.md
@@ -19,13 +19,30 @@ The repository includes post-commit and post-merge hooks that automatically sync
 
 ## Setup Instructions
 
-### 1. Copy the Configuration Template
+### 1. Install the Git Hooks
 
-```bash
-cp config/local-deployment-config.json.example config/local-deployment-config.json
+**IMPORTANT**: Git hooks are not part of the repository. You must install them locally on your machine.
+
+Run the installation script from the repository root:
+
+```powershell
+.\scripts\Install-GitHooks.ps1
 ```
 
-### 2. Edit Your Local Configuration
+This script will:
+- Create `post-commit` and `post-merge` hooks in `.git/hooks/`
+- Validate your configuration
+- Provide guidance on next steps
+
+### 2. Copy the Configuration Template
+
+If not already created, copy the example config:
+
+```powershell
+Copy-Item config\local-deployment-config.json.example config\local-deployment-config.json
+```
+
+### 3. Edit Your Local Configuration
 
 Edit `config/local-deployment-config.json` with your deployment path:
 
@@ -36,22 +53,14 @@ Edit `config/local-deployment-config.json` with your deployment path:
 }
 ```
 
+**IMPORTANT**: The config file should ONLY contain these two fields. Do not include `$schema`, `description`, or `notes` fields from the example - remove them if present.
+
 **Configuration Options:**
 
 - `stagingMirror`: Absolute path to the directory where files will be synced
   - Use double backslashes on Windows: `C:\\Users\\...`
   - Use forward slashes on Unix: `/home/user/...`
 - `enabled`: Set to `false` to temporarily disable deployment without removing the config
-
-### 3. Verify Hook Installation
-
-The hooks are already installed in `.git/hooks/`. You can verify they exist:
-
-```bash
-ls -l .git/hooks/post-commit .git/hooks/post-merge
-```
-
-If they're missing, they will need to be recreated (contact the repository maintainer).
 
 ### 4. Test the Setup
 

--- a/config/local-deployment-config.json.example
+++ b/config/local-deployment-config.json.example
@@ -1,11 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Local deployment configuration for git hooks - copy to local-deployment-config.json and customize",
   "stagingMirror": "C:\\Users\\YourUsername\\Documents\\Scripts",
-  "enabled": true,
-  "notes": [
-    "stagingMirror: Directory where repository files will be mirrored on post-commit/post-merge",
-    "enabled: Set to false to disable automatic deployment while keeping the config",
-    "This file should NOT be committed - it's for local machine configuration only"
-  ]
+  "enabled": true
 }

--- a/scripts/Install-GitHooks.ps1
+++ b/scripts/Install-GitHooks.ps1
@@ -1,0 +1,163 @@
+<#
+.SYNOPSIS
+    Installs git post-commit and post-merge hooks for automatic deployment.
+
+.DESCRIPTION
+    This script installs the git hooks required for automatic file synchronization
+    to your staging mirror directory. It creates wrapper scripts in .git/hooks/
+    that call the PowerShell implementation scripts.
+
+.NOTES
+    Author: Manoj Bhaskaran
+    Version: 1.0.0
+    Last Updated: 2025-11-22
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# Get repository root
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    Write-Error "Not in a git repository. Please run this script from within the My-Scripts repository."
+    exit 1
+}
+
+# Convert to Windows path
+$repoRoot = $repoRoot -replace '/', '\'
+
+Write-Host "Installing git hooks in: $repoRoot" -ForegroundColor Green
+Write-Host ""
+
+# Define hook directory
+$hooksDir = Join-Path $repoRoot ".git\hooks"
+
+if (-not (Test-Path $hooksDir)) {
+    Write-Error "Hooks directory not found: $hooksDir"
+    exit 1
+}
+
+# ==========================================
+# Post-Commit Hook
+# ==========================================
+$postCommitPath = Join-Path $hooksDir "post-commit"
+$postCommitContent = @'
+#!/bin/sh
+# Post-commit hook to sync repository changes to staging mirror
+# Calls the PowerShell implementation in src/powershell/git/Invoke-PostCommitHook.ps1
+
+# Get the repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Path to the PowerShell script (convert to Windows path)
+PS_SCRIPT="$REPO_ROOT/src/powershell/git/Invoke-PostCommitHook.ps1"
+PS_SCRIPT_WIN=$(echo "$PS_SCRIPT" | sed 's/\//\\/g')
+
+# Check if PowerShell is available (pwsh for cross-platform, or powershell.exe on Windows)
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+elif command -v powershell.exe >/dev/null 2>&1; then
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+else
+    echo "PowerShell not found. Skipping post-commit deployment."
+    exit 0
+fi
+'@
+
+Write-Host "Creating post-commit hook..." -ForegroundColor Cyan
+Set-Content -Path $postCommitPath -Value $postCommitContent -Encoding UTF8 -NoNewline
+Write-Host "  ✓ Created: $postCommitPath" -ForegroundColor Green
+
+# ==========================================
+# Post-Merge Hook
+# ==========================================
+$postMergePath = Join-Path $hooksDir "post-merge"
+$postMergeContent = @'
+#!/bin/sh
+# Post-merge hook to sync merged changes to staging mirror
+# Calls the PowerShell implementation in src/powershell/git/Invoke-PostMergeHook.ps1
+
+# Get the repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Path to the PowerShell script (convert to Windows path)
+PS_SCRIPT="$REPO_ROOT/src/powershell/git/Invoke-PostMergeHook.ps1"
+PS_SCRIPT_WIN=$(echo "$PS_SCRIPT" | sed 's/\//\\/g')
+
+# Check if PowerShell is available (pwsh for cross-platform, or powershell.exe on Windows)
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+elif command -v powershell.exe >/dev/null 2>&1; then
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_WIN"
+else
+    echo "PowerShell not found. Skipping post-merge deployment."
+    exit 0
+fi
+'@
+
+Write-Host "Creating post-merge hook..." -ForegroundColor Cyan
+Set-Content -Path $postMergePath -Value $postMergeContent -Encoding UTF8 -NoNewline
+Write-Host "  ✓ Created: $postMergePath" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Git hooks installed successfully!" -ForegroundColor Green
+Write-Host ""
+
+# ==========================================
+# Check for local config
+# ==========================================
+$localConfigPath = Join-Path $repoRoot "config\local-deployment-config.json"
+$exampleConfigPath = Join-Path $repoRoot "config\local-deployment-config.json.example"
+
+if (-not (Test-Path $localConfigPath)) {
+    Write-Host "⚠ Local deployment config not found" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "To enable automatic deployment, create your local configuration:" -ForegroundColor Yellow
+    Write-Host "  1. Copy the example config:" -ForegroundColor White
+    Write-Host "     Copy-Item '$exampleConfigPath' '$localConfigPath'" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  2. Edit the config with your staging mirror path:" -ForegroundColor White
+    Write-Host "     notepad '$localConfigPath'" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  3. Set your staging mirror path (e.g., C:\Users\Manoj\Documents\Scripts)" -ForegroundColor White
+    Write-Host ""
+} else {
+    Write-Host "✓ Local deployment config found: $localConfigPath" -ForegroundColor Green
+
+    # Validate the config
+    try {
+        $config = Get-Content -Path $localConfigPath -Raw | ConvertFrom-Json
+
+        if (-not $config.stagingMirror) {
+            Write-Host "  ⚠ Warning: stagingMirror not set in config" -ForegroundColor Yellow
+        } elseif (-not (Test-Path $config.stagingMirror)) {
+            Write-Host "  ⚠ Warning: Staging mirror directory does not exist: $($config.stagingMirror)" -ForegroundColor Yellow
+            Write-Host "    The directory will be created on first deployment." -ForegroundColor Gray
+        } else {
+            Write-Host "  ✓ Staging mirror: $($config.stagingMirror)" -ForegroundColor Green
+        }
+
+        if ($config.enabled -eq $false) {
+            Write-Host "  ⚠ Deployment is currently DISABLED in config" -ForegroundColor Yellow
+            Write-Host "    Set 'enabled: true' to activate automatic deployment." -ForegroundColor Gray
+        } else {
+            Write-Host "  ✓ Deployment enabled" -ForegroundColor Green
+        }
+    }
+    catch {
+        Write-Host "  ⚠ Warning: Could not parse config file: $_" -ForegroundColor Yellow
+    }
+}
+
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  • Make a test commit to verify the post-commit hook works"
+Write-Host "  • Run 'git pull' to verify the post-merge hook works"
+Write-Host "  • Check logs in <stagingMirror>\logs\post-commit-my-scripts_powershell_YYYY-MM-DD.log"
+Write-Host ""


### PR DESCRIPTION
**New Features:**
- Created Install-GitHooks.ps1 script to install hooks on local machines
- Validates configuration and provides clear setup guidance
- Checks for common configuration issues

**Fixes:**
- Simplified local-deployment-config.json.example to only required fields
- Removed confusing $schema, description, and notes fields
- Updated documentation to emphasize hooks must be installed locally
- Added clear warning about config file format

**Documentation Updates:**
- Reorganized setup instructions with hook installation as step 1
- Added validation steps to installation script
- Clarified that git hooks are local and not part of repository

**Why This Matters:**
Git hooks live in .git/hooks/ and are NOT committed to the repository. Users must run the installation script to enable automatic deployment.

**User Action Required:**
Run: .\scripts\Install-GitHooks.ps1
Then fix config file to remove extra fields.