### PR TITLE
refactor(FileDistributor): scaffold support module and move path helpers

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.6.14 — 2026-03-29
+### Changed
+- Added a new internal `FileManagement/FileDistributor` support module scaffold (`FileDistributor.psd1`, `FileDistributor.psm1`, and `Private/PathHelpers.ps1`) as the first step of Proposal 6 module splitting.
+- Moved six low-risk path/filesystem helper functions from `FileDistributor.ps1` into `Private/PathHelpers.ps1`: `New-Ref`, `New-Directory`, `Resolve-PathWithFallback`, `Resolve-FilePathIfDirectory`, `Initialize-FilePath`, and `Resolve-SubfolderPath`.
+- Updated `FileDistributor.ps1` to import the new `FileDistributor` module alongside `FileQueue`, reducing script size and centralizing helper loading.
+
 ## 4.6.13 — 2026-03-27
 ### Fixed
 - Restored fallback-candidate behavior in `Get-SubfolderFileCounts` for scan failures: when subfolder enumeration throws, the helper now attempts to continue with caller-provided candidates (after target-root normalization/validation) instead of unconditionally returning `$null`.

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.6.13
+ 4.6.14
 
  CHANGELOG:
    See CHANGELOG.md in this directory for full release history.
@@ -310,6 +310,8 @@ Import-Module "$PSScriptRoot\..\modules\Core\Logging\PurgeLogs.psm1" -Force
 
 # Import FileQueue module for queue management
 Import-Module "$PSScriptRoot\..\modules\FileManagement\FileQueue\FileQueue.psd1" -Force
+Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistributor.psd1" -Force
+. "$PSScriptRoot\..\modules\FileManagement\FileDistributor\Private\PathHelpers.ps1"
 
 # Note: Logger initialization moved to after LogFilePath resolution
 
@@ -385,96 +387,13 @@ if ($Help) {
 }
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.6.11"
+$script:Version = "4.6.14"
 $script:Warnings = 0
 $script:Errors = 0
 
 # ===== Windows path resolution helpers (executed before any logging) =====
 # Determine script root (works in PS 5.1+ when running as a script)
 $script:ScriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Path $MyInvocation.MyCommand.Path -Parent }
