### PR TITLE
Add video batch processing with frame extraction

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -7,6 +7,17 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 > This file is module-scoped. For repository-wide changes affecting other scripts, see the root `CHANGELOG.md`.
 
 ## [Unreleased]
+
+## [3.0.4] - 2026-01-03
+### Fixed
+- **Python module import robustness**: Enhanced `Invoke-Cropper` to prevent "No module named crop_colours" errors:
+  - Added pre-flight check to verify `media.crop_colours` module is importable before execution
+  - Explicitly initialize ProcessStartInfo.Environment collection to ensure proper environment variable inheritance
+  - Added file existence verification for crop_colours.py before attempting module invocation
+  - Improved error messages with PYTHONPATH details and specific import diagnostics
+  - Added debug logging to display exact Python command and PYTHONPATH value
+
+## [3.0.3] - 2026-01-03
 ### Fixed
 - **Python module import failure**: Fixed "No module named crop_colours" error when using `-RunCropper` without specifying `-PythonScriptPath`. The module now automatically configures PYTHONPATH to include `src/python` and uses the correct module path `media.crop_colours` instead of `crop_colours`.
 

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.0.3'
+  ModuleVersion     = '3.0.4'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.0.3: Fixed empty catch blocks in error handling (added explanatory comments for resource cleanup, process termination).'
+      ReleaseNotes = '3.0.4: Enhanced Python module import with pre-flight checks, explicit environment initialization, and detailed diagnostic logging for media.crop_colours module invocation.'
     }
   }
 }


### PR DESCRIPTION
Resolves "No module named crop_colours" errors by:
- Adding pre-flight check to verify media.crop_colours is importable
- Explicitly initializing ProcessStartInfo.Environment for proper inheritance
- Verifying crop_colours.py file exists before module invocation
- Adding detailed debug logging for Python command and PYTHONPATH
- Improving error messages with PYTHONPATH and import diagnostics

Version bumped to 3.0.4.