### PR TITLE
Add git hook integration coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced `Write-Host` usage in system maintenance scripts with the centralized logging framework and structured run outputs for automation (`Invoke-SystemHealthCheck.ps1`, `Install-SystemHealthCheckTask.ps1`, `Remove-DuplicateFiles.ps1`).
+- Corrected git hook launchers to call the PowerShell hook implementations from their canonical path under `src/powershell/git`.
 
 ### Added
 
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - Automated vulnerability reports in GitHub Actions summary
       - Artifact uploads for detailed analysis (30-day retention)
       - Fails build on security vulnerabilities (configurable)
+- Git hook integration test suite (`tests/integration/GitHooks.Integration.Tests.ps1`) that provisions a temporary repository, installs hooks, and validates staging mirror updates, deployment targets, and configuration handling for post-commit and post-merge workflows.
   - **Integration Test Coverage**:
     - Added `tests/integration/Test-BackupRestore.Tests.ps1` to validate PostgreSQL backup/restore flows end-to-end
     - Exercises backup creation, restore validation, data integrity checks, and retention cleanup with temporary PostgreSQL instances

--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ This repository uses git hooks for quality enforcement to catch issues before th
   - Updates staging directory with merged changes
   - Deploys updated modules
   - Handles dependency updates and log rotation
+- **Integration coverage**: `tests/integration/GitHooks.Integration.Tests.ps1` exercises staging mirror updates, deployment targets, and configuration handling to validate the end-to-end hook workflow.
 
 ### Installation
 

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -32,7 +32,7 @@ if ! command -v pwsh >/dev/null 2>&1; then
 fi
 
 # Execute the PowerShell script
-SCRIPT_PATH="$REPO_ROOT/src/powershell/Invoke-PostCommitHook.ps1"
+SCRIPT_PATH="$REPO_ROOT/src/powershell/git/Invoke-PostCommitHook.ps1"
 
 if [ -f "$SCRIPT_PATH" ]; then
     log_message "INFO" "Executing PowerShell script: $SCRIPT_PATH"

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -32,7 +32,7 @@ if ! command -v pwsh >/dev/null 2>&1; then
 fi
 
 # Execute the PowerShell script
-SCRIPT_PATH="$REPO_ROOT/src/powershell/Invoke-PostMergeHook.ps1"
+SCRIPT_PATH="$REPO_ROOT/src/powershell/git/Invoke-PostMergeHook.ps1"
 
 if [ -f "$SCRIPT_PATH" ]; then
     log_message "INFO" "Executing PowerShell script: $SCRIPT_PATH"

