### PR TITLE
Remove duplicate Conventional Commits validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Conventional Commits Validation Duplication** (#653)
+  - Resolved duplicate commit message validation between manual hook and commitizen
+  - Manual `hooks/commit-msg` was removed in commit 874c5d9 (2025-12-09)
+  - Standardized on commitizen hook via `.pre-commit-config.yaml`
+  - Updated analysis documentation with resolution status
+  - **Impact**: Eliminated duplicate validation, reduced maintenance burden
+  - **Related**: Part of broader migration to single pre-commit framework system (PR #655, Issue #647)
+
 - **Git Hook Permission Issues** (#648)
   - Issue automatically resolved by migration to pre-commit framework (PR #655, issue #647)
   - Removed hooks with permission problems: `post-checkout` and `pre-push`

--- a/analysis/git-hooks-issue-009-conventional-commits-duplication.md
+++ b/analysis/git-hooks-issue-009-conventional-commits-duplication.md
@@ -3,8 +3,28 @@
 **Priority:** Low
 **Type:** Duplication
 **Component:** Git Hooks (commit-msg)
+**Status:** ✅ RESOLVED
 
-## Description
+## Resolution
+
+**Resolved In:** Commit `874c5d9` (2025-12-09)
+**Resolution Type:** Manual hook removed in favor of pre-commit framework
+
+The duplicate commit message validation has been resolved by removing the manual `hooks/commit-msg` script and standardizing on the commitizen hook managed by the pre-commit framework. This change was part of the broader migration to a single hook management system.
+
+**Actions Taken:**
+- ✅ Removed `hooks/commit-msg` (82 lines)
+- ✅ Retained commitizen hook in `.pre-commit-config.yaml`
+- ✅ Updated documentation in `docs/guides/git-hooks.md`
+- ✅ Standardized to single validation system
+
+**Related Changes:**
+- PR #655: Migration to single pre-commit framework system
+- Issue #647: Dual hook management system
+
+---
+
+## Original Issue Description
 
 Commit message validation for Conventional Commits format is implemented twice:
 1. Manual shell script in `hooks/commit-msg`


### PR DESCRIPTION
…(#653)

- Updated analysis file with resolution status and timeline
- Added CHANGELOG entry documenting the fix
- Manual hooks/commit-msg was removed in commit 874c5d9
- Standardized on commitizen via pre-commit framework
- Part of broader migration to single hook management system

Related: #647, PR #655