### PR TITLE
Replace Write-Host usage in shared modules

### DIFF
--- a/src/powershell/modules/Core/ErrorHandling/Public/Test-CommandAvailable.ps1
+++ b/src/powershell/modules/Core/ErrorHandling/Public/Test-CommandAvailable.ps1
@@ -12,7 +12,7 @@ function Test-CommandAvailable {
 
     .EXAMPLE
         if (Test-CommandAvailable "git") {
-            Write-Host "Git is available"
+            Write-Output "Git is available"
         }
 
     .OUTPUTS

--- a/src/powershell/modules/Core/ErrorHandling/Public/Test-IsElevated.ps1
+++ b/src/powershell/modules/Core/ErrorHandling/Public/Test-IsElevated.ps1
@@ -9,7 +9,7 @@ function Test-IsElevated {
 
     .EXAMPLE
         if (Test-IsElevated) {
-            Write-Host "Running with admin privileges"
+            Write-Output "Running with admin privileges"
         }
 
     .OUTPUTS

--- a/src/powershell/modules/Core/ErrorHandling/README.md
+++ b/src/powershell/modules/Core/ErrorHandling/README.md
@@ -66,7 +66,7 @@ Checks if the script is running with elevated privileges (Administrator on Windo
 **Example:**
 ```powershell
 if (Test-IsElevated) {
-    Write-Host "Running with admin privileges"
+    Write-Output "Running with admin privileges"
 } else {
     Write-Warning "Not running with admin privileges"
 }
@@ -97,7 +97,7 @@ Checks if a command, cmdlet, or executable is available in the current session.
 **Example:**
 ```powershell
 if (Test-CommandAvailable "git") {
-    Write-Host "Git is available"
+    Write-Output "Git is available"
 } else {
     Write-Warning "Git is not installed"
 }
@@ -115,7 +115,7 @@ try {
     Copy-Item $source $destination -Force
 }
 catch {
-    Write-Host "Error: $_" -ForegroundColor Red
+    Write-Error "Error: $_"
     throw
 }
 ```

--- a/src/powershell/modules/Core/FileOperations/Public/Test-FolderWritable.ps1
+++ b/src/powershell/modules/Core/FileOperations/Public/Test-FolderWritable.ps1
@@ -15,12 +15,12 @@ function Test-FolderWritable {
 
     .EXAMPLE
         if (Test-FolderWritable "C:\\temp") {
-            Write-Host "Folder is writable"
+            Write-Output "Folder is writable"
         }
 
     .EXAMPLE
         if (Test-FolderWritable "C:\\logs" -SkipCreate) {
-            Write-Host "Folder exists and is writable"
+            Write-Output "Folder exists and is writable"
         }
 
     .OUTPUTS

--- a/src/powershell/modules/Core/FileOperations/README.md
+++ b/src/powershell/modules/Core/FileOperations/README.md
@@ -92,11 +92,11 @@ Tests if a folder exists and is writable.
 **Example:**
 ```powershell
 if (Test-FolderWritable "C:\temp") {
-    Write-Host "Folder is writable"
+    Write-Output "Folder is writable"
 }
 
 if (Test-FolderWritable "C:\logs" -SkipCreate) {
-    Write-Host "Folder exists and is writable"
+    Write-Output "Folder exists and is writable"
 }
 ```
 
@@ -130,9 +130,9 @@ Creates a directory if it doesn't exist.
 New-DirectoryIfNotExists "C:\temp\logs"
 
 if (New-DirectoryIfNotExists $path) {
-    Write-Host "Directory was created"
+    Write-Output "Directory was created"
 } else {
-    Write-Host "Directory already existed"
+    Write-Output "Directory already existed"
 }
 ```
 
@@ -146,7 +146,7 @@ Gets the size of a file in bytes.
 **Example:**
 ```powershell
 $size = Get-FileSize "C:\temp\file.txt"
-Write-Host "File size: $size bytes"
+Write-Output "File size: $size bytes"
 ```
 
 ## Migration Guide

--- a/src/powershell/modules/Core/Logging/PurgeLogs/Private/Logging.ps1
+++ b/src/powershell/modules/Core/Logging/PurgeLogs/Private/Logging.ps1
@@ -1,4 +1,5 @@
 function Write-LogMessage {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [string]$Level,

--- a/src/powershell/modules/Core/Logging/PurgeLogs/Public/ConvertTo-Bytes.ps1
+++ b/src/powershell/modules/Core/Logging/PurgeLogs/Public/ConvertTo-Bytes.ps1
@@ -1,4 +1,5 @@
 function ConvertTo-Bytes {
+    [CmdletBinding()]
     <#
     .SYNOPSIS
     Converts a human-readable size string into a long byte value.

--- a/src/powershell/modules/Database/PostgresBackup/Public/Backup-PostgresDatabase.ps1
+++ b/src/powershell/modules/Database/PostgresBackup/Public/Backup-PostgresDatabase.ps1
@@ -1,4 +1,5 @@
 function Backup-PostgresDatabase {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$dbname,

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Logging.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Logging.ps1
@@ -13,7 +13,7 @@
 
   Notes:
     - Info uses the Information stream (`Write-Information -InformationAction Continue`)
-      for better pipeline behavior. If that fails (rare), we fall back to Write-Host.
+      for better pipeline behavior. If that fails (rare), we fall back to Write-Output.
     - Debug echoes for Warn/Error help when collecting verbose traces.
 .PARAMETER Level
   Log level classification: Info, Warn, or Error.
@@ -63,7 +63,7 @@ function Write-Message {
     switch ($Level) {
         'Info' {
             try { Write-Information -MessageData $formatted -InformationAction Continue }
-            catch { Write-Host $formatted -ForegroundColor Cyan }
+            catch { Write-Output $formatted }
         }
         'Warn' { Write-Warning $formatted; Write-Debug $formatted }
         'Error' { Write-Error   $formatted; Write-Debug $formatted }


### PR DESCRIPTION
## Summary
- replace Write-Host usage in shared module examples and logging to keep pipeline-friendly streams
- add CmdletBinding() to shared module functions lacking advanced function metadata

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c1a06afb883259cc08cd45a863f15)