### PR TITLE
Fix unreachable FileSystemInfo branch in Invoke-FileDistribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ pip install -e .
 - **[PurgeLogs](src/powershell/modules/Core/Logging/PurgeLogs/)** (v2.0.0) – Log file purging and retention management
 - **[FileSystem](src/powershell/modules/Core/FileSystem/)** (v1.0.0) – Common file system operations (directory creation, file accessibility checks, path validation, file locking detection)
 - **[FileQueue](src/powershell/modules/FileManagement/FileQueue/)** (v1.0.0) – File queue management for distribution operations with state persistence and session tracking
-- **[FileDistributor](src/powershell/modules/FileManagement/FileDistributor/)** (v1.1.10) – Private support helpers for FileDistributor orchestration (path handling, state persistence, and state-file locking)
+- **[FileDistributor](src/powershell/modules/FileManagement/FileDistributor/)** (v1.1.11) – Private support helpers for FileDistributor orchestration (path handling, state persistence, and state-file locking)
 
 **Python Modules:**
 

--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.7.11 — 2026-04-05
+
+### Fixed
+
+- Fixed an input-type mismatch in `Invoke-FileDistribution`: the `-Files` parameter was typed as `[string[]]` while the function body contains an explicit `[System.IO.FileSystemInfo]` branch for `$file.FullName` and `$file.Name`. PowerShell converted incoming `FileSystemInfo` objects to strings at parameter binding time, making the `FileSystemInfo` branch effectively unreachable dead code and potentially losing object metadata. Updated the parameter type to `[object[]]` so both string paths and `FileSystemInfo` inputs are handled as intended. Added a unit test in `tests/powershell/unit/FileDistributor.Tests.ps1` to assert `Invoke-FileDistribution` exposes `System.Object[]` for `-Files`. Bumped `FileDistributor` module version to `1.1.11`.
+
 ## 4.7.10 — 2026-04-05
 
 ### Fixed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.7.10
+ 4.7.11
 
  CHANGELOG:
    See CHANGELOG.md in this directory for full release history.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -33,6 +33,9 @@ Scripts for file operations, distribution, copying, and archiving.
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.7.11**
+  - Fixed `Invoke-FileDistribution` parameter typing for `-Files`: changed `[string[]]` to `[object[]]` so `System.IO.FileSystemInfo` inputs are not coerced to strings during parameter binding and the in-function `FileSystemInfo` handling branch remains reachable.
+  - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.11` and added regression coverage for the `-Files` parameter type.
 - **FileDistributor.ps1 v4.6.14**
   - Created the new internal `FileManagement/FileDistributor` module scaffold and moved six private path helper functions (`New-Ref`, `New-Directory`, `Resolve-PathWithFallback`, `Resolve-FilePathIfDirectory`, `Initialize-FilePath`, `Resolve-SubfolderPath`) out of `FileDistributor.ps1` into `modules/FileManagement/FileDistributor/Private/PathHelpers.ps1`.
 - **FileDistributor.ps1 v4.6.13**

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.1.10'
+    ModuleVersion     = '1.1.11'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
@@ -2,7 +2,7 @@
 
 function Invoke-FileDistribution {
     param (
-        [string[]]$Files,
+        [object[]]$Files,
         [object[]]$Subfolders,
         [Parameter(Mandatory = $true)][string]$TargetRoot,
         [int]$Limit,

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -254,6 +254,14 @@ Describe "FileDistributor Math Operations" {
 }
 
 Describe 'FileDistributor Module Public API' {
+    It 'Invoke-FileDistribution accepts FileSystemInfo inputs for -Files' {
+        $modPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psd1'
+        Import-Module -Name $modPath -Force | Out-Null
+        $filesParam = (Get-Command Invoke-FileDistribution -ErrorAction Stop).Parameters['Files']
+
+        $filesParam.ParameterType.FullName | Should -Be 'System.Object[]'
+    }
+
     It 'Should expose post-processing functions through module exports' {
         $modPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psd1'
         Import-Module -Name $modPath -Force | Out-Null


### PR DESCRIPTION
### Motivation
- `Invoke-FileDistribution` declared `-Files` as `[string[]]` which coerced incoming `System.IO.FileSystemInfo` objects to strings at parameter binding time, rendering the in-function `[IO.FileSystemInfo]` branch unreachable and losing object metadata. 
- The change restores correct input handling so callers can pass either string paths or `FileSystemInfo` objects without accidental coercion. 
- Bumped versions and documentation so the fix is discoverable and tracked in release notes.

### Description
- Changed the `-Files` parameter type in `Invoke-FileDistribution` from `[string[]]` to `[object[]]` to preserve `FileSystemInfo` inputs at bind time. 
- Added a regression unit test in `tests/powershell/unit/FileDistributor.Tests.ps1` that asserts the `Files` parameter type is `System.Object[]`. 
- Bumped the FileDistributor module version to `1.1.11` and the script version to `4.7.11`. 
- Updated `CHANGELOG.md`, `README.md`, and the file-management README to document the fix and version bumps.

### Testing
- Added a Pester unit test covering the `-Files` parameter type, but no tests were executed here because `pwsh`/PowerShell Core is not available in this environment. 
- Attempted to run `Invoke-Pester` with `pwsh -NoProfile -Command "Invoke-Pester -Path 'tests/powershell/unit/FileDistributor.Tests.ps1' -Output Detailed"`, which failed with `pwsh: command not found`. 
- Consumers or CI should run `Invoke-Pester` in a PowerShell environment (Windows PowerShell or PowerShell Core with Pester installed) to validate the new test and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e2b95f0c8325a1b26e6872f62dce)