### PR TITLE
Remove password prompt from backup script

### DIFF
--- a/src/powershell/modules/Database/PostgresBackup/PostgresBackup.psd1
+++ b/src/powershell/modules/Database/PostgresBackup/PostgresBackup.psd1
@@ -1,7 +1,7 @@
 @{
     # Module manifest for PostgresBackup
     RootModule        = 'PostgresBackup.psm1'
-    ModuleVersion     = '2.0.1'
+    ModuleVersion     = '2.0.2'
     GUID              = '4f7b8a9c-2e6d-4b3a-9f8e-1c5a7d9b2e4f'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = ''
@@ -15,7 +15,7 @@
         PSData = @{
             Tags         = @('postgresql','backup','database','retention','pg_dump')
             ProjectUri   = ''
-            ReleaseNotes = '2.0.1: Standardized module loader, Public/Private layout, and reusable helper scripts.'
+            ReleaseNotes = '2.0.2: Fixed .pgpass authentication by using standard pg_dump options instead of connection string when no password is provided.'
         }
     }
 }

--- a/tests/powershell/unit/PostgresBackup.Tests.ps1
+++ b/tests/powershell/unit/PostgresBackup.Tests.ps1
@@ -667,8 +667,11 @@ Describe "Backup-PostgresDatabase" -Skip:(-not $script:isWindows) {
                 -log_file $script:testLogFile `
                 -user "test_user"
 
-            # Should use empty password (relying on .pgpass)
-            $script:capturedCommand | Should -Match "test_user:@localhost"
+            # Should use standard options (not connection string) to allow .pgpass lookup
+            $script:capturedCommand | Should -Match "-U test_user"
+            $script:capturedCommand | Should -Match "-d testdb"
+            $script:capturedCommand | Should -Match "-h localhost"
+            $script:capturedCommand | Should -Not -Match "postgresql://"
         }
 
         It "Uses provided password when specified" {


### PR DESCRIPTION
The Backup-PostgresDatabase function was prompting for a password even when .pgpass was configured. This occurred because when no password was provided, the function created a connection string with an empty password field (postgresql://user:@localhost/db), which bypassed .pgpass lookup.

Changes:
- Modified Backup-PostgresDatabase to use standard pg_dump command-line options (-U, -d, -h) when no password is provided, allowing pg_dump to look up credentials from .pgpass
- Retained connection string format when password is explicitly provided for backward compatibility
- Updated unit tests to validate the new behavior
- Bumped module version to 2.0.2

Fixes password prompts in Backup-TimelineDatabase.ps1 and Backup-GnuCashDatabase.ps1 scripts.