### PR TITLE
fix(FileDistributor): correct FilesToDelete parameter type in functions

### DIFF
--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -1053,7 +1053,7 @@ function DistributeFilesToSubfolders {
         [switch]$ShowProgress,
         [int]$UpdateFrequency,
         [string]$DeleteMode,
-        [ref]$FilesToDelete,
+        $FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [ref]$GlobalFileCounter,
         [int]$TotalFiles
     )
@@ -1253,7 +1253,7 @@ function RedistributeFilesInTarget {
         [switch]$ShowProgress,
         [int]$UpdateFrequency,
         [string]$DeleteMode,
-        [ref]$FilesToDelete,
+        $FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [ref]$GlobalFileCounter,
         [int]$TotalFiles
     )
@@ -1431,7 +1431,7 @@ function RebalanceSubfoldersByAverage {
         [switch]$ShowProgress,
         [int]$UpdateFrequency = 100,
         [Parameter(Mandatory = $true)][string]$DeleteMode,
-        [Parameter(Mandatory = $true)][ref]$FilesToDelete,
+        [Parameter(Mandatory = $true)]$FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [Parameter(Mandatory = $true)][ref]$GlobalFileCounter
     )
 
@@ -1610,7 +1610,7 @@ function ConsolidateSubfoldersToMinimum {
         [switch]$ShowProgress,
         [int]$UpdateFrequency = 100,
         [Parameter(Mandatory = $true)][string]$DeleteMode,
-        [Parameter(Mandatory = $true)][ref]$FilesToDelete,
+        [Parameter(Mandatory = $true)]$FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [Parameter(Mandatory = $true)][ref]$GlobalFileCounter
     )
 


### PR DESCRIPTION
Fixed parameter type mismatch where functions declared [ref]$FilesToDelete but the FileQueue object is a PSCustomObject (reference type) that doesn't require [ref] wrapping.

Changes:
- Remove [ref] declaration from FilesToDelete parameter in:
  * DistributeFilesToSubfolders
  * RedistributeFilesInTarget
  * RebalanceSubfoldersByAverage
  * ConsolidateSubfoldersToMinimum
- Add explanatory comments indicating FileQueue is a reference type

Root cause: FileQueue (created by New-FileQueue) returns a PSCustomObject, which is already a reference type. Modifications to it are reflected even when passed to functions without [ref] wrapping. The [ref] declaration was causing "Reference type is expected in argument" errors when calling these functions.

Functions were already implemented to use $FilesToDelete directly (not .Value), confirming they expected direct object passing, not references.

Resolves: "Cannot process argument transformation on parameter 'FilesToDelete'"