### PR TITLE
fix(batch): change logging delimiter from pipe to semicolon in RunDel…

### DIFF
--- a/src/batch/RunDeleteOldDownloads.bat
+++ b/src/batch/RunDeleteOldDownloads.bat
@@ -102,7 +102,7 @@ exit /b
 :WriteLog
 setlocal
 :: Get timestamp, timezone, hostname, and PID using PowerShell
-for /f "usebackq tokens=1,2,3,4 delims=|" %%a in (`powershell -NoProfile -Command "$ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'; $tz=(Get-TimeZone).StandardName; $hostname=$env:COMPUTERNAME; $pid=$PID; Write-Output \"$ts|$tz|$hostname|$pid\""`) do (
+for /f "usebackq tokens=1,2,3,4 delims=;" %%a in (`powershell -NoProfile -Command "$ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'; $tz=(Get-TimeZone).StandardName; $hostname=$env:COMPUTERNAME; $pid=$PID; Write-Output \"$ts;$tz;$hostname;$pid\""`) do (
     set "TS=%%a"
     set "TZ=%%b"
     set "HOST=%%c"


### PR DESCRIPTION
…eteOldDownloads.bat

Replaced pipe character (|) with semicolon (;) as delimiter in WriteLog function to avoid batch script parsing conflicts that caused "| was unexpected at this time" error.