### PR TITLE
feat(backup): add TaskPath parameter for custom Task Scheduler folder…

### DIFF
--- a/src/powershell/backup/README.md
+++ b/src/powershell/backup/README.md
@@ -46,6 +46,9 @@ For **Sync-MacriumBackups.ps1**, use the automated registration script for quick
 # Register task in a custom Task Scheduler folder
 .\Register-SyncMacriumBackupsTask.ps1 -TaskPath "\Backup Tasks\"
 
+# Register task in a nested folder structure (auto-creates all levels)
+.\Register-SyncMacriumBackupsTask.ps1 -TaskPath "\Backups\Nightly\"
+
 # Register task in the root Task Scheduler Library
 .\Register-SyncMacriumBackupsTask.ps1 -TaskPath "\"
 


### PR DESCRIPTION
… organization

Add ability to specify custom folder location in Task Scheduler where the task will be created, with automatic folder creation if it doesn't exist.

Changes to Register-SyncMacriumBackupsTask.ps1:
- Add -TaskPath parameter with default value "\My Scheduled Tasks\"
- Validate TaskPath format (must start/end with backslash or be root "\")
- Automatically create Task Scheduler folder if it doesn't exist
- Update task registration to use specified TaskPath
- Update removal logic to include TaskPath parameter
- Enhanced output messages to display full task path (TaskPath + TaskName)
- Update manual test command to include -TaskPath parameter
- Display task location in Task Scheduler UI reference

Changes to README.md:
- Add usage examples for TaskPath parameter
- Document folder organization feature in features list
- Add examples for custom folders and root folder placement
- Show removal commands with TaskPath for custom folders

Default behavior: Tasks are now created in "\My Scheduled Tasks\" folder for better organization, instead of root Task Scheduler Library.