### PR TITLE
fix(batch): correct repository root path resolution in RunDeleteOldDo…

### DIFF
--- a/src/batch/RunDeleteOldDownloads.bat
+++ b/src/batch/RunDeleteOldDownloads.bat
@@ -22,7 +22,7 @@ set "LOG_FILE=%LOG_DIR%\%SCRIPT_NAME%_batch_%LOG_DATE%.log"
 
 :: Get script directory and navigate to repository root
 set "SCRIPT_DIR=%~dp0"
-set "REPO_ROOT=%SCRIPT_DIR%.."
+set "REPO_ROOT=%SCRIPT_DIR%..\.."
 
 :: Build path to PowerShell script using relative path
 set "SCRIPT=%REPO_ROOT%\src\powershell\system\Remove-OldDownload.ps1"


### PR DESCRIPTION
…wnloads.bat

Changed REPO_ROOT from one level up (..) to two levels up (..\..) to properly reach the repository root from src\batch\ directory. This fixes the "Script not found" error.