### PR TITLE
Refactor: Extract static constants to dedicated gdrive_constants module

### DIFF
--- a/src/python/cloud/CHANGELOG.md
+++ b/src/python/cloud/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.9.0] - 2026-03-29
+
+### Changed
+- **Refactor:** Extracted all static configuration constants and the `EXTENSION_MIME_TYPES` lookup table from `gdrive_recover.py` into a new dedicated module `gdrive_constants.py`. `gdrive_recover.py` now imports these from `gdrive_constants`. No logic changes; existing behaviour is unchanged.
+
 ## [1.8.3] - 2026-03-26
 
 ### Changed

--- a/src/python/cloud/README.md
+++ b/src/python/cloud/README.md
@@ -5,6 +5,7 @@ Python scripts for cloud service integration, primarily Google Drive operations.
 ## Scripts
 
 - **gdrive_recover.py** - Google Drive file recovery and restoration utilities
+- **gdrive_constants.py** - Static configuration constants shared by gdrive_recover.py and future sibling modules
 - **google_drive_root_files_delete.py** - Cleans up files in Google Drive root directory
 - **drive_space_monitor.py** - Monitors Google Drive storage usage and sends alerts
 - **cloudconvert_utils.py** - CloudConvert API utilities for file conversion

--- a/src/python/cloud/gdrive_constants.py
+++ b/src/python/cloud/gdrive_constants.py
@@ -1,0 +1,86 @@
+"""
+Static configuration constants for the Google Drive recovery tool.
+
+This module is a dependency-free constants store shared by gdrive_recover.py
+and future sibling modules (validators, reporters, etc.).  It has no runtime
+logic: every name is either a literal or a simple os.getenv() call evaluated
+at import time.
+"""
+
+import os
+
+# ---------------------------------------------------------------------------
+# API / OAuth
+# ---------------------------------------------------------------------------
+SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+# ---------------------------------------------------------------------------
+# File-operation defaults
+# ---------------------------------------------------------------------------
+DEFAULT_STATE_FILE = "gdrive_recovery_state.json"
+DEFAULT_LOG_FILE = "gdrive_recovery.log"
+DEFAULT_PROCESS_BATCH = 500
+MAX_RETRIES = 3
+RETRY_DELAY = 2  # seconds
+PAGE_SIZE = 1000
+DEFAULT_WORKERS = 5
+INFERRED_MODIFY_ERROR = "Cannot modify file (inferred from untrash check)"
+
+# ---------------------------------------------------------------------------
+# Rate-limiting / HTTP transport
+# ---------------------------------------------------------------------------
+DEFAULT_MAX_RPS = 5.0  # conservative default; set 0 to disable
+DEFAULT_BURST = 0  # token bucket capacity; 0 = disabled (legacy pacing)
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MiB
+DEFAULT_HTTP_TRANSPORT = "auto"  # auto|httplib2|requests
+DEFAULT_HTTP_POOL_MAXSIZE = 32
+
+# ---------------------------------------------------------------------------
+# Credential / token path resolution (env-overridable)
+#  - GDRIVE_CREDENTIALS_PATH: shared Google client secret JSON for auth modules
+#  - GDRIVE_TOKEN_PATH:        shared OAuth token cache path
+#  - GDRT_CREDENTIALS_FILE:   override for the recovery tool only
+#  - GDRT_TOKEN_FILE:         override token cache for the recovery tool only
+# ---------------------------------------------------------------------------
+DEFAULT_CREDENTIALS_FILE = os.getenv("GDRIVE_CREDENTIALS_PATH", "credentials.json")
+DEFAULT_TOKEN_FILE = os.getenv("GDRIVE_TOKEN_PATH", "token.json")
+CREDENTIALS_FILE = os.getenv("GDRT_CREDENTIALS_FILE", DEFAULT_CREDENTIALS_FILE)
+TOKEN_FILE = os.getenv("GDRT_TOKEN_FILE", DEFAULT_TOKEN_FILE)
+
+# ---------------------------------------------------------------------------
+# Module-level guard flags
+# ---------------------------------------------------------------------------
+# One-time console note guard for requests→httplib2 fallback
+_PRINTED_REQUESTS_FALLBACK = False
+
+# ---------------------------------------------------------------------------
+# Extension → MIME-type mapping for robust server-side filtering
+# ---------------------------------------------------------------------------
+EXTENSION_MIME_TYPES = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "bmp": "image/bmp",
+    "tiff": "image/tiff",
+    "tif": "image/tiff",
+    "webp": "image/webp",
+    "svg": "image/svg+xml",
+    "pdf": "application/pdf",
+    "doc": "application/msword",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "xls": "application/vnd.ms-excel",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "ppt": "application/vnd.ms-powerpoint",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "txt": "text/plain",
+    "csv": "text/csv",
+    "mp4": "video/mp4",
+    "avi": "video/x-msvideo",
+    "mov": "video/quicktime",
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "zip": "application/zip",
+    "rar": "application/vnd.rar",
+    "7z": "application/x-7z-compressed",
+}

