### PR TITLE
fix(powershell): move CmdletBinding and param block before executable…

### DIFF
--- a/src/powershell/system/Remove-OldDownload.ps1
+++ b/src/powershell/system/Remove-OldDownload.ps1
@@ -72,12 +72,6 @@
       - Verifies deletion with Test-Path and records the result.
 #>
 
-# Import logging framework
-Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
-
-# Initialize logger
-Initialize-Logger -ScriptName "DeleteOldDownloads" -LogLevel 20
-
 [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param(
     [Parameter()]
@@ -107,6 +101,12 @@ param(
     [Parameter()]
     [switch]$PassThru
 )
+
+# Import logging framework
+Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
+
+# Initialize logger
+Initialize-Logger -ScriptName "DeleteOldDownloads" -LogLevel 20
 
 #region --- Setup & Utilities ---
 


### PR DESCRIPTION
… code in Remove-OldDownload.ps1

Reordered script to place [CmdletBinding()] and param() block before Import-Module and Initialize-Logger calls, as required by PowerShell syntax. This fixes the "Unexpected attribute 'CmdletBinding'" parser error.