### PR TITLE
Remove vestigial TotalFiles from Invoke-TargetRedistribution and drop dead subfolder guard

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 4.7.13 — 2026-04-05
+
+### Fixed
+
+- Removed a vestigial `[int]$TotalFiles` parameter from `Invoke-TargetRedistribution` in `src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1`. The parameter was not used anywhere in the function body and had become stale after redistribution progress was refactored to use per-phase totals. Updated the `FileDistributor.ps1` call site in `Invoke-DistributionPhase` to stop passing `-TotalFiles 0`.
+- Removed a dead inner null-subfolder guard inside the root-redistribution block of `Invoke-TargetRedistribution` (`if ($normalizedSubfolders.Count -eq 0) { ... }`). This branch was unreachable because the earlier normalization guard already guarantees at least one destination subfolder by creating an emergency subfolder when needed.
+- Bumped `FileDistributor` module version to `1.1.13`.
+
 ## 4.7.12 — 2026-04-05
 
 ### Fixed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.7.12
+ 4.7.13
 
  CHANGELOG:
    See CHANGELOG.md in this directory for full release history.
@@ -410,7 +410,7 @@ if ($Help) {
 }
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.7.10"
+$script:Version = "4.7.13"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -851,7 +851,7 @@ function Invoke-DistributionPhase {
     }
 
     if ($RunState.LastCheckpoint -lt 5) {
-        Invoke-TargetRedistribution -TargetFolder $TargetFolder -Subfolders $RunState.subfolders -FilesPerFolderLimit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -TotalFiles 0 -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount ([ref]$script:Warnings) -ErrorCount ([ref]$script:Errors)
+        Invoke-TargetRedistribution -TargetFolder $TargetFolder -Subfolders $RunState.subfolders -FilesPerFolderLimit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount ([ref]$script:Warnings) -ErrorCount ([ref]$script:Errors)
         $cp5 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -IncludeFilesToDelete
         Save-DistributionState -Checkpoint 5 -AdditionalVariables $cp5 -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $script:Warnings -ErrorsSoFar $script:Errors -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
     }

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -33,6 +33,10 @@ Scripts for file operations, distribution, copying, and archiving.
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.7.13**
+  - Removed a vestigial, unused `-TotalFiles` parameter from module function `Invoke-TargetRedistribution` and updated the script call site accordingly.
+  - Removed a dead inner `if ($normalizedSubfolders.Count -eq 0)` guard in `Invoke-TargetRedistribution`; this branch was unreachable because an earlier guard already creates an emergency subfolder whenever no valid subfolders exist.
+  - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.13`.
 - **FileDistributor.ps1 v4.7.12**
   - Removed direct `Write-Host` completion output from module function `Invoke-FileDistribution`; completion is now logged via `Write-LogInfo` only for consistent framework-managed logging behavior.
   - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.12`.

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.1.12'
+    ModuleVersion     = '1.1.13'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
@@ -10,7 +10,6 @@ function Invoke-TargetRedistribution {
         [string]$DeleteMode,
         $FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [ref]$GlobalFileCounter,
-        [int]$TotalFiles,
         [int]$RetryDelay = 10,
         [int]$RetryCount = 3,
         [int]$MaxBackoff = 60,
@@ -43,16 +42,6 @@ function Invoke-TargetRedistribution {
     $redistributionProcessed = 0
 
     if ($rootFiles.Count -gt 0) {
-        # Use the already normalized subfolders directly
-        if ($normalizedSubfolders.Count -eq 0) {
-            # Create a new subfolder if none exist
-            $randomName = Get-RandomFileName
-            $newFolder = Join-Path -Path $TargetFolder -ChildPath $randomName
-            New-Item -Path $newFolder -ItemType Directory -Force | Out-Null
-            Write-LogInfo "Created new target subfolder: $newFolder for redistribution from root folder."
-            $normalizedSubfolders = @($newFolder)
-        }
-
         # Reset phase counter and compute correct denominator
         $GlobalFileCounter.Value = 0
         $redistributionTotal += $rootFiles.Count


### PR DESCRIPTION
### Motivation

- Fix the inconsistency reported in the redistribution flow where a leftover `TotalFiles` parameter remained in `Invoke-TargetRedistribution` and an inner null-subfolder guard was dead/unreachable.  
- Keep the public API and internal call sites consistent after refactoring redistribution progress to use per-phase totals, and update versions/docs to reflect the fix.

### Description

- Removed the unused `[int]$TotalFiles` parameter from the signature of `Invoke-TargetRedistribution` in `src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1`.  
- Deleted the unreachable inner `if ($normalizedSubfolders.Count -eq 0) { ... }` guard inside the root-redistribution block because an earlier normalization/emergency-folder guard already guarantees at least one destination.  
- Updated the script call site in `Invoke-DistributionPhase` (`src/powershell/file-management/FileDistributor.ps1`) to stop passing `-TotalFiles 0` to `Invoke-TargetRedistribution`.  
- Bumped FileDistributor module version to `1.1.13` (`FileDistributor.psd1`) and script metadata version to `4.7.13`, and added corresponding entries to `CHANGELOG.md` and `README.md` documenting the change.

### Testing

- Ran a repository search with `rg` to confirm there are no remaining call sites passing `-TotalFiles` and no leftover `[int]$TotalFiles` parameter references, which returned no matches.  
- Performed light static validation by loading the modified files into memory where possible, but a full PowerShell syntax/load check using `pwsh` could not be executed because `pwsh` is not available in this environment.  
- No automated unit tests were run in this environment beyond the static search; the changes are limited to signature/guard cleanup and documentation/version bumps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1f73eb3908325b445d83859c430f8)