### PR TITLE
Fix Sync-MacriumBackups MaxChunkMB 4096 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync-MacriumBackups.ps1: MaxChunkMB 4096 honored** (v2.6.1)
+  - Added 4096 MB to the allowed rclone chunk size options so the documented MaxChunkMB range is honored
+  - Prevents 4096 MB inputs from silently capping to 2048 MB
+
 - **FileDistributor.ps1: Console Feedback for Rebalancing Operations** (v4.4.1)
   - Added console output for early exit conditions in `-RebalanceToAverage`, `-ConsolidateToMinimum`, and `-RandomizeDistribution` modes
   - Users now see clear messages when operations are skipped due to:

--- a/src/powershell/backup/README.md
+++ b/src/powershell/backup/README.md
@@ -84,6 +84,8 @@ Pre-configured task XML definitions are located in:
 
 Database connection parameters are typically configured within each script or read from environment variables. Check individual scripts for specific configuration requirements.
 
+For `Sync-MacriumBackups.ps1`, the `-MaxChunkMB` parameter accepts 64-4096 MB and the script selects the largest supported rclone chunk size at or below your limit and available memory.
+
 ## Logging and automation
 
 - All backup utilities use the PowerShell Logging Framework and write logs to the standard logs directory as defined in the logging specification.

--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -61,9 +61,13 @@
     Forces a sync run regardless of the previous run's status.
 
 .NOTES
-    Version: 2.6.0
+    Version: 2.6.1
 
     CHANGELOG
+    ## 2.6.1 - 2026-01-15
+    ### Fixed
+    - Allowed 4096 MB rclone chunk size when MaxChunkMB is set to the documented maximum
+
     ## 2.6.0 - 2026-01-15
     ### Changed
     - Refactored Initialize-StateFile to eliminate duplicated interrupted state handling logic
@@ -198,7 +202,7 @@ param(
 )
 
 # Script Version (extracted from .NOTES for programmatic access)
-$ScriptVersion = "2.6.0"
+$ScriptVersion = "2.6.1"
 
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
@@ -825,7 +829,7 @@ function Get-ChunkSize {
     $halfFreeMB = [math]::Floor($freeMB / 2)
 
     # Allowed rclone chunk sizes (in MB)
-    $allowedSizes = @(64, 128, 256, 512, 1024, 2048)
+    $allowedSizes = @(64, 128, 256, 512, 1024, 2048, 4096)
 
     # Select the largest allowable chunk size that fits within both thresholds
     $chunk = $allowedSizes | Where-Object { $_ -le $halfFreeMB -and $_ -le $MaxChunkMB } | Select-Object -Last 1


### PR DESCRIPTION
### Motivation
- The `MaxChunkMB` parameter is validated with `[ValidateRange(64, 4096)]` but `Get-ChunkSize` only allowed up to 2048MB, so a user-specified `4096` would be silently capped; the review comment is valid and this patch ensures the documented range is honored.

### Description
- Added `4096` to the allowed rclone chunk sizes in `Get-ChunkSize` in `src/powershell/backup/Sync-MacriumBackups.ps1`, bumped the script `Version`/`$ScriptVersion` to `2.6.1`, and recorded the fix in `CHANGELOG.md` and `src/powershell/backup/README.md` to document the `-MaxChunkMB` `64-4096` range.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a00846d48325b1aa70c3c88975ed)