### PR TITLE
fix: move CmdletBinding attribute before param block

### DIFF
--- a/src/powershell/media/Convert-ImageFile.ps1
+++ b/src/powershell/media/Convert-ImageFile.ps1
@@ -148,12 +148,6 @@
         about large append-only log files.
 #>
 
-# Import logging framework
-Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
-
-# Initialize logger
-Initialize-Logger -ScriptName "picconvert" -LogLevel 20
-
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
     [Parameter(Mandatory = $false)]
@@ -186,6 +180,12 @@ param(
     [ValidateRange(1, 1048576)]
     [int]$LogWarnSizeMB = 10
 )
+
+# Import logging framework
+Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
+
+# Initialize logger
+Initialize-Logger -ScriptName "picconvert" -LogLevel 20
 
 # region: Globals / State -------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves parser error 'Unexpected attribute CmdletBinding' by moving the [CmdletBinding()] attribute to appear before the param() block. Moved Import-Module and Initialize-Logger calls to after param block where executable code belongs.

PowerShell requires this structure:
1. Comments
2. [CmdletBinding()] attribute
3. param() block
4. Executable code