### PR TITLE
Add validation attributes to script parameters

### DIFF
--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -155,12 +155,12 @@ param(
     # ===========================
     [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^[a-zA-Z0-9\s_-]+$')]
+    [ValidatePattern('^[^"`$|;&<>\r\n\t]+$')]
     [string]$PreferredSSID = "ManojNew_5G",
 
     [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^[a-zA-Z0-9\s_-]+$')]
+    [ValidatePattern('^[^"`$|;&<>\r\n\t]+$')]
     [string]$FallbackSSID = "ManojNew",
 
     # ===========================


### PR DESCRIPTION
…acriumBackups

Enhanced the parameter block with comprehensive validation, security improvements, and better organization to address code review suggestions.

Changes:
- Added [Parameter(Mandatory=$false)] to all optional parameters for consistency
- Added [ValidatePattern('^[a-zA-Z0-9\s_-]+$')] to SSID parameters to prevent command injection attacks (blocks semicolons, pipes, dollar signs, etc.)
- Added [ValidateRange(64, 4096)] to MaxChunkMB parameter for bounds checking
- Added [ValidateNotNullOrEmpty()] to all string parameters
- Reorganized parameters into logical groups with clear section comments:
  * Path Parameters (SourcePath, RcloneRemote)
  * Network Parameters (PreferredSSID, FallbackSSID)
  * Rclone Configuration (MaxChunkMB)
  * Execution Control (Interactive, AutoResume, Force)
- Added comprehensive test documentation (PARAMETER_VALIDATION_TESTS.md)
- Added implementation summary documentation (PARAMETER_IMPROVEMENTS_SUMMARY.md)

Security improvements:
- SSID validation now blocks common command injection vectors while allowing legitimate WiFi naming conventions (alphanumeric, spaces, hyphens, underscores)
- Prevents variable expansion, command chaining, and escape sequence attacks

Backward compatibility:
- All existing scripts with default values continue to work
- Only malformed or malicious inputs will be rejected

Related to code review suggestions for enhanced parameter validation, consistency, and security.