### PR TITLE
Enhance Sync-MacriumBackups logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - State persistence across sessions
     - FIFO processing with peek support
     - Flexible item removal with filters
+- **Sync-MacriumBackups Logging Enhancements**
+  - Log the sanitized rclone command line for auditing
+  - Log framework, rclone, and state file paths to the framework log
+  - Align rclone log timestamp format with the logging framework for consistency
 
 ### Changed
 

--- a/src/powershell/backup/README.md
+++ b/src/powershell/backup/README.md
@@ -87,5 +87,6 @@ Database connection parameters are typically configured within each script or re
 ## Logging and automation
 
 - All backup utilities use the PowerShell Logging Framework and write logs to the standard logs directory as defined in the logging specification.
+- `Sync-MacriumBackups.ps1` logs the sanitized rclone command line for auditability and aligns rclone log timestamps with the framework log format.
 - Backup launcher scripts emit structured `PSCustomObject` summaries via `Write-Output` so task schedulers and automation can capture results programmatically.
 - `scripts/Sync-Directory.ps1` returns a plan (counts + relative paths) when run with `-PreviewOnly` and a detailed action log after execution.


### PR DESCRIPTION
### Motivation

- Improve auditability by recording the rclone command line (with sensitive values redacted) before execution.
- Ensure rclone and framework logs use a consistent timestamp format for easier correlation during troubleshooting.
- Persist log path information (framework log, rclone log, state file) to the centralized framework log for traceability.

### Description

- Added `Get-SanitizedRcloneArgs` and `Format-RcloneCommandLine` helpers and log the sanitized `rclone` command line via `Write-LogInfo` before invocation.
- Added rclone logging options `--log-format` and `--log-date-format` to align rclone timestamps with the framework format and included them in the assembled `rclone` args.
- Emit framework log entries for the framework log path, rclone log path, and state file using `Write-LogInfo` in addition to the existing `Write-Host` output.
- Bumped the script `Version` to `2.5.1` and updated `CHANGELOG.md` and the backup `README.md` to document the logging enhancements.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968943983f083258d9a93bb48badf3b)