--- a/tests/integration/GitHooks.Integration.Tests.ps1
+++ b/tests/integration/GitHooks.Integration.Tests.ps1
@@ -1,0 +1,129 @@
+[CmdletBinding()]
+param()
+
+Describe "Git Hook Integration" {
+    BeforeAll {
+        $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot ".." "..")
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("git_hooks_integration_{0}" -f ([guid]::NewGuid()))
+        $script:repoPath = Join-Path $script:testRoot "repo"
+        $script:stagingMirror = Join-Path $script:testRoot "staging"
+        $script:deployBase = Join-Path $script:testRoot "modules"
+        $script:moduleName = "IntegrationSample"
+        $script:moduleVersion = "1.2.3"
+        $script:moduleRelPath = "src\\powershell\\modules\\$($script:moduleName)\\$($script:moduleName).psm1"
+
+        New-Item -Path $script:testRoot -ItemType Directory -Force | Out-Null
+        New-Item -Path $script:repoPath -ItemType Directory -Force | Out-Null
+        New-Item -Path $script:stagingMirror -ItemType Directory -Force | Out-Null
+        New-Item -Path $script:deployBase -ItemType Directory -Force | Out-Null
+
+        Copy-Item -Path (Join-Path $script:repoRoot "src/powershell/git") -Destination (Join-Path $script:repoPath "src/powershell") -Recurse -Force
+        Copy-Item -Path (Join-Path $script:repoRoot "src/powershell/modules") -Destination (Join-Path $script:repoPath "src/powershell") -Recurse -Force
+
+        $modulePath = Join-Path $script:repoPath $script:moduleRelPath
+        New-Item -Path (Split-Path $modulePath -Parent) -ItemType Directory -Force | Out-Null
+        @"
+<#
+Version: $($script:moduleVersion)
+#>
+function Get-IntegrationSample {
+    [CmdletBinding()]
+    param()
+    "integration works"
+}
+
+Export-ModuleMember -Function Get-IntegrationSample
+"@ | Set-Content -Path $modulePath -Encoding utf8
+
+        $configDir = Join-Path $script:repoPath "config"
+        New-Item -Path (Join-Path $configDir "modules") -ItemType Directory -Force | Out-Null
+
+        $localConfig = @{ stagingMirror = $script:stagingMirror; enabled = $true } | ConvertTo-Json
+        $localConfig | Set-Content -Path (Join-Path $configDir "local-deployment-config.json") -Encoding utf8
+
+        $deploymentEntry = "$($script:moduleName)|$($script:moduleRelPath)|Alt:$($script:deployBase)|Integration Tester|Integration sample module"
+        $deploymentEntry | Set-Content -Path (Join-Path $configDir "modules" "deployment.txt") -Encoding utf8
+
+        Push-Location $script:repoPath
+        git init -b main | Out-Null
+        git config user.name "Integration Tester"
+        git config user.email "integration@example.com"
+
+        Copy-Item -Path (Join-Path $script:repoRoot "hooks" "post-commit") -Destination (Join-Path $script:repoPath ".git/hooks/post-commit") -Force
+        Copy-Item -Path (Join-Path $script:repoRoot "hooks" "post-merge") -Destination (Join-Path $script:repoPath ".git/hooks/post-merge") -Force
+        Get-ChildItem -Path (Join-Path $script:repoPath ".git/hooks") -Filter "post-*" | ForEach-Object { $_.LastWriteTime = Get-Date; chmod +x $_.FullName }
+
+        git add .
+        git commit -m "chore: seed integration repo" | Out-Null
+        Pop-Location
+
+        $env:PSModulePath = "$($script:deployBase){0}$($env:PSModulePath)" -f [IO.Path]::PathSeparator
+    }
+
+    AfterAll {
+        if (Get-Module -Name $script:moduleName -ErrorAction SilentlyContinue) {
+            Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+        }
+
+        if (Test-Path -LiteralPath $script:testRoot) {
+            Remove-Item -LiteralPath $script:testRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Deploys modules after commit" {
+        Push-Location $script:repoPath
+        Add-Content -Path $script:moduleRelPath -Value "# commit deployment" -Encoding utf8
+        git add $script:moduleRelPath
+        git commit -m "test: trigger post-commit" | Out-Null
+        Pop-Location
+
+        $stagedFile = Join-Path $script:stagingMirror $script:moduleRelPath
+        $deployedModule = Join-Path $script:deployBase "$($script:moduleName)/$($script:moduleVersion)/$($script:moduleName).psm1"
+        $deployedManifest = Join-Path $script:deployBase "$($script:moduleName)/$($script:moduleVersion)/$($script:moduleName).psd1"
+
+        Test-Path -LiteralPath $stagedFile | Should -BeTrue
+        Test-Path -LiteralPath $deployedModule | Should -BeTrue
+        Test-Path -LiteralPath $deployedManifest | Should -BeTrue
+
+        Import-Module -Name $deployedModule -Force
+        (Get-IntegrationSample) | Should -Be "integration works"
+    }
+
+    It "Post-merge hook deploys merged module updates" {
+        Push-Location $script:repoPath
+        git checkout -b feature/update-module | Out-Null
+
+        (Get-Content -Path $script:moduleRelPath -Raw).Replace($script:moduleVersion, "1.2.4") | Set-Content -Path $script:moduleRelPath -Encoding utf8
+        git add $script:moduleRelPath
+        git commit -m "feat: bump integration module" | Out-Null
+
+        git checkout main | Out-Null
+        git merge feature/update-module -m "merge feature branch" | Out-Null
+        Pop-Location
+
+        $mergedModule = Join-Path $script:deployBase "$($script:moduleName)/1.2.4/$($script:moduleName).psm1"
+        $mergedManifest = Join-Path $script:deployBase "$($script:moduleName)/1.2.4/$($script:moduleName).psd1"
+
+        Test-Path -LiteralPath $mergedModule | Should -BeTrue
+        Test-Path -LiteralPath $mergedManifest | Should -BeTrue
+    }
+
+    It "Respects local deployment configuration settings" {
+        $newMirror = Join-Path $script:testRoot "staging-new"
+        New-Item -Path $newMirror -ItemType Directory -Force | Out-Null
+
+        $script:stagingMirror = $newMirror
+        $localConfig = @{ stagingMirror = $script:stagingMirror; enabled = $true } | ConvertTo-Json
+        $localConfig | Set-Content -Path (Join-Path $script:repoPath "config" "local-deployment-config.json") -Encoding utf8
+
+        Push-Location $script:repoPath
+        Remove-Item -LiteralPath (Join-Path $script:testRoot "staging") -Recurse -Force -ErrorAction SilentlyContinue
+        Add-Content -Path $script:moduleRelPath -Value "# updated mirror" -Encoding utf8
+        git add $script:moduleRelPath
+        git commit -m "test: move staging mirror" | Out-Null
+        Pop-Location
+
+        $stagedFile = Join-Path $script:stagingMirror $script:moduleRelPath
+        Test-Path -LiteralPath $stagedFile | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- add integration tests that provision a temporary repo to validate post-commit and post-merge hook behavior and configuration handling
- point hook launcher scripts at the git hook PowerShell entry points under `src/powershell/git`
- document the new integration coverage in README and changelog

## Testing
- `pwsh -NoProfile -File tests/powershell/Invoke-Tests.ps1 -Path tests/integration -CodeCoverageEnabled:$false -Verbosity Normal` *(fails: `pwsh` not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7c4cd82883259c8ab6ac2c07d038)