### PR TITLE
Improve Sync-MacriumBackups rclone command logging and bump version to v2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync-MacriumBackups.ps1: Improved sanitized rclone command logging** (v2.6.3)
+  - Added single-line sanitized command output for easy copy/paste reproduction
+  - Logged multi-line arguments without a dangling backslash-only line
+
 - **Remove-MergedGitBranch.ps1: Dry-run safety and log file output** (v2.7.3)
   - Dry-run now avoids pruning remote-tracking branches to prevent accidental deletion prompts
   - `-LogFile` now routes logging output to the specified file path

--- a/src/powershell/backup/README.md
+++ b/src/powershell/backup/README.md
@@ -89,6 +89,6 @@ For `Sync-MacriumBackups.ps1`, the `-MaxChunkMB` parameter accepts 64-4096 MB an
 ## Logging and automation
 
 - All backup utilities use the PowerShell Logging Framework and write logs to the standard logs directory as defined in the logging specification.
-- `Sync-MacriumBackups.ps1` logs the sanitized rclone command line for auditability and aligns rclone log timestamps with the framework log format.
+- `Sync-MacriumBackups.ps1` logs sanitized rclone command lines in single-line and multi-line formats for auditability and aligns rclone log timestamps with the framework log format.
 - Backup launcher scripts emit structured `PSCustomObject` summaries via `Write-Output` so task schedulers and automation can capture results programmatically.
 - `scripts/Sync-Directory.ps1` returns a plan (counts + relative paths) when run with `-PreviewOnly` and a detailed action log after execution.

--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -61,9 +61,14 @@
     Forces a sync run regardless of the previous run's status.
 
 .NOTES
-    Version: 2.6.2
+    Version: 2.6.3
 
     CHANGELOG
+    ## 2.6.3 - 2026-01-15
+    ### Fixed
+    - Added single-line and multi-line sanitized rclone command output for easier reconstruction and debugging
+    - Avoided logging a dangling rclone backslash line without arguments
+
     ## 2.6.2 - 2026-01-15
     ### Fixed
     - Enhanced rclone command logging to display each argument on a separate line for better debugging
@@ -207,7 +212,7 @@ param(
 )
 
 # Script Version (extracted from .NOTES for programmatic access)
-$ScriptVersion = "2.6.2"
+$ScriptVersion = "2.6.3"
 
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
@@ -932,15 +937,13 @@ function Sync-Backups {
     $sanitizedCommandLine = Format-RcloneCommandLine -Args $sanitizedArgs
 
     # Log the full command line for debugging (especially important when rclone fails)
-    Write-LogInfo "Rclone command line (sanitized):"
-    Write-LogInfo "  rclone \"
+    Write-LogInfo "Rclone command line (sanitized, single-line):"
+    Write-LogInfo "  $sanitizedCommandLine"
+    Write-LogInfo "Rclone command line (sanitized, multi-line):"
+    Write-LogInfo "  rclone"
     foreach ($arg in $sanitizedArgs) {
-        if ($arg -match "\s") {
-            Write-LogInfo "    `"$arg`""
-        }
-        else {
-            Write-LogInfo "    $arg"
-        }
+        $formattedArg = if ($arg -match "\s") { "`"$arg`"" } else { $arg }
+        Write-LogInfo "    $formattedArg"
     }
     Write-LogInfo "Starting sync with chunk size: $chunkSize"
 


### PR DESCRIPTION
### Motivation

- Provide clearer, copy/paste-friendly diagnostic output when rclone fails so the full command can be reconstructed easily. 
- Remove a logging artifact that produced a dangling backslash-only line which could confuse debugging and lead to malformed reconstructions.
- Bump the script version in the script notes so programmatic consumers can detect the change.

### Description

- Updated `src/powershell/backup/Sync-MacriumBackups.ps1` to emit a sanitized single-line `rclone` command for easy copy/paste reproduction and a sanitized multi-line argument listing for readable diagnostics. 
- Replaced the previous dangling `rclone \` log line with the new single-line output and ensured multi-line output does not emit an isolated backslash-only line. 
- Bumped the script `Version` in the `.NOTES` block and the `$ScriptVersion` variable from `2.6.2` to `2.6.3`. 
- Documented the change in `src/powershell/backup/README.md` and added an Unreleased changelog entry in `CHANGELOG.md` describing the logging improvements.

### Testing

- No automated tests were executed as part of this change. 
- Changes are limited to logging and documentation updates and do not modify runtime control flow or rclone argument construction logic used at execution time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969057d86b08325b8d4bb02a1d841e6)