### PR TITLE
docs(hooks): document resolution of permission issues #648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Git Hook Permission Issues** (#648)
+  - Issue automatically resolved by migration to pre-commit framework (PR #655, issue #647)
+  - Removed hooks with permission problems: `post-checkout` and `pre-push`
+  - Remaining hooks (`post-commit`, `post-merge`) have correct executable permissions
+  - All hook management now standardized via `.pre-commit-config.yaml`
+  - Updated analysis documentation to reflect resolution status
+  - **Impact**: Eliminated permission-related hook execution failures
+
 ### Added
 
 - **FileQueue Module** (#602)

--- a/analysis/git-hooks-issue-004-hook-permissions.md
+++ b/analysis/git-hooks-issue-004-hook-permissions.md
@@ -117,7 +117,45 @@ If this is `false`, permissions won't be tracked in the repository.
 - `/hooks/pre-push` (line 1: `#!/bin/sh` shebang present)
 - Both files have correct shebang but lack executable bit
 
+## Resolution
+
+**Status:** RESOLVED (as of commit 2c14c5d)
+
+This issue was **automatically resolved** by the migration to the pre-commit framework system (PR #655, addressing issue #647).
+
+### How It Was Resolved
+
+The problematic hooks (`post-checkout` and `pre-push`) were removed entirely when the repository migrated from manual git hooks to the pre-commit framework:
+
+- **Commit:** 874c5d9 - "fix(hooks): migrate to single pre-commit framework system"
+- **Merge:** 2c14c5d - Merged via PR #655
+- **Date:** December 9, 2025
+
+### Files Removed
+
+The following hooks were deleted (no longer needed with pre-commit framework):
+- `hooks/commit-msg` (82 lines removed)
+- `hooks/post-checkout` (61 lines removed) - ✓ Had permission issue
+- `hooks/pre-commit` (175 lines removed)
+- `hooks/pre-push` (49 lines removed) - ✓ Had permission issue
+
+### Current State
+
+- **Remaining hooks:** `post-commit` and `post-merge` (PowerShell automation hooks)
+- **Current permissions:** Both have correct executable permissions (755)
+- **Git tracking:** Both tracked as executable (100755)
+- **Hook management:** Standardized via `.pre-commit-config.yaml`
+
+### Benefits of Migration
+
+1. ✅ Eliminated permission issues (files no longer exist)
+2. ✅ Standardized hook management via pre-commit framework
+3. ✅ Automatic hook installation and updates
+4. ✅ Consistent configuration across all environments
+5. ✅ Built-in permission handling by pre-commit framework
+
 ## Related Issues
 
 - #001: Git Hooks Not Installed
 - #006: Missing Dependencies (Git LFS)
+- #647: Dual Hook Management System Creates Confusion (resolved by migration)


### PR DESCRIPTION
Issue #648 was automatically resolved by the migration to the pre-commit framework system (PR #655, issue #647). The problematic hooks (post-checkout and pre-push) that lacked executable permissions were removed entirely as part of the standardization effort.

Changes:
- Updated analysis/git-hooks-issue-004-hook-permissions.md with resolution status
- Added detailed explanation of how migration resolved the issue
- Documented current state of remaining hooks (post-commit, post-merge)
- Updated CHANGELOG.md to record fix for issue #648
- Verified remaining hooks have correct permissions (755/100755)

Impact: Eliminated permission-related hook execution failures through framework-based hook management.

Resolves #648
Related to #647 (dual hook management system)