### PR TITLE
Add PostgreSQL backup/restore integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - Automated vulnerability reports in GitHub Actions summary
       - Artifact uploads for detailed analysis (30-day retention)
       - Fails build on security vulnerabilities (configurable)
+  - **Integration Test Coverage**:
+    - Added `tests/integration/Test-BackupRestore.Tests.ps1` to validate PostgreSQL backup/restore flows end-to-end
+    - Exercises backup creation, restore validation, data integrity checks, and retention cleanup with temporary PostgreSQL instances
       - Dependency review comments on pull requests
   - **Dependencies Added** (requirements.txt):
     - safety==3.2.11 - Python dependency security scanner

--- a/README.md
+++ b/README.md
@@ -429,6 +429,15 @@ Install-Module -Name Pester -Force -Scope CurrentUser
 Invoke-Pester -Path tests/powershell
 ```
 
+**Integration Tests (PostgreSQL + PowerShell)**:
+```powershell
+# Requires PostgreSQL utilities on PATH: initdb, pg_ctl, psql, pg_dump, pg_restore
+# Install Pester as shown above
+
+# Run integration suite
+Invoke-Pester -Path tests/integration
+```
+
 ### Test Coverage
 
 We maintain test coverage to ensure code quality and reliability:

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,7 @@ We use a comprehensive testing framework to ensure code quality and reliability:
 
 ```
 tests/
+├── integration/         # Cross-platform integration tests
 ├── python/
 │   ├── unit/              # Python unit tests
 │   │   ├── test_validators.py
@@ -80,6 +81,19 @@ Install-Module -Name Pester -Force -Scope CurrentUser
 #### Run all PowerShell tests
 ```powershell
 Invoke-Pester -Path tests/powershell
+```
+
+### Integration Tests (PowerShell + PostgreSQL)
+
+These tests spin up a temporary PostgreSQL instance and validate the end-to-end backup/restore process using the `PostgresBackup` module.
+
+#### Prerequisites
+- PostgreSQL client and server utilities available on PATH (`initdb`, `pg_ctl`, `psql`, `pg_dump`, `pg_restore`).
+- Pester installed (see above).
+
+#### Run integration suite
+```powershell
+Invoke-Pester -Path tests/integration
 ```
 
 #### Run with coverage (using helper script - recommended)

