### PR TITLE
Add persistent state tracking for backups

### DIFF
--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -45,9 +45,19 @@
     Runs the sync with rclone --progress output shown on the console, suitable for manual invocation.
 
 .NOTES
-    Version: 2.1.0
+    Version: 2.2.0
 
     CHANGELOG
+    ## 2.2.0 - 2026-01-13
+    ### Added
+    - Persistent state tracking with JSON state file (Sync-MacriumBackups_state.json)
+    - State file records: lastRunId (GUID), status, startTime, endTime, lastExitCode, lastStep
+    - Atomic state file writes using temporary file and rename
+    - Detection and warning for interrupted runs (status=InProgress from previous run)
+    - State updates at each major step: Initialize, Test-BackupPath, Test-Rclone, Test-Network, Sync-Backups
+    - State finalization on success (Succeeded) and failure (Failed) with exit codes
+    - Exception handling to mark state as Failed on unhandled errors
+
     ## 2.1.0 - 2026-01-13
     ### Changed
     - Configure logging to centralized Scripts\logs directory
@@ -95,33 +105,170 @@ $LogFile = Join-Path $logDir "Sync-MacriumBackups_rclone.log"
 
 Initialize-Logger -resolvedLogDir $logDir -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
 
+# Set StateFile path
+$StateFile = Join-Path $logDir "Sync-MacriumBackups_state.json"
+
 # Output log paths for verification
 Write-Host "Framework logs: $($Global:LogConfig.LogFilePath)" -ForegroundColor Cyan
 Write-Host "Rclone logs: $LogFile" -ForegroundColor Cyan
+Write-Host "State file: $StateFile" -ForegroundColor Cyan
 
 Add-Type -Namespace SleepControl -Name PowerMgmt -MemberDefinition @"
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern uint SetThreadExecutionState(uint esFlags);
 "@ -Language CSharp
 
