### PR TITLE
fix(batch): only show error popup for fatal failures (exit code 1) in…

### DIFF
--- a/src/batch/RunDeleteOldDownloads.bat
+++ b/src/batch/RunDeleteOldDownloads.bat
@@ -74,8 +74,9 @@ if "%RC%"=="0" (
   call :LogError "Script failed with exit code: %RC%"
 )
 
-:: On failure, show a MessageBox to the interactive user
-if not "%RC%"=="0" (
+:: On fatal failure (exit code 1), show a MessageBox to the interactive user
+:: Exit code 2 (partial failures) is logged but doesn't trigger popup
+if "%RC%"=="1" (
   call :LogInfo "Displaying error message to user"
   "%RUNNER%" -NoLogo -NoProfile -Command ^
     "Add-Type -AssemblyName System.Windows.Forms; " ^


### PR DESCRIPTION
… RunDeleteOldDownloads.bat

Changed error popup logic to only trigger on fatal script failures (exit code 1), not on partial failures (exit code 2). Exit code 2 indicates successful deletion with some individual file/folder failures, which are logged but don't require user notification via popup.