### PR TITLE
fix: audit locked python dependencies

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install security scanning tools
         run: |
           python -m pip install --upgrade pip
-          pip install safety pip-audit
+          pip install $(grep -E '^safety==' requirements.lock) $(grep -E '^pip-audit==' requirements.lock)
 
       - name: Run Safety check
         id: safety
@@ -50,7 +50,7 @@ jobs:
           echo "## Safety Security Scan Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if safety check --json -r requirements.txt > safety-report.json 2>&1; then
+          if safety check --json -r requirements.lock > safety-report.json 2>&1; then
             echo "✅ **Safety Check**: No known security vulnerabilities detected" >> $GITHUB_STEP_SUMMARY
             echo "safety_exit=0" >> $GITHUB_OUTPUT
             echo "SAFETY_STATUS=success" >> $GITHUB_ENV
@@ -58,7 +58,7 @@ jobs:
             echo "⚠️ **Safety Check**: Vulnerabilities detected" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            safety check -r requirements.txt >> $GITHUB_STEP_SUMMARY 2>&1 || true
+            safety check -r requirements.lock >> $GITHUB_STEP_SUMMARY 2>&1 || true
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "safety_exit=1" >> $GITHUB_OUTPUT
             echo "SAFETY_STATUS=failure" >> $GITHUB_ENV
@@ -74,7 +74,7 @@ jobs:
 
           # CVE-2026-0994: protobuf DoS vulnerability - no fix released yet (patch in master only)
           # Remove --ignore-vuln once protobuf releases a patched version
-          if pip-audit -r requirements.txt --desc --ignore-vuln CVE-2026-0994 > pip-audit-report.txt 2>&1; then
+          if pip-audit -r requirements.lock --desc --ignore-vuln CVE-2026-0994 > pip-audit-report.txt 2>&1; then
             echo "✅ **pip-audit Check**: No known security vulnerabilities detected" >> $GITHUB_STEP_SUMMARY
             echo "audit_exit=0" >> $GITHUB_OUTPUT
             echo "AUDIT_STATUS=success" >> $GITHUB_ENV
@@ -140,7 +140,7 @@ jobs:
             echo "1. Review the vulnerability reports above" >> $GITHUB_STEP_SUMMARY
             echo "2. Update affected packages to secure versions" >> $GITHUB_STEP_SUMMARY
             echo "3. Test the application with updated dependencies" >> $GITHUB_STEP_SUMMARY
-            echo "4. Commit the updated requirements.txt" >> $GITHUB_STEP_SUMMARY
+            echo "4. Commit the updated requirements.lock (and requirements.txt if ranges changed)" >> $GITHUB_STEP_SUMMARY
             echo "5. Re-run this security scan to verify fixes" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Security scans: audit the locked dependency set**
+  - Updated GitHub Actions security scanning to install pinned `safety` and `pip-audit` versions from `requirements.lock`
+  - Switched Safety and `pip-audit` checks from `requirements.txt` to `requirements.lock` so CI audits the reproducible dependency set instead of re-resolving floating ranges
+  - Updated the README security commands to match the lockfile-based workflow and reduce false positives from transient dependency resolution
+
 - **Sync-MacriumBackups.ps1: Align rclone log format with documentation** (v2.6.5)
   - Set rclone log format to `date,time,microseconds` (documented options) for consistent timestamps
   - Removed unsupported log time format probing to avoid unknown-flag errors

--- a/README.md
+++ b/README.md
@@ -555,13 +555,13 @@ This repository includes automated security scanning to detect vulnerabilities i
 
 ```bash
 # Install security scanning tools
-pip install safety pip-audit
+pip install $(grep -E '^safety==' requirements.lock) $(grep -E '^pip-audit==' requirements.lock)
 
-# Run safety check
-safety check -r requirements.txt
+# Run safety check against the locked dependency set used by CI/production
+safety check -r requirements.lock
 
-# Run pip-audit
-pip-audit -r requirements.txt --desc
+# Run pip-audit against the locked dependency set used by CI/production
+pip-audit -r requirements.lock --desc
 
 # Run both via pre-commit
 pre-commit run python-safety-dependencies-check --all-files
@@ -572,6 +572,7 @@ pre-commit run python-safety-dependencies-check --all-files
 - Pre-commit hook configured in `.pre-commit-config.yaml`
 - Reports are uploaded as GitHub Actions artifacts (30-day retention)
 - Builds fail on detected vulnerabilities to ensure prompt remediation
+- CI audits `requirements.lock` so results match the reproducible dependency set that the repository supports
 
 **Enabling Dependabot (Recommended):**
 


### PR DESCRIPTION
### Motivation
- CI was re-resolving floating ranges from `requirements.txt` when running dependency scanners, causing results to diverge from the reproducible environment and producing transient findings (e.g. `nltk`-related alerts); scans should target the exact, pinned dependency set used in CI/production.
- Make local docs and CI workflow consistent so security scans report against the same locked versions developers and CI rely on.

### Description
- Updated `.github/workflows/security-scan.yml` to install the `safety` and `pip-audit` versions pinned in `requirements.lock` and to run both scanners against `requirements.lock` instead of `requirements.txt`.
- Updated `README.md` security instructions to install the pinned scanner versions from `requirements.lock` and to run `safety`/`pip-audit` against `requirements.lock` for reproducible results.
- Added an Unreleased entry to `CHANGELOG.md` documenting the change to lockfile-based security scanning and the rationale.

### Testing
- Ran `git diff --check` to validate no whitespace or diff issues and it passed.
- Reviewed the workflow excerpt (`.github/workflows/security-scan.yml`) and README excerpt to confirm the scanner install and invocation now reference `requirements.lock` and the pinned scanner versions; review completed successfully.
- Committed the changes (`fix: audit locked python dependencies`) and verified repository status updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17785b8d48325b360b9647bc9980f)