+#region State Management Functions
+
+function Read-StateFile {
+    <#
+    .SYNOPSIS
+        Reads the state file if it exists and returns the state object.
+    #>
+    if (Test-Path $StateFile) {
+        try {
+            $stateJson = Get-Content -Path $StateFile -Raw -ErrorAction Stop
+            return ($stateJson | ConvertFrom-Json)
+        }
+        catch {
+            Write-LogWarning "Failed to read state file: $_"
+            return $null
+        }
+    }
+    return $null
+}
+
+function Write-StateFile {
+    <#
+    .SYNOPSIS
+        Atomically writes the state object to the state file.
+    .DESCRIPTION
+        Writes to a temporary file first, then renames it to ensure atomic writes.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$State
+    )
+
+    try {
+        # Convert hashtable to JSON
+        $stateJson = $State | ConvertTo-Json -Depth 10
+
+        # Write to temporary file
+        $tempFile = "$StateFile.tmp"
+        $stateJson | Set-Content -Path $tempFile -Force -ErrorAction Stop
+
+        # Atomic rename
+        Move-Item -Path $tempFile -Destination $StateFile -Force -ErrorAction Stop
+    }
+    catch {
+        Write-LogError "Failed to write state file: $_"
+        # Clean up temp file if it exists
+        if (Test-Path $tempFile) {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Initialize-StateFile {
+    <#
+    .SYNOPSIS
+        Initializes the state file at script start and checks for interrupted runs.
+    .DESCRIPTION
+        Creates a new run ID and sets status to InProgress. If a previous run was
+        in progress, it logs a warning about the interrupted run.
+    #>
+    # Check previous state
+    $previousState = Read-StateFile
+
+    if ($null -ne $previousState -and $previousState.status -eq "InProgress") {
+        Write-LogWarning "Previous run (ID: $($previousState.lastRunId)) was interrupted. Last step: $($previousState.lastStep)"
+        Write-LogWarning "Previous run started at: $($previousState.startTime)"
+    }
+
+    # Create new state
+    $newRunId = [guid]::NewGuid().ToString()
+    $newState = @{
+        lastRunId = $newRunId
+        status = "InProgress"
+        startTime = (Get-Date).ToString("o")
+        endTime = $null
+        lastExitCode = $null
+        lastStep = "Initialize"
+    }
+
+    Write-StateFile -State $newState
+    Write-LogInfo "State tracking initialized. Run ID: $newRunId"
+
+    return $newState
+}
+
+function Update-StateStep {
+    <#
+    .SYNOPSIS
+        Updates the lastStep field in the state file.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StepName
+    )
+
+    $currentState = Read-StateFile
+    if ($null -ne $currentState) {
+        $currentState.lastStep = $StepName
+        Write-StateFile -State $currentState
+    }
+}
+
+function Complete-StateFile {
+    <#
+    .SYNOPSIS
+        Marks the state as completed (Succeeded or Failed) with end time and exit code.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Succeeded", "Failed")]
+        [string]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [int]$ExitCode = 0
+    )
+
+    $currentState = Read-StateFile
+    if ($null -ne $currentState) {
+        $currentState.status = $Status
+        $currentState.endTime = (Get-Date).ToString("o")
+        $currentState.lastExitCode = $ExitCode
+        Write-StateFile -State $currentState
+        Write-LogInfo "State finalized: $Status (Exit code: $ExitCode)"
+    }
+}
+
+#endregion
+
 function Test-BackupPath {
+    Update-StateStep -StepName "Test-BackupPath"
     if (-not (Test-Path $SourcePath)) {
         Write-LogError "Backup source path '$SourcePath' is not accessible."
+        Complete-StateFile -Status "Failed" -ExitCode 1
         exit 1
     }
     Write-LogInfo "Validated source path '$SourcePath'"
 }
 
 function Test-Rclone {
+    Update-StateStep -StepName "Test-Rclone"
     $rcloneCheck = & rclone about $RcloneRemote 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-LogError "Rclone Google Drive validation failed: $rcloneCheck"
+        Complete-StateFile -Status "Failed" -ExitCode 1
         exit 1
     }
     Write-LogInfo "Validated Google Drive remote `"$RcloneRemote`""
 }
 
 function Test-Network {
+    Update-StateStep -StepName "Test-Network"
     # Use Google's public DNS for internet connectivity test
     $connectivityTestTarget = "8.8.8.8"
 
@@ -164,6 +311,7 @@ function Test-Network {
         }
         else {
             Write-LogError "Neither '$PreferredSSID' nor '$FallbackSSID' WiFi networks are available."
+            Complete-StateFile -Status "Failed" -ExitCode 1
             exit 1
         }
 
@@ -171,6 +319,7 @@ function Test-Network {
         $currentSSID = (netsh wlan show interfaces | Select-String "SSID" | Select-Object -First 1).ToString().Split(':')[1].Trim()
         if ($currentSSID -ne $PreferredSSID -and $currentSSID -ne $FallbackSSID) {
             Write-LogError "Failed to connect to preferred or fallback WiFi networks."
+            Complete-StateFile -Status "Failed" -ExitCode 1
             exit 1
         }
 
@@ -180,6 +329,7 @@ function Test-Network {
     # Step 2: Internet test
     if (-not (Test-Connection -ComputerName $connectivityTestTarget -Count 2 -Quiet)) {
         Write-LogError "No internet connection. Sync aborted."
+        Complete-StateFile -Status "Failed" -ExitCode 1
         exit 1
     }
 
@@ -208,6 +358,7 @@ function Get-ChunkSize {
 }
 
 function Sync-Backups {
+    Update-StateStep -StepName "Sync-Backups"
     $chunkSize = Get-ChunkSize
     $rcloneArgs = @(
         "sync", $SourcePath, $RcloneRemote,
@@ -236,15 +387,22 @@ function Sync-Backups {
 
     if ($LASTEXITCODE -eq 0) {
         Write-LogInfo "Sync completed successfully"
+        Complete-StateFile -Status "Succeeded" -ExitCode 0
     }
     else {
         Write-LogError "Sync failed with exit code $LASTEXITCODE"
+        Complete-StateFile -Status "Failed" -ExitCode $LASTEXITCODE
+        exit $LASTEXITCODE
     }
 }
 
 # Execution Flow
 try {
     Write-LogInfo "Starting Macrium backup sync script"
+
+    # Initialize state tracking
+    $script:currentState = Initialize-StateFile
+
     # Prevent sleep & display timeout
     [SleepControl.PowerMgmt]::SetThreadExecutionState([uint32]"0x80000003") | Out-Null
     Write-LogInfo "System sleep and display timeout temporarily disabled"
@@ -254,6 +412,11 @@ try {
     Test-Rclone
     Test-Network
     Sync-Backups
+}
+catch {
+    Write-LogError "Unhandled exception: $_"
+    Complete-StateFile -Status "Failed" -ExitCode 1
+    throw
 }
 finally {
     # Restore normal sleep behavior


### PR DESCRIPTION
Add comprehensive state tracking system to detect interrupted runs and monitor backup progress across unexpected reboots.

Features:
- JSON state file in logs directory (Sync-MacriumBackups_state.json)
- Tracks: runId (GUID), status, startTime, endTime, exitCode, lastStep
- Atomic writes using temp file and rename pattern
- Detects interrupted runs (InProgress status from previous run)
- Updates state at each step: Initialize, Test-BackupPath, Test-Rclone, Test-Network, Sync-Backups
- Finalizes state on success (Succeeded) or failure (Failed)
- Exception handling marks state as Failed on unhandled errors

Technical details:
- Read-StateFile: Reads existing state from JSON
- Write-StateFile: Atomic writes with temp file
- Initialize-StateFile: Creates new run, warns on interrupted previous run
- Update-StateStep: Updates current step in state
- Complete-StateFile: Finalizes with status and exit code

Version bumped to 2.2.0