### PR TITLE
fix: restore pip-audit virtualenv compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Python dev dependency security overrides** (v2.7.4)
-  - Added explicit `virtualenv>=20.36.2` and `filelock>=3.20.3` constraints to `requirements.txt` so future resolves avoid the known TOCTOU advisories reported in the `pre-commit` runtime stack
-  - Pinned `virtualenv==20.36.2` and `filelock==3.20.3` in `requirements.lock` so Safety and `pip-audit` scan the same patched dependency set used by CI
+  - Added explicit `virtualenv>=20.36.1` and `filelock>=3.20.3` constraints to `requirements.txt` so future resolves avoid the known TOCTOU advisories reported in the `pre-commit` runtime stack
+  - Pinned `virtualenv==20.36.1` and `filelock==3.20.3` in `requirements.lock` so Safety and `pip-audit` scan the same patched dependency set used by CI
   - Updated README installation and security guidance to document the patched lockfile-based workflow
+
+- **pip-audit lockfile install compatibility**
+  - Replaced the unavailable `virtualenv==20.36.2` lockfile pin with `virtualenv==20.36.1`, which is present on the package index used by automation
+  - Relaxed the floating `requirements.txt` lower bound to `virtualenv>=20.36.1` so development installs stay aligned with the lockfile
+  - Updated installation guidance to explain the `pip-audit` failure mode and the compatible replacement pin
 
 - **Security scans: audit the locked dependency set**
   - Updated GitHub Actions security scanning to install pinned `safety` and `pip-audit` versions from `requirements.lock`

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -160,7 +160,7 @@ pip install -r requirements.txt
 pip3 install -r requirements.lock
 ```
 
-`requirements.lock` also pins the `pre-commit` runtime stack (`virtualenv` and `filelock`) to patched versions so local tooling matches CI security scans.
+`requirements.lock` also pins the `pre-commit` runtime stack (`virtualenv` and `filelock`) to patched versions so local tooling matches CI security scans. The pinned `virtualenv` build is `20.36.1` because some package indexes do not publish `20.36.2`, which caused `pip-audit` environment creation to fail.
 
 ## Optional Software Installation
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The repository now ships with **dual dependency manifests**:
 
 - Use `requirements.lock` for deterministic, reproducible installs (CI, production machines).
 - Use `requirements.txt` for local development when you want the latest compatible releases within vetted version ranges.
-- The manifests explicitly pin `virtualenv` and `filelock` to patched versions because repository tooling such as `pre-commit` depends on them transitively.
+- The manifests explicitly pin `virtualenv` and `filelock` to patched versions because repository tooling such as `pre-commit` depends on them transitively. The lockfile now uses `virtualenv==20.36.1`, which remains available on package indexes where `20.36.2` is missing.
 
 **Configuration Guide**: See [config/CONFIG_GUIDE.md](config/CONFIG_GUIDE.md) for detailed configuration instructions.
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -23,7 +23,7 @@ pytest-mock==3.11.1
 
 # Code quality and formatting
 pre-commit==4.3.0
-virtualenv==20.36.2
+virtualenv==20.36.1
 filelock==3.20.3
 black==26.3.1
 bandit==1.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pytest-mock>=3.11.0,<4.0.0
 
 # Code quality and formatting
 pre-commit>=4.3.0,<5.0.0
-virtualenv>=20.36.2,<21.0.0
+virtualenv>=20.36.1,<21.0.0
 filelock>=3.20.3,<4.0.0
 black>=26.3.1
 bandit>=1.7.9,<2.0.0


### PR DESCRIPTION
### Motivation
- `pip-audit` was failing to create its temporary virtual environment because the lockfile pinned `virtualenv==20.36.2`, which is not available on some package indexes used by automation. 
- The repository needs consistent, installable pins so CI/scan tooling and local installs use the same patched runtime stack.

### Description
- Replaced the unavailable lockfile pin by changing `requirements.lock` to `virtualenv==20.36.1`. 
- Aligned the floating development constraint in `requirements.txt` to `virtualenv>=20.36.1,<21.0.0`. 
- Updated `README.md` and `INSTALLATION.md` to document the compatible lockfile pin and the `pip-audit` failure mode. 
- Added changelog entries in `CHANGELOG.md` describing the compatibility fix and the adjusted dependency notes.

### Testing
- Ran `git diff --check` to ensure no whitespace or index issues, which succeeded. 
- Ran small Python verifications that assert `requirements.lock` contains `virtualenv==20.36.1` and `requirements.txt` contains `virtualenv>=20.36.1,<21.0.0`, which succeeded. 
- Attempted `python -m pip install --dry-run --report /tmp/virtualenv-report.json virtualenv==20.36.1`, which could not perform a live resolution in this environment due to outbound package-index access being blocked by a proxy, so a remote install check was not possible here. 
- Changes committed as `fix: restore pip-audit virtualenv compatibility`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17ce726e48325b1fe57479c60d80a)