### PR TITLE
Add auto-resume feature to backup sync script

### DIFF
--- a/src/powershell/backup/Sync-MacriumBackups.ps1
+++ b/src/powershell/backup/Sync-MacriumBackups.ps1
@@ -61,9 +61,14 @@
     Forces a sync run regardless of the previous run's status.
 
 .NOTES
-    Version: 2.6.5
+    Version: 2.6.6
 
     CHANGELOG
+    ## 2.6.6 - 2026-01-15
+    ### Fixed
+    - Added missing 'reason' property to state object initialization to fix AutoResume functionality
+    - Resolved "property 'reason' cannot be found" error in Mark-InterruptedState function
+
     ## 2.6.5 - 2026-01-15
     ### Fixed
     - Aligned rclone log formatting with supported --log-format options (date,time,microseconds)
@@ -222,7 +227,7 @@ param(
 )
 
 # Script Version (extracted from .NOTES for programmatic access)
-$ScriptVersion = "2.6.5"
+$ScriptVersion = "2.6.6"
 
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
@@ -433,6 +438,7 @@ function Initialize-StateFile {
         lastStep = "Initialize"
         syncStartTime = $null
         syncDurationSeconds = $null
+        reason = $null
     }
 
     Write-StateFile -State $newState


### PR DESCRIPTION
- Added reason property to state object initialization (set to null)
- Fixes "property 'reason' cannot be found" error in Mark-InterruptedState
- Bumped version to 2.6.6 with changelog entry

The Mark-InterruptedState function was attempting to set a 'reason' property on the state object, but this property wasn't defined in the initial state structure. When ConvertFrom-Json reads the state file, it creates a PSCustomObject with fixed properties, preventing dynamic property addition without Add-Member. Adding the property to the initial state definition ensures all state objects have this property from the start.