### PR TITLE
Fix Drive Space Monitor Task Scheduler path

### DIFF
--- a/src/python/cloud/cloudconvert_utils.py
+++ b/src/python/cloud/cloudconvert_utils.py
@@ -1,5 +1,14 @@
 import os
 import sys
+from pathlib import Path
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+
+sys.path.insert(0, str(modules_logging))
+
 import requests
 import urllib.parse
 import argparse

--- a/src/python/cloud/drive_space_monitor.py
+++ b/src/python/cloud/drive_space_monitor.py
@@ -7,6 +7,18 @@ performed to a log file using the standard cross-platform logging framework.
 """
 
 import os
+import sys
+from pathlib import Path
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+modules_auth = repo_root / "src" / "python" / "modules" / "auth"
+
+sys.path.insert(0, str(modules_logging))
+sys.path.insert(0, str(modules_auth))
+
 import argparse
 import logging
 from googleapiclient.errors import HttpError

--- a/src/python/cloud/google_drive_root_files_delete.py
+++ b/src/python/cloud/google_drive_root_files_delete.py
@@ -24,6 +24,18 @@ Notes:
 """
 
 from __future__ import print_function
+import sys
+from pathlib import Path
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+modules_auth = repo_root / "src" / "python" / "modules" / "auth"
+
+sys.path.insert(0, str(modules_logging))
+sys.path.insert(0, str(modules_auth))
+
 from googleapiclient.errors import HttpError
 from google_drive_auth import authenticate_and_get_drive_service
 from google.auth.credentials import Credentials

--- a/src/python/data/csv_to_gpx.py
+++ b/src/python/data/csv_to_gpx.py
@@ -12,11 +12,21 @@ Usage:
 import argparse
 import csv
 import os
+import sys
 import xml.dom.minidom
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Tuple
 from xml.etree.ElementTree import Element, SubElement, tostring
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+modules_auth = repo_root / "src" / "python" / "modules" / "auth"
+
+sys.path.insert(0, str(modules_logging))
+sys.path.insert(0, str(modules_auth))
 
 from elevation import get_elevation
 import python_logging_framework as plog

--- a/src/python/data/extract_timeline_locations.py
+++ b/src/python/data/extract_timeline_locations.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import re
+import sys
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -18,6 +19,15 @@ from typing import (
     Tuple,
     cast,
 )
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+modules_auth = repo_root / "src" / "python" / "modules" / "auth"
+
+sys.path.insert(0, str(modules_logging))
+sys.path.insert(0, str(modules_auth))
 
 import psycopg2
 from psycopg2.extensions import connection as PgConnection, cursor as PgCursor

--- a/src/python/data/seat_assignment.py
+++ b/src/python/data/seat_assignment.py
@@ -1,9 +1,18 @@
 import pandas as pd
-import python_logging_framework as plog
-import networkx as nx
 import sys
 import os
+from pathlib import Path
 from collections import namedtuple
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+
+sys.path.insert(0, str(modules_logging))
+
+import python_logging_framework as plog
+import networkx as nx
 
 # Initialize logger for this module
 logger = plog.initialise_logger(__name__)

--- a/src/python/media/find_duplicate_images.py
+++ b/src/python/media/find_duplicate_images.py
@@ -26,9 +26,19 @@ CHANGELOG:
 """
 
 import os
+import sys
 import csv
 import hashlib
 import argparse
+from pathlib import Path
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+
+sys.path.insert(0, str(modules_logging))
+
 import python_logging_framework as plog
 import logging
 import json

--- a/src/python/media/recover_extensions.py
+++ b/src/python/media/recover_extensions.py
@@ -20,10 +20,19 @@ python recover_extensions.py --move-unknowns --debug
 """
 
 import re
+import sys
 import time
 import argparse
-import python_logging_framework as plog
 from pathlib import Path
+
+# Add module paths to sys.path for imports
+script_dir = Path(__file__).resolve().parent
+repo_root = script_dir.parent.parent.parent
+modules_logging = repo_root / "src" / "python" / "modules" / "logging"
+
+sys.path.insert(0, str(modules_logging))
+
+import python_logging_framework as plog
 from collections import defaultdict
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor, as_completed


### PR DESCRIPTION
Resolves Task Scheduler execution error where Python scripts couldn't find custom modules (google_drive_auth, python_logging_framework, elevation).

Changes:
- Added sys.path configuration to all Python scripts that import custom modules
- Dynamically resolves repo root and adds module paths at runtime
- Scripts now work correctly when executed from Task Scheduler or any location

Affected scripts:
- cloud/drive_space_monitor.py
- cloud/google_drive_root_files_delete.py
- cloud/cloudconvert_utils.py
- data/csv_to_gpx.py
- data/extract_timeline_locations.py
- data/seat_assignment.py
- media/find_duplicate_images.py
- media/recover_extensions.py

The sys.path setup calculates the repository root dynamically and adds:
- src/python/modules/logging (for python_logging_framework)
- src/python/modules/auth (for google_drive_auth and elevation)

This ensures scripts can find custom modules regardless of execution context (Task Scheduler, command line, IDE, etc.).