--- a/src/python/cloud/gdrive_recover.py
+++ b/src/python/cloud/gdrive_recover.py
@@ -16,7 +16,7 @@ Requirements:
 See CHANGELOG.md in this directory for version history.
 """
 
-__version__ = "1.8.3"
+__version__ = "1.9.0"
 
 import os
 import io
@@ -45,6 +45,30 @@ except ImportError:
 
 # v1.5.7: pure validators (extensions & policy)
 from validators import validate_extensions, normalize_policy_token
+
+# v1.9.0: static configuration constants extracted to dedicated module
+from gdrive_constants import (
+    EXTENSION_MIME_TYPES,
+    SCOPES,
+    DEFAULT_STATE_FILE,
+    DEFAULT_LOG_FILE,
+    DEFAULT_PROCESS_BATCH,
+    MAX_RETRIES,
+    RETRY_DELAY,
+    PAGE_SIZE,
+    DEFAULT_WORKERS,
+    INFERRED_MODIFY_ERROR,
+    DEFAULT_MAX_RPS,
+    DEFAULT_BURST,
+    DOWNLOAD_CHUNK_BYTES,
+    DEFAULT_HTTP_TRANSPORT,
+    DEFAULT_HTTP_POOL_MAXSIZE,
+    DEFAULT_CREDENTIALS_FILE,
+    DEFAULT_TOKEN_FILE,
+    CREDENTIALS_FILE,
+    TOKEN_FILE,
+    _PRINTED_REQUESTS_FALLBACK,
+)
 
 
 # -------------------- Minimal structural types --------------------
@@ -80,35 +104,6 @@ except ImportError:
     )
     sys.exit(1)
 
-# Environment toggle for strict policy (v1.5.8)
-# Configuration constants
-SCOPES = ["https://www.googleapis.com/auth/drive"]
-DEFAULT_STATE_FILE = "gdrive_recovery_state.json"
-DEFAULT_LOG_FILE = "gdrive_recovery.log"
-DEFAULT_PROCESS_BATCH = 500
-MAX_RETRIES = 3
-RETRY_DELAY = 2  # seconds
-PAGE_SIZE = 1000
-DEFAULT_WORKERS = 5
-INFERRED_MODIFY_ERROR = "Cannot modify file (inferred from untrash check)"
-DEFAULT_MAX_RPS = 5.0  # conservative default; set 0 to disable
-DEFAULT_BURST = 0  # token bucket capacity; 0 = disabled (legacy pacing)
-DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MiB
-DEFAULT_HTTP_TRANSPORT = "auto"  # auto|httplib2|requests
-DEFAULT_HTTP_POOL_MAXSIZE = 32
-# Credential locations (env-overridable)
-#  - GDRIVE_CREDENTIALS_PATH: shared Google client secret JSON for auth modules
-#  - GDRIVE_TOKEN_PATH: shared OAuth token cache path
-#  - GDRT_CREDENTIALS_FILE: override for the recovery tool only
-#  - GDRT_TOKEN_FILE: override token cache for the recovery tool only
-DEFAULT_CREDENTIALS_FILE = os.getenv("GDRIVE_CREDENTIALS_PATH", "credentials.json")
-DEFAULT_TOKEN_FILE = os.getenv("GDRIVE_TOKEN_PATH", "token.json")
-CREDENTIALS_FILE = os.getenv("GDRT_CREDENTIALS_FILE", DEFAULT_CREDENTIALS_FILE)
-TOKEN_FILE = os.getenv("GDRT_TOKEN_FILE", DEFAULT_TOKEN_FILE)
-
-# one-time console note guard for requests→httplib2 fallback
-_PRINTED_REQUESTS_FALLBACK = False
-
 
 def get_recoverable_files(service):
     """Return trashed Google Drive files that can be restored."""
@@ -136,37 +131,6 @@ def get_recoverable_files(service):
             break
 
     return trashed_files
-
-
-# Extension to MIME type mapping for robust server-side filtering
-EXTENSION_MIME_TYPES = {
-    "jpg": "image/jpeg",
-    "jpeg": "image/jpeg",
-    "png": "image/png",
-    "gif": "image/gif",
-    "bmp": "image/bmp",
-    "tiff": "image/tiff",
-    "tif": "image/tiff",
-    "webp": "image/webp",
-    "svg": "image/svg+xml",
-    "pdf": "application/pdf",
-    "doc": "application/msword",
-    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "xls": "application/vnd.ms-excel",
-    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "ppt": "application/vnd.ms-powerpoint",
-    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "txt": "text/plain",
-    "csv": "text/csv",
-    "mp4": "video/mp4",
-    "avi": "video/x-msvideo",
-    "mov": "video/quicktime",
-    "mp3": "audio/mpeg",
-    "wav": "audio/wav",
-    "zip": "application/zip",
-    "rar": "application/vnd.rar",
-    "7z": "application/x-7z-compressed",
-}
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Extracted all static configuration constants and the `EXTENSION_MIME_TYPES` lookup table from `gdrive_recover.py` into a new dedicated module `gdrive_constants.py`. This improves code organization and enables sharing of constants with future sibling modules (validators, reporters, etc.) without creating circular dependencies.

## Key Changes
- **New module:** `gdrive_constants.py` - A dependency-free constants store containing:
  - API/OAuth configuration (SCOPES)
  - File operation defaults (batch size, retry settings, worker counts)
  - Rate-limiting and HTTP transport settings
  - Credential/token path resolution with environment variable overrides
  - Extension-to-MIME-type mapping for robust server-side filtering
  - Module-level guard flags

- **Updated:** `gdrive_recover.py`
  - Removed all constant definitions (moved to `gdrive_constants.py`)
  - Added imports from `gdrive_constants` module
  - Version bumped to 1.9.0
  - No logic changes; existing behavior is unchanged

- **Updated:** `README.md` and `CHANGELOG.md` to document the new module

## Implementation Details
- `gdrive_constants.py` is intentionally dependency-free (only uses `os.getenv()`) to serve as a shared configuration layer
- Environment variable resolution happens at import time for credential/token paths
- All 25+ constants are now centralized and reusable by other modules in the cloud utilities package
- Maintains backward compatibility; no functional changes to `gdrive_recover.py`

https://claude.ai/code/session_0174RQ4MK59hbY94G7JLJ3mh