--- a/tests/integration/Test-BackupRestore.Tests.ps1
+++ b/tests/integration/Test-BackupRestore.Tests.ps1
@@ -1,0 +1,142 @@
+[CmdletBinding()]
+param()
+
+Describe "Backup and Restore Integration" {
+    BeforeAll {
+        $script:skipReason = $null
+
+        $requiredCommands = @('initdb', 'pg_ctl', 'psql', 'pg_dump', 'pg_restore')
+        $missingCommands = @()
+        foreach ($command in $requiredCommands) {
+            if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+                $missingCommands += $command
+            }
+        }
+
+        if ($missingCommands.Count -gt 0) {
+            $script:skipReason = "Missing required PostgreSQL utilities: $($missingCommands -join ', ')"
+            return
+        }
+
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "postgres_backup_integration_$([guid]::NewGuid())"
+        $script:dataDirectory = Join-Path $script:testRoot "pgdata"
+        $script:backupDirectory = Join-Path $script:testRoot "backups"
+        $script:logFile = Join-Path $script:testRoot "backup.log"
+        $script:postgresPort = 5432
+        $script:restoreDatabase = "backup_restore_validation"
+        $script:sourceDatabase = "backup_restore_source"
+        $script:oldBackupFile = Join-Path $script:backupDirectory "${script:sourceDatabase}_backup_old.backup"
+
+        New-Item -Path $script:testRoot -ItemType Directory -Force | Out-Null
+        New-Item -Path $script:backupDirectory -ItemType Directory -Force | Out-Null
+
+        & initdb -D $script:dataDirectory -A trust --username=postgres --no-locale | Out-Null
+
+        $postgresConfig = Join-Path $script:dataDirectory "postgresql.conf"
+        Add-Content -Path $postgresConfig -Value "port = $($script:postgresPort)" -Encoding utf8
+        Add-Content -Path $postgresConfig -Value "listen_addresses = 'localhost'" -Encoding utf8
+
+        $script:postgresLog = Join-Path $script:testRoot "postgres.log"
+        & pg_ctl -D $script:dataDirectory -l $script:postgresLog -o "-F" start | Out-Null
+
+        $maxAttempts = 10
+        $attempt = 0
+        do {
+            $attempt++
+            Start-Sleep -Seconds 1
+            try {
+                & psql -h localhost -p $script:postgresPort -U postgres -d postgres -c "SELECT 1;" | Out-Null
+                $script:serverReady = $true
+            }
+            catch {
+                $script:serverReady = $false
+            }
+        } while (-not $script:serverReady -and $attempt -lt $maxAttempts)
+
+        if (-not $script:serverReady) {
+            $script:skipReason = "PostgreSQL server did not start successfully for integration test"
+            return
+        }
+
+        & psql -h localhost -p $script:postgresPort -U postgres -d postgres -c "DROP DATABASE IF EXISTS $($script:sourceDatabase);" | Out-Null
+        & psql -h localhost -p $script:postgresPort -U postgres -d postgres -c "CREATE DATABASE $($script:sourceDatabase);" | Out-Null
+
+        $seedDataSql = @'
+CREATE TABLE IF NOT EXISTS widgets (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    quantity INTEGER NOT NULL,
+    updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+INSERT INTO widgets (name, quantity, updated_at) VALUES
+    ('alpha', 10, NOW() - INTERVAL '2 days'),
+    ('bravo', 20, NOW() - INTERVAL '1 day'),
+    ('charlie', 30, NOW());
+'@
+        $seedDataSql | & psql -h localhost -p $script:postgresPort -U postgres -d $script:sourceDatabase | Out-Null
+
+        Import-Module "$PSScriptRoot/../src/powershell/modules/Database/PostgresBackup/PostgresBackup.psm1" -Force
+
+        InModuleScope PostgresBackup {
+            $script:pg_dump_path = "pg_dump"
+            $script:service_name = "postgresql-integration"
+            $script:service_start_wait = 1
+            $script:max_wait_time = 10
+        }
+
+        Mock -ModuleName PostgresBackup -CommandName Get-Service -MockWith {
+            [PSCustomObject]@{ Name = 'postgresql-integration'; Status = 'Running' }
+        }
+
+        Mock -ModuleName PostgresBackup -CommandName Start-Service -MockWith {}
+        Mock -ModuleName PostgresBackup -CommandName Stop-Service -MockWith {}
+        Mock -ModuleName PostgresBackup -CommandName Wait-ServiceStatus -MockWith {}
+
+        "stale backup" | Out-File -FilePath $script:oldBackupFile -Encoding utf8
+        (Get-Item $script:oldBackupFile).LastWriteTime = (Get-Date).AddDays(-14)
+
+        Backup-PostgresDatabase `
+            -dbname $script:sourceDatabase `
+            -backup_folder $script:backupDirectory `
+            -log_file $script:logFile `
+            -user "postgres" `
+            -retention_days 1 `
+            -min_backups 1
+
+        $script:latestBackup = Get-ChildItem -Path $script:backupDirectory -Filter "${script:sourceDatabase}_backup_*.backup" |
+            Sort-Object -Property LastWriteTime -Descending |
+            Select-Object -First 1
+
+        & psql -h localhost -p $script:postgresPort -U postgres -d postgres -c "DROP DATABASE IF EXISTS $($script:restoreDatabase);" | Out-Null
+        & psql -h localhost -p $script:postgresPort -U postgres -d postgres -c "CREATE DATABASE $($script:restoreDatabase);" | Out-Null
+
+        & pg_restore -h localhost -p $script:postgresPort -U postgres -d $script:restoreDatabase -c $script:latestBackup.FullName | Out-Null
+
+        $script:sourceRows = & psql -h localhost -p $script:postgresPort -U postgres -d $script:sourceDatabase -At -F '|' -c "SELECT id, name, quantity FROM widgets ORDER BY id;"
+        $script:restoredRows = & psql -h localhost -p $script:postgresPort -U postgres -d $script:restoreDatabase -At -F '|' -c "SELECT id, name, quantity FROM widgets ORDER BY id;"
+    }
+
+    It "Restores database to exact state" -Skip:([bool]$script:skipReason) {
+        $script:sourceRows | Should -Not -BeNullOrEmpty
+        $script:restoredRows | Should -Be $script:sourceRows
+    }
+
+    It "Applies retention policy to prune expired backups" -Skip:([bool]$script:skipReason) {
+        Test-Path -Path $script:oldBackupFile | Should -BeFalse
+        $script:latestBackup | Should -Not -BeNullOrEmpty
+    }
+
+    AfterAll {
+        if ($script:serverReady) {
+            & pg_ctl -D $script:dataDirectory stop -s -m fast | Out-Null
+        }
+
+        if (Test-Path $script:testRoot) {
+            Remove-Item -Path $script:testRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        if (Get-Module -Name PostgresBackup -ErrorAction SilentlyContinue) {
+            Remove-Module -Name PostgresBackup -Force -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PowerShell integration test that provisions a temporary PostgreSQL instance, runs a backup, restores it, and validates data integrity
- cover backup retention cleanup and document how to run the new integration suite
- update testing documentation to include PostgreSQL prerequisites

## Testing
- Not run (PowerShell/PostgreSQL tools not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c455ddc308325ae9fbf383fc92d97)