### PR TITLE
refactor(file-distributor): extract subfolder count and distribution summary helpers

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 4.6.13 — 2026-03-27
+### Fixed
+- Restored fallback-candidate behavior in `Get-SubfolderFileCounts` for scan failures: when subfolder enumeration throws, the helper now attempts to continue with caller-provided candidates (after target-root normalization/validation) instead of unconditionally returning `$null`.
+- Updated distribution/redistribution call sites to pass known subfolder candidates to the helper so transient enumeration issues do not skip the phase when safe fallback inputs are available.
+
 ## 4.6.12 — 2026-03-27
 ### Changed
 - Refactored subfolder enumeration/counting into a streamlined private `Get-SubfolderFileCounts` helper with optional zero-file inclusion and shared error handling for all five algorithms (`DistributeFilesToSubfolders`, `RedistributeFilesInTarget`, `RebalanceSubfoldersByAverage`, `RandomizeDistributionAcrossFolders`, `ConsolidateSubfoldersToMinimum`).

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.6.12
+ 4.6.13
 
  CHANGELOG:
    See CHANGELOG.md in this directory for full release history.
@@ -226,9 +226,9 @@ To display the script's help text:
 .\FileDistributor.ps1 -Help
 
 .NOTES
-## 4.6.12 — 2026-03-27
+## 4.6.13 — 2026-03-27
 ### Changed
-- Extracted shared `Get-SubfolderFileCounts` and `Write-DistributionSummary` helpers to deduplicate repeated subfolder counting and distribution-table logging across file distribution algorithms.
+- Restored candidate-subfolder fallback when directory scans fail in `Get-SubfolderFileCounts`, so distribution/redistribution can continue with known candidates instead of aborting the phase.
 - Full changelog: `./CHANGELOG.md`.
 
 Script Workflow:
@@ -1036,21 +1036,50 @@ function Invoke-FileMove {
 function Get-SubfolderFileCounts {
     param(
         [Parameter(Mandatory)][string]$TargetFolder,
-        [switch]$IncludeEmpty
+        [switch]$IncludeEmpty,
+        [object[]]$FallbackSubfolders
     )
 
     $subfolders = $null
+    $scanFailed = $false
     try {
         $subfolders = @(Get-ChildItem -LiteralPath $TargetFolder -Directory -Force -ErrorAction Stop)
     }
     catch {
-        LogMessage -Message ("Failed to enumerate subfolders under '{0}': {1}" -f $TargetFolder, $_.Exception.Message) -IsError
-        return $null
+        $scanFailed = $true
+        LogMessage -Message ("Failed to enumerate subfolders under '{0}': {1}" -f $TargetFolder, $_.Exception.Message) -IsWarning
+        $subfolders = @()
+
+        if ($FallbackSubfolders -and $FallbackSubfolders.Count -gt 0) {
+            LogMessage -Message "Continuing with fallback subfolder candidates after scan failure." -IsWarning
+            foreach ($candidate in $FallbackSubfolders) {
+                $candidatePath = if ($candidate -is [IO.FileSystemInfo]) { $candidate.FullName } else { [string]$candidate }
+                if ([string]::IsNullOrWhiteSpace($candidatePath)) { continue }
+
+                $resolved = Resolve-SubfolderPath -Path $candidatePath -TargetRoot $TargetFolder
+                if (-not $resolved) { continue }
+                if (-not (Test-Path -LiteralPath $resolved -PathType Container)) { continue }
+
+                try {
+                    $normalized = [IO.Path]::GetFullPath($resolved)
+                    $subfolders += [pscustomobject]@{ FullName = $normalized }
+                }
+                catch {
+                    continue
+                }
+            }
+        }
     }
 
     if (-not $subfolders -or $subfolders.Count -eq 0) {
+        if ($scanFailed) {
+            LogMessage -Message "No usable fallback subfolders were available after scan failure." -IsError
+            return $null
+        }
         return @{}
     }
+
+    $subfolders = @($subfolders | Sort-Object FullName -Unique)
 
     $folderCounts = @{}
     $totalFiles = 0
@@ -1122,7 +1151,7 @@ function DistributeFilesToSubfolders {
     )
 
     $targetNormalized = [IO.Path]::GetFullPath($TargetRoot)
-    $folderCounts = Get-SubfolderFileCounts -TargetFolder $TargetRoot -IncludeEmpty
+    $folderCounts = Get-SubfolderFileCounts -TargetFolder $TargetRoot -IncludeEmpty -FallbackSubfolders $Subfolders
     if ($null -eq $folderCounts) {
         return
     }
@@ -1323,7 +1352,7 @@ function RedistributeFilesInTarget {
         [int]$TotalFiles
     )
 
-    $folderFilesMap = Get-SubfolderFileCounts -TargetFolder $TargetFolder -IncludeEmpty
+    $folderFilesMap = Get-SubfolderFileCounts -TargetFolder $TargetFolder -IncludeEmpty -FallbackSubfolders $Subfolders
     if ($null -eq $folderFilesMap) {
         return
     }

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -33,6 +33,8 @@ Scripts for file operations, distribution, copying, and archiving.
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.6.13**
+  - Restored safe fallback behavior for subfolder scan failures by allowing `Get-SubfolderFileCounts` to continue with caller-provided candidate folders (when available), preventing distribution/redistribution phases from being skipped on transient enumeration errors.
 - **FileDistributor.ps1 v4.6.12**
   - Extracted shared `Get-SubfolderFileCounts` (all five algorithms) and `Write-DistributionSummary` (rebalance/randomize/consolidate before/after summaries) to remove duplicated counting and distribution-table logging blocks.
 - **FileDistributor.ps1 v4.6.11**


### PR DESCRIPTION
### Motivation
- Remove repeated subfolder enumeration / counting and distribution-table logging repeated across distribution/rebalance/randomize/consolidate algorithms to improve maintainability and reduce duplication. 
- Provide small, well-scoped private helpers that do not rely on script-scope variables so callers can derive totals from returned data and logging stays consistent.

### Description
- Added private `Get-SubfolderFileCounts` with signature `Get-SubfolderFileCounts -TargetFolder <string> [-IncludeEmpty]` that enumerates subfolders, counts files, returns a hashtable `{ FullPath -> FileCount }`, and logs enumeration/count failures; callers sum the values to compute `totalFiles` where needed. 
- Added private `Write-DistributionSummary` with signature `Write-DistributionSummary -FolderCounts <hashtable> -Average <double> [-Label <string>] [-UpperBound <int>] [-LowerBound <int>]` that logs a sorted per-folder table and optionally labels DONOR/RECEIVER/BALANCED when bounds are supplied. 
- Updated all five algorithm flows to use the new helper(s): `DistributeFilesToSubfolders`, `RedistributeFilesInTarget`, `RebalanceSubfoldersByAverage`, `RandomizeDistributionAcrossFolders`, and `ConsolidateSubfoldersToMinimum`, and preserved emergency-subfolder creation and existing ordering/format of log messages. 
- Bumped `FileDistributor.ps1` version to `4.6.12` and updated `src/powershell/file-management/CHANGELOG.md` and `src/powershell/file-management/README.md` to record the refactor. 

### Testing
- Ran `git diff --check` which succeeded with no whitespace/errors reported. 
- Searched for usages with `rg` (`Write-DistributionSummary` / `Get-SubfolderFileCounts -TargetFolder`) to validate callsites were updated, which returned the expected locations. 
- Attempted PowerShell parser validation (`pwsh` based) but it could not run in this environment because `pwsh` is not installed, so live parse/PSLint was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5fb79666c8325b3e794277ef92360)