-
-function New-Ref {
-    param($Initial = $null)
-    # Create a stable [ref] container and assign its initial value safely
-    $r = [ref]$null
-    $r.Value = $Initial
-    return $r
-}
-
-function New-Directory {
-    param([Parameter(Mandatory = $true)][string]$DirectoryPath)
-    if (-not (Test-Path -LiteralPath $DirectoryPath)) {
-        try { New-Item -ItemType Directory -Path $DirectoryPath -Force | Out-Null } catch {
-            Write-LogDebug "Failed to create directory ${DirectoryPath}: $_"
-        }
-    }
-    return (Test-Path -LiteralPath $DirectoryPath)
-}
-
-function Resolve-PathWithFallback {
-    param(
-        [string]$UserPath,
-        [Parameter(Mandatory = $true)][string]$ScriptRelativePath,
-        [Parameter(Mandatory = $true)][string]$WindowsDefaultPath,
-        [Parameter(Mandatory = $true)][string]$TempFallbackPath
-    )
-    # 1) User-provided
-    if ($UserPath) {
-        $parent = Split-Path -Path $UserPath -Parent
-        if (New-Directory -DirectoryPath $parent) { return $UserPath }
-    }
-    # 2) Script-root relative
-    $scriptCandidate = Join-Path -Path $script:ScriptRoot -ChildPath $ScriptRelativePath
-    $parent = Split-Path -Path $scriptCandidate -Parent
-    if (New-Directory -DirectoryPath $parent) { return $scriptCandidate }
-    # 3) Windows default (LOCALAPPDATA)
-    $winCandidate = $WindowsDefaultPath
-    $parent = Split-Path -Path $winCandidate -Parent
-    if (New-Directory -DirectoryPath $parent) { return $winCandidate }
-    # 4) TEMP fallback
-    $tempCandidate = $TempFallbackPath
-    $parent = Split-Path -Path $tempCandidate -Parent
-    if (New-Directory -DirectoryPath $parent) { return $tempCandidate }
-    # If all fail, return TEMP even if directory creation failed (subsequent operations will error & be logged)
-    return $TempFallbackPath
-}
-
-# Normalize a path that may actually be a directory; if it's a directory (or ends with a slash),
-# append the provided default filename. No-op if it's already a file path.
-function Resolve-FilePathIfDirectory {
-    param(
-        [Parameter(Mandatory = $true)][ref]$Path,
-        [Parameter(Mandatory = $true)][string]$DefaultFileName
-    )
-    $p = $Path.Value
-    if ([string]::IsNullOrWhiteSpace($p)) { return }
-    try {
-        if (Test-Path -LiteralPath $p -PathType Container) {
-            $Path.Value = (Join-Path -Path $p -ChildPath $DefaultFileName)
-            return
-        }
-    }
-    catch {
-        Write-LogDebug "Failed to test path ${p}: $_"
-    }
-    # If it doesn't exist but clearly looks like a directory (trailing slash), treat as directory
-    if ($p -match '[\\/]\s*$') {
-        $Path.Value = (Join-Path -Path $p -ChildPath $DefaultFileName)
-        return
-    }
-}
-
-# Ensure the parent directory exists; optionally "touch" the file so that subsequent Add-Content works.
-function Initialize-FilePath {
-    param(
-        [Parameter(Mandatory = $true)][string]$FilePath,
-        [switch]$CreateFile
-    )
-    # Use -Path with -Parent to avoid parameter-set ambiguity on older PowerShell versions
-    $dir = Split-Path -Path $FilePath -Parent
-    if ($dir) { [void][System.IO.Directory]::CreateDirectory($dir) }
-    if ($CreateFile -and -not (Test-Path -LiteralPath $FilePath -PathType Leaf)) { New-Item -ItemType File -Path $FilePath -Force | Out-Null }
-}
 
 # Function to log messages
 function LogMessage {
@@ -836,29 +755,6 @@ function ResolveFileNameConflict {
     } while (Test-Path -Path $newFilePath)
 
     return $newFileName
-}
-
-function Resolve-SubfolderPath {
-    param(
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][string]$TargetRoot
-    )
-    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
-    # Reject bare drive and drive-relative forms
-    if ($Path -match '^[A-Za-z]$' -or $Path -match '^[A-Za-z]:$' -or $Path -match '^[A-Za-z]:[^\\/].*') { return $null }
-    if ([System.IO.Path]::IsPathRooted($Path)) {
-        try {
-            # Add this before GetFullPath:
-            LogMessage -Message "DEBUG: Attempting GetFullPath for '$Path'" -IsDebug
-            return [IO.Path]::GetFullPath($Path)
-        }
-        catch {
-            # Add this in catch:
-            LogMessage -Message "DEBUG: GetFullPath threw for '$Path': $($_.Exception.Message)" -IsWarning
-            return $null
-        }
-    }
-    return (Join-Path -Path $TargetRoot -ChildPath $Path)
 }
 
 function CreateRandomSubfolders {

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -33,6 +33,8 @@ Scripts for file operations, distribution, copying, and archiving.
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.6.14**
+  - Created the new internal `FileManagement/FileDistributor` module scaffold and moved six private path helper functions (`New-Ref`, `New-Directory`, `Resolve-PathWithFallback`, `Resolve-FilePathIfDirectory`, `Initialize-FilePath`, `Resolve-SubfolderPath`) out of `FileDistributor.ps1` into `modules/FileManagement/FileDistributor/Private/PathHelpers.ps1`.
 - **FileDistributor.ps1 v4.6.13**
   - Restored safe fallback behavior for subfolder scan failures by allowing `Get-SubfolderFileCounts` to continue with caller-provided candidate folders (when available), preventing distribution/redistribution phases from being skipped on transient enumeration errors.
 - **FileDistributor.ps1 v4.6.12**

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,0 +1,20 @@
+@{
+    RootModule = 'FileDistributor.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
+    Author = 'Manoj Bhaskaran'
+    CompanyName = 'Unknown'
+    Copyright = '(c) 2026. All rights reserved.'
+    Description = 'Private support module for FileDistributor.ps1 — path helpers, state management, and distribution algorithms.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @()
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+    PrivateData = @{
+        PSData = @{
+            Tags = @('FileManagement', 'FileDistributor', 'Private')
+            ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
+        }
+    }
+}

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
@@ -1,0 +1,25 @@
+# FileDistributor.psm1 - File Distributor Support Module
+
+$ModuleRoot = $PSScriptRoot
+
+$privateFunctions = @(Get-ChildItem -Path "$ModuleRoot\Private\*.ps1" -ErrorAction SilentlyContinue)
+foreach ($import in $privateFunctions) {
+    try {
+        . $import.FullName
+    }
+    catch {
+        Write-Error "Failed to import private function $($import.FullName): $_"
+    }
+}
+
+$publicFunctions = @(Get-ChildItem -Path "$ModuleRoot\Public\*.ps1" -ErrorAction SilentlyContinue)
+foreach ($import in $publicFunctions) {
+    try {
+        . $import.FullName
+    }
+    catch {
+        Write-Error "Failed to import public function $($import.FullName): $_"
+    }
+}
+
+Export-ModuleMember -Function $publicFunctions.BaseName

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/PathHelpers.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/PathHelpers.ps1
@@ -1,0 +1,97 @@
+function New-Ref {
+    param($Initial = $null)
+    $r = [ref]$null
+    $r.Value = $Initial
+    return $r
+}
+
+function New-Directory {
+    param([Parameter(Mandatory = $true)][string]$DirectoryPath)
+    if (-not (Test-Path -LiteralPath $DirectoryPath)) {
+        try { New-Item -ItemType Directory -Path $DirectoryPath -Force | Out-Null }
+        catch { Write-LogDebug "Failed to create directory ${DirectoryPath}: $_" }
+    }
+    return (Test-Path -LiteralPath $DirectoryPath)
+}
+
+function Resolve-PathWithFallback {
+    param(
+        [string]$UserPath,
+        [Parameter(Mandatory = $true)][string]$ScriptRelativePath,
+        [Parameter(Mandatory = $true)][string]$WindowsDefaultPath,
+        [Parameter(Mandatory = $true)][string]$TempFallbackPath
+    )
+
+    if ($UserPath) {
+        $parent = Split-Path -Path $UserPath -Parent
+        if (New-Directory -DirectoryPath $parent) { return $UserPath }
+    }
+
+    $scriptRoot = if ($script:ScriptRoot) { $script:ScriptRoot } elseif ($PSScriptRoot) { Split-Path -Path $PSScriptRoot -Parent } else { (Get-Location).Path }
+
+    $scriptCandidate = Join-Path -Path $scriptRoot -ChildPath $ScriptRelativePath
+    $parent = Split-Path -Path $scriptCandidate -Parent
+    if (New-Directory -DirectoryPath $parent) { return $scriptCandidate }
+
+    $winCandidate = $WindowsDefaultPath
+    $parent = Split-Path -Path $winCandidate -Parent
+    if (New-Directory -DirectoryPath $parent) { return $winCandidate }
+
+    $tempCandidate = $TempFallbackPath
+    $parent = Split-Path -Path $tempCandidate -Parent
+    if (New-Directory -DirectoryPath $parent) { return $tempCandidate }
+
+    return $TempFallbackPath
+}
+
+function Resolve-FilePathIfDirectory {
+    param(
+        [Parameter(Mandatory = $true)][ref]$Path,
+        [Parameter(Mandatory = $true)][string]$DefaultFileName
+    )
+    $p = $Path.Value
+    if ([string]::IsNullOrWhiteSpace($p)) { return }
+    try {
+        if (Test-Path -LiteralPath $p -PathType Container) {
+            $Path.Value = (Join-Path -Path $p -ChildPath $DefaultFileName)
+            return
+        }
+    }
+    catch {
+        Write-LogDebug "Failed to test path ${p}: $_"
+    }
+    if ($p -match '[\\/]\s*$') {
+        $Path.Value = (Join-Path -Path $p -ChildPath $DefaultFileName)
+        return
+    }
+}
+
+function Initialize-FilePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [switch]$CreateFile
+    )
+    $dir = Split-Path -Path $FilePath -Parent
+    if ($dir) { [void][System.IO.Directory]::CreateDirectory($dir) }
+    if ($CreateFile -and -not (Test-Path -LiteralPath $FilePath -PathType Leaf)) { New-Item -ItemType File -Path $FilePath -Force | Out-Null }
+}
+
+function Resolve-SubfolderPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$TargetRoot
+    )
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+    if ($Path -match '^[A-Za-z]$' -or $Path -match '^[A-Za-z]:$' -or $Path -match '^[A-Za-z]:[^\\/].*') { return $null }
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        try {
+            LogMessage -Message "DEBUG: Attempting GetFullPath for '$Path'" -IsDebug
+            return [IO.Path]::GetFullPath($Path)
+        }
+        catch {
+            LogMessage -Message "DEBUG: GetFullPath threw for '$Path': $($_.Exception.Message)" -IsWarning
+            return $null
+        }
+    }
+    return (Join-Path -Path $TargetRoot -ChildPath $Path)
+}


### PR DESCRIPTION
### Motivation
- Prepare for Proposal 6 by introducing a dedicated FileManagement/FileDistributor module and moving the lowest-risk, dependency-free path helpers out of the monolithic script to validate module wiring before refactoring complex state/algorithm code.

### Description
- Added a new module scaffold at `src/powershell/modules/FileManagement/FileDistributor/` containing `FileDistributor.psd1` (ModuleVersion `1.0.0`) and `FileDistributor.psm1` that dot-sources `Private/` and `Public/` per existing module patterns.
- Created `Private/PathHelpers.ps1` and moved six path/filesystem helper functions into it: `New-Ref`, `New-Directory`, `Resolve-PathWithFallback`, `Resolve-FilePathIfDirectory`, `Initialize-FilePath`, and `Resolve-SubfolderPath`.
- Updated `src/powershell/file-management/FileDistributor.ps1` to import the new module and dot-source the `PathHelpers.ps1` file, and removed the now-moved function definitions from the script.
- Bumped the FileDistributor script version to `4.6.14` and added corresponding entries to `src/powershell/file-management/CHANGELOG.md` and a recent-update note in `src/powershell/file-management/README.md`.

### Testing
- Static verification: ran repository inspection commands to confirm the new module files exist, `PathHelpers.ps1` contains the six moved functions, and `FileDistributor.ps1` now imports the module and sources the helpers, which succeeded.
- Runtime smoke test: attempted `pwsh -NoProfile -Command "./src/powershell/file-management/FileDistributor.ps1 -Help"`, but it failed in this environment because `pwsh` is not installed (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98c3f3bbc83258ce464b146f37450)