### PR TITLE
Quote SSID values in netsh wlan connect

### DIFF
--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -690,7 +690,7 @@ function Test-Network {
         $availableNetworks = (netsh wlan show networks mode=bssid) -join "`n"
         if ($availableNetworks -match $PreferredSSID) {
             Write-LogInfo "Switching from '$FallbackSSID' to preferred network '$PreferredSSID'"
-            netsh wlan connect name=$PreferredSSID
+            netsh wlan connect name="$PreferredSSID"
             Start-Sleep -Seconds 10
 
             $currentSSID = Get-CurrentSSID
@@ -716,11 +716,11 @@ function Test-Network {
         $availableNetworks = (netsh wlan show networks mode=bssid) -join "`n"
         if ($availableNetworks -match $PreferredSSID) {
             Write-LogInfo "Connecting to preferred network '$PreferredSSID'"
-            netsh wlan connect name=$PreferredSSID
+            netsh wlan connect name="$PreferredSSID"
         }
         elseif ($availableNetworks -match $FallbackSSID) {
             Write-LogInfo "Connecting to fallback network '$FallbackSSID'"
-            netsh wlan connect name=$FallbackSSID
+            netsh wlan connect name="$FallbackSSID"
         }
         else {
             Write-LogError "Neither '$PreferredSSID' nor '$FallbackSSID' WiFi networks are available."


### PR DESCRIPTION
SSIDs containing spaces were causing connection failures due to unquoted values in netsh commands. Updated all three connection attempts to properly quote the SSID parameter.

Changes:
- Line 693: Quote $PreferredSSID when switching from fallback
- Line 719: Quote $PreferredSSID in initial connection attempt
- Line 723: Quote $FallbackSSID in fallback connection attempt

Fixes: SSIDs with spaces now connect correctly