### PR TITLE
Add Profile-Helpers.ps1 for repo script management

### DIFF
--- a/scripts/Profile-Helpers.ps1
+++ b/scripts/Profile-Helpers.ps1
@@ -124,11 +124,14 @@ function Update-RepoIndex {
     )
 
     # Single recursive pass — collect all PowerShell-relevant file types.
+    # Split the full path into segments and reject any file whose path contains
+    # an excluded directory at *any* depth, not just the immediate parent.
     $files =
         Get-ChildItem -Path $Root -Recurse -File -ErrorAction SilentlyContinue |
         Where-Object {
             $_.Extension -in '.ps1', '.psm1', '.psd1' -and
-            ($excludeDirs -notcontains $_.Directory.Name)
+            -not ($_.FullName.Split([IO.Path]::DirectorySeparatorChar) |
+                  Where-Object { $excludeDirs -contains $_ })
         }
 
     # Build the script index from .ps1 files.


### PR DESCRIPTION
## Summary
Add a new PowerShell profile helper module that enables fast, convenient execution of repository scripts and lazy-loading of modules without impacting startup performance.

## Key Changes
- **Script Discovery & Execution**: Implements a caching system that indexes all `.ps1` scripts under a repository and makes them executable from anywhere by name, without creating proxy functions
- **Lazy Module Loading**: Automatically imports repository modules (`.psm1`/`.psd1` files) on first repo script invocation, keeping startup fast
- **PSReadLine Integration**: Adds an Enter-key handler that transparently expands repo script names to their full paths before execution
- **Manual Index Management**: Provides `Update-RepoIndex` function to rebuild script and module caches after adding or renaming files
- **Tab Completion**: Implements argument completion for the `Run-RepoScript` function
- **Status Reporting**: Includes `Show-RepoProfileStatus` for debugging and verification

## Implementation Details
- Uses JSON caching (`script_index.json`, `module_index.json`) stored in `$CacheDir` for fast startup
- Deduplicates scripts by name, keeping the newest version when conflicts exist
- Excludes common non-source directories (node_modules, .git, venv, etc.) from indexing
- Implements a busy flag in the PSReadLine handler to prevent recursion
- Gracefully handles missing caches and import failures with appropriate error messages
- Requires three variables to be pre-configured: `$RepoRoot`, `$PsRoot`, and `$CacheDir`

https://claude.ai/code/session_015E7gUNkGzRfZKJhKeUP3xe