### PR TITLE
Clean up VLC pid files after batch processing

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -433,6 +433,17 @@ function Start-VideoBatch {
         }
     }
 
+    # Clean up the PID registry file created for this run
+    if ($pidFile -and (Test-Path -LiteralPath $pidFile)) {
+        try {
+            Remove-Item -LiteralPath $pidFile -Force -ErrorAction Stop
+            Write-Debug "Cleaned up PID registry: $pidFile"
+        }
+        catch {
+            Write-Message -Level Warn -Message ("Failed to remove PID registry file '{0}': {1}" -f $pidFile, $_.Exception.Message)
+        }
+    }
+
     $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — processed {1} file(s)" -f ($MyInvocation.MyCommand.Module.Version.ToString()), $processedCount)
     Write-Debug 'TRACE Start-VideoBatch: leaving (no output intended)'
     return


### PR DESCRIPTION
The PID registry files (.vlc_pids_<RunGuid>.txt) were being created in the Screenshots folder to track VLC processes during execution, but were never cleaned up after the script completed. This resulted in leftover temporary files accumulating in the output directory.

Added cleanup logic at the end of Start-VideoBatch to remove the PID registry file after all processing is complete. The cleanup is wrapped in a try-catch block to ensure the script completes successfully even if the file removal fails.