### PR TITLE
Replace MyInvocation.MyCommand.Module.Version with context.Version

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -149,7 +149,7 @@ function Start-VideoBatch {
             throw
         }
 
-        $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — crop-only mode" -f ($MyInvocation.MyCommand.Module.Version.ToString()))
+        $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — crop-only mode" -f ($context.Version))
         Write-Debug 'TRACE Start-VideoBatch: leaving (CropOnly)'
         return
     }
@@ -444,7 +444,7 @@ function Start-VideoBatch {
         }
     }
 
-    $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — processed {1} file(s)" -f ($MyInvocation.MyCommand.Module.Version.ToString()), $processedCount)
+    $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — processed {1} file(s)" -f ($context.Version), $processedCount)
     Write-Debug 'TRACE Start-VideoBatch: leaving (no output intended)'
     return
 }


### PR DESCRIPTION
## Summary
Updated version retrieval in logging messages to use `$context.Version` instead of `$MyInvocation.MyCommand.Module.Version.ToString()` for consistency and improved maintainability.

## Key Changes
- Replaced `$MyInvocation.MyCommand.Module.Version.ToString()` with `$context.Version` in two log messages within the `Start-VideoBatch` function
  - Line 152: Crop-only mode completion message
  - Line 447: Standard processing completion message

## Implementation Details
This change simplifies the version retrieval by using the already-available `$context` variable instead of accessing the module version through the invocation metadata. This approach is more direct and likely more performant, while maintaining the same logging output.

https://claude.ai/code/session_01Y4yZEcehqMGVhvWzizKNpZ