### PR TITLE
Fix race condition in Invoke-TargetRedistribution Get-Random

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.7.5 — 2026-04-02
+
+### Fixed
+
+- Fixed a race condition in `Invoke-TargetRedistribution` where `Get-Random -Count $excess` could throw *"Cannot process argument because the value of argument 'Count' is not valid"* if another process deleted files from an overloaded folder between the cached file-count snapshot and the actual `Get-ChildItem` enumeration. The fix collects all current files into a variable first, then clamps the excess count to the actual file count using `[Math]::Min()`, and skips `Get-Random` entirely when all files need to be redistributed. Bumped `FileDistributor` module version to `1.1.5`.
+
 ## 4.7.4 — 2026-04-02
 
 ### Fixed

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'FileDistributor.psm1'
-    ModuleVersion = '1.1.4'
+    ModuleVersion = '1.1.5'
     GUID = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author = 'Manoj Bhaskaran'
     CompanyName = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
@@ -84,7 +84,13 @@ function Invoke-TargetRedistribution {
         $fileCount = $folderFilesMap[$folder]
         if ($fileCount -gt $FilesPerFolderLimit) {
             $excess = $fileCount - $FilesPerFolderLimit
-            $overloadedFiles = Get-ChildItem -Path $folder -File | Get-Random -Count $excess
+            $allFolderFiles = @(Get-ChildItem -Path $folder -File)
+            $safeExcess = [Math]::Min($excess, $allFolderFiles.Count)
+            $overloadedFiles = if ($safeExcess -lt $allFolderFiles.Count) {
+                $allFolderFiles | Get-Random -Count $safeExcess
+            } else {
+                $allFolderFiles
+            }
             $filesToRedistributeMap[$folder] = $overloadedFiles
             Write-LogInfo "Folder $folder is overloaded by $excess file(s), queuing for redistribution."
             $redistributionTotal += $overloadedFiles.Count


### PR DESCRIPTION
## Summary
Fixed a race condition in `Invoke-TargetRedistribution` where `Get-Random -Count $excess` could fail if files were deleted between the cached file-count check and the actual file enumeration.

## Changes
- **Invoke-TargetRedistribution.ps1**: Refactored file selection logic to be resilient against concurrent file deletions:
  - Collect all current files into a variable first using `@(Get-ChildItem -Path $folder -File)`
  - Clamp the excess count to the actual file count using `[Math]::Min($excess, $allFolderFiles.Count)`
  - Skip `Get-Random` entirely when all files need to be redistributed (optimization)
  - Use conditional logic to only call `Get-Random` when the excess count is less than available files

## Implementation Details
The original code relied on a cached file count (`$folderFilesMap[$folder]`) that could become stale if another process deleted files concurrently. This caused `Get-Random -Count $excess` to fail when `$excess` exceeded the actual number of files available. The fix ensures the excess count never exceeds the actual file count and avoids unnecessary `Get-Random` calls when all files must be redistributed.

Module version bumped to `1.1.5`.

https://claude.ai/code/session_017S7aJgqXkgMPvyud2MkYia