### PR TITLE
Remove duplicate progress display in FileDistributor

### DIFF
--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -1248,7 +1248,6 @@ function DistributeFilesToSubfolders {
         if ($ShowProgress -and ($GlobalFileCounter.Value % $UpdateFrequency -eq 0)) {
             $percentComplete = [math]::Floor(($GlobalFileCounter.Value / $TotalFiles) * 100)
             Write-Progress -Activity "Distributing Files" -Status "Processed $($GlobalFileCounter.Value) of $TotalFiles files" -PercentComplete $percentComplete
-            LogMessage -Message "Processed $($GlobalFileCounter.Value) of $TotalFiles files." -ConsoleOutput
         }
     }
 


### PR DESCRIPTION
…Progress

When -ShowProgress was enabled, progress was displayed both as text lines and as a progress bar, causing duplication. Removed the redundant text output since the progress bar already shows this information.

The final completion message is still displayed after the progress bar completes.