### PR TITLE
Add HTTP timeouts for CloudConvert operations

### DIFF
--- a/docs/architecture/external-integrations.md
+++ b/docs/architecture/external-integrations.md
@@ -206,6 +206,12 @@ sequenceDiagram
 - `cloudconvert` (official Python SDK)
 - `requests`
 
+**HTTP Timeouts (connect, read in seconds)**:
+- `TIMEOUT_QUICK`: `(5, 15)` for status checks
+- `TIMEOUT_STANDARD`: `(5, 30)` for job creation and API calls
+- `TIMEOUT_UPLOAD`: `(10, 300)` for file uploads
+- `TIMEOUT_DOWNLOAD`: `(10, 300)` for file downloads
+
 ### Scripts Using CloudConvert
 
 | Script | Language | Purpose |

--- a/tests/python/unit/test_cloudconvert_timeouts.py
+++ b/tests/python/unit/test_cloudconvert_timeouts.py
@@ -1,0 +1,36 @@
+from src.python.cloud.cloudconvert_utils import (
+    TIMEOUT_STANDARD,
+    TIMEOUT_UPLOAD,
+    create_upload_task,
+    handle_file_upload,
+)
+
+
+def test_create_upload_task_includes_timeout(mocker):
+    """Verify timeout parameter is included."""
+    mock_post = mocker.patch("requests.post")
+    mock_post.return_value.status_code = 201
+    mock_post.return_value.json.return_value = {
+        "data": {"tasks": [{"id": "task_id"}]}
+    }
+
+    create_upload_task("fake_api_key")
+
+    call_kwargs = mock_post.call_args[1]
+    assert "timeout" in call_kwargs
+    assert call_kwargs["timeout"] == TIMEOUT_STANDARD
+
+
+def test_file_upload_uses_longer_timeout(mocker, tmp_path):
+    """Verify file uploads use extended timeout."""
+    mock_post = mocker.patch("requests.post")
+
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("dummy content")
+
+    handle_file_upload(
+        str(test_file), "http://upload.url", {"key": "${filename}"}
+    )
+
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["timeout"] == TIMEOUT_UPLOAD


### PR DESCRIPTION
## Summary
- add configurable timeout constants for CloudConvert HTTP operations and apply them to API calls
- improve timeout and request error logging for job creation and task status checks
- document timeout defaults and add unit tests verifying timeout usage for uploads

## Testing
- pytest tests/python/unit/test_cloudconvert_timeouts.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931487fcc508325a3407cd3fd90db3f)