### PR TITLE
Fix Resolve-Path mock parameters

### DIFF
--- a/tests/powershell/unit/Invoke-PostCommitHook.Tests.ps1
+++ b/tests/powershell/unit/Invoke-PostCommitHook.Tests.ps1
@@ -102,7 +102,8 @@ BeforeAll {
     # Override file system cmdlets with mock implementations AFTER loading functions
     # This ensures they're in the right scope for the loaded functions to use
     function global:Resolve-Path {
-        param([Parameter(Mandatory=$false)]$LiteralPath, $ErrorAction)
+        [CmdletBinding()]
+        param([Parameter(Mandatory=$false)]$LiteralPath)
         # Return the path as-is without actual resolution
         return [PSCustomObject]@{
             ProviderPath = $LiteralPath

--- a/tests/powershell/unit/Invoke-PostMergeHook.Tests.ps1
+++ b/tests/powershell/unit/Invoke-PostMergeHook.Tests.ps1
@@ -101,7 +101,8 @@ BeforeAll {
     # Override file system cmdlets with mock implementations AFTER loading functions
     # This ensures they're in the right scope for the loaded functions to use
     function global:Resolve-Path {
-        param([Parameter(Mandatory=$false)]$LiteralPath, $ErrorAction)
+        [CmdletBinding()]
+        param([Parameter(Mandatory=$false)]$LiteralPath)
         # Return the path as-is without actual resolution
         return [PSCustomObject]@{
             ProviderPath = $LiteralPath


### PR DESCRIPTION
## Summary
- adjust Resolve-Path mocks in post-commit and post-merge hook tests to rely on CmdletBinding for common parameters
- prevent duplicate ErrorAction definitions that were causing Deploy-ModuleFromConfig tests to fail

## Testing
- not run (PowerShell not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e24ea0ec83258be87aee4cd36f2a)