### PR TITLE
Add SonarCloud token validation check

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -228,8 +228,10 @@ jobs:
           echo "${{ github.workspace }}/sonar-scanner/sonar-scanner-6.0.0.4432-linux/bin" >> $GITHUB_PATH
 
       - name: Check SonarCloud Token
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+          if [ -z "$SONAR_TOKEN" ]; then
             echo "::error::SONAR_TOKEN secret is not configured!"
             echo "::error::Please configure SONAR_TOKEN in GitHub repository secrets:"
             echo "::error::1. Go to https://sonarcloud.io"


### PR DESCRIPTION
The previous implementation was checking the GitHub Actions expression directly in the bash condition, which always evaluated to an empty string when the secret wasn't set. This caused the validation to always fail.

Now the secret is passed as an environment variable first, then checked in bash, allowing proper validation of whether SONAR_TOKEN is configured.