### PR TITLE
fix: suppress bandit false positive for status symbol dictionary

### DIFF
--- a/src/python/cloud/gdrive_recover.py
+++ b/src/python/cloud/gdrive_recover.py
@@ -1517,7 +1517,7 @@ class DriveTrashRecoveryTool:
             self._print_single_operation_privilege(operation, result)
 
     def _print_single_operation_privilege(self, operation: str, result: Dict[str, Any]):
-        status_symbol = {"pass": "✓", "fail": "❌"}.get(result["status"], "?")
+        status_symbol = {"pass": "✓", "fail": "❌"}.get(result["status"], "?")  # nosec B105
         print(f"  {operation.title()}: {status_symbol} {result['status'].upper()}")
         if result["error"]:
             print(f"    Error: {result['error']}")


### PR DESCRIPTION
B105 incorrectly flags {"pass": "✓"} as a hardcoded password because the dictionary key "pass" matches password-related patterns. The value is just a UI checkmark symbol for displaying operation status.

https://claude.ai/code/session_01C4PtLL6PEYgC3mqAsAzvzY