### PR TITLE
Extract Write-VerifySummary helper and fix logging bug

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG
 
-## Copy-AndroidFiles 2.1.0 — 2026-04-07
+---
 
-### Changed
+## Copy-AndroidFiles
+
+---
+
+### 2.1.0 — 2026-04-07
+
+#### Changed
 
 - **Extracted `Write-VerifySummary` helper function** from `Copy-AndroidFiles.ps1`. The
   post-transfer verification output block was copy-pasted across all four transfer modes
@@ -12,12 +18,18 @@
   post-transfer local counts/sizes, retrieves the remote file count, renders the comparison
   table, and emits any warning via `Write-LogWarning`.
 
-### Fixed
+#### Fixed
 
 - **`Write-Warning` logging bug in TAR-to-file mode.** The verify path for tar-to-file
   called `Write-Warning` (built-in) instead of `Write-LogWarning` (framework). Warnings
   were displayed on-screen but not written to log files. The extracted `Write-VerifySummary`
   helper always uses `Write-LogWarning`, fixing the bug for all modes.
+
+---
+
+## FileDistributor
+
+---
 
 ## 4.8.0 — 2026-04-05
 

--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## Copy-AndroidFiles 2.1.0 — 2026-04-07
+
+### Changed
+
+- **Extracted `Write-VerifySummary` helper function** from `Copy-AndroidFiles.ps1`. The
+  post-transfer verification output block was copy-pasted across all four transfer modes
+  (resume pull, pull, stream-tar, tar-to-file), totalling ~95 redundant lines. A single
+  parameterised helper now handles all modes: it accepts `LocalRoot`, `FilesBefore`,
+  `BytesBefore`, `RemoteParent`, `RemoteLeaf`, `TotalBytes`, and `WarnMessage`, calculates
+  post-transfer local counts/sizes, retrieves the remote file count, renders the comparison
+  table, and emits any warning via `Write-LogWarning`.
+
+### Fixed
+
+- **`Write-Warning` logging bug in TAR-to-file mode.** The verify path for tar-to-file
+  called `Write-Warning` (built-in) instead of `Write-LogWarning` (framework). Warnings
+  were displayed on-screen but not written to log files. The extracted `Write-VerifySummary`
+  helper always uses `Write-LogWarning`, fixing the bug for all modes.
+
 ## 4.8.0 — 2026-04-05
 
 ### Changed (Option A — module consolidation)

--- a/src/powershell/file-management/Copy-AndroidFiles.ps1
+++ b/src/powershell/file-management/Copy-AndroidFiles.ps1
@@ -108,9 +108,17 @@
 
 .NOTES
     VERSION
-      2.0.0
+      2.1.0
 
     CHANGELOG
+        2.1.0
+        - Extracted Write-VerifySummary helper: eliminated ~95 lines of duplicated post-transfer
+          verify logic that was copy-pasted across all four transfer modes (resume pull, pull,
+          stream-tar, tar-to-file).
+        - Fixed Write-Warning logging bug: the TAR-to-file verify path called Write-Warning
+          instead of Write-LogWarning, causing warnings to appear on-screen only and not be
+          persisted to log files. The extracted helper always uses Write-LogWarning.
+
         2.0.0
         - Refactored to use PowerShellLoggingFramework.psm1 for standardized logging
         - Replaced Write-Host with Write-LogInfo for informational messages
@@ -607,6 +615,72 @@ fi
     }
 }
 
+function Write-VerifySummary {
+    <#
+.SYNOPSIS
+    Prints a post-transfer verification summary table and warns if local count is below remote.
+.DESCRIPTION
+    Calculates post-transfer local file counts and sizes, retrieves remote file counts,
+    displays comparative statistics in table format, and emits a properly-logged warning
+    when the local count falls below the remote count.
+.PARAMETER LocalRoot
+    Local directory to measure after transfer.
+.PARAMETER FilesBefore
+    Local file count captured before transfer.
+.PARAMETER BytesBefore
+    Local byte total captured before transfer.
+.PARAMETER RemoteParent
+    Parent directory on the device (POSIX).
+.PARAMETER RemoteLeaf
+    Leaf (file or directory) name on the device.
+.PARAMETER TotalBytes
+    Pre-transfer remote size in bytes (used to derive SizeMB for Remote row).
+.PARAMETER WarnMessage
+    Warning text emitted via Write-LogWarning if local count < remote count.
+.OUTPUTS
+    None. Writes a formatted table to the host and optionally a warning to the log.
+#>
+    param(
+        [string]$LocalRoot,
+        [int64]$FilesBefore,
+        [int64]$BytesBefore,
+        [string]$RemoteParent,
+        [string]$RemoteLeaf,
+        [int64]$TotalBytes,
+        [string]$WarnMessage
+    )
+
+    $localCount   = Get-LocalFileCount  -Path $LocalRoot
+    $localBytes   = Get-LocalDirSize    -Path $LocalRoot
+    $remoteCount  = Get-RemoteFileCount -RemoteParent $RemoteParent -RemoteLeaf $RemoteLeaf
+    $remoteSizeMB = if ($TotalBytes -gt 0) { [math]::Round($TotalBytes / 1MB) } else { $null }
+
+    $afterFiles = $localCount
+    $deltaFiles = $afterFiles - $FilesBefore
+
+    $beforeMB = [math]::Round($BytesBefore / 1MB)
+    $afterMB  = [math]::Round($localBytes / 1MB)
+    $deltaMB  = $afterMB - $beforeMB
+
+    $rows = @(
+        [pscustomobject]@{
+            Scope  = 'Local'
+            Files  = ("{0} → {1} (+{2})" -f $FilesBefore, $afterFiles, $deltaFiles)
+            SizeMB = ("{0} → {1} (+{2})" -f $beforeMB, $afterMB, $deltaMB)
+        }
+        [pscustomobject]@{
+            Scope  = 'Remote'
+            Files  = $remoteCount
+            SizeMB = $remoteSizeMB
+        }
+    )
+    $rows | Format-Table -AutoSize | Out-String | Write-Host
+
+    if ($remoteCount -gt 0 -and $localCount -lt $remoteCount) {
+        Write-LogWarning $WarnMessage
+    }
+}
+
 Write-LogDebug "Destination: $Dest"
 New-Item -ItemType Directory -Force -Path $Dest | Out-Null
 
@@ -679,37 +753,10 @@ if ($Mode -eq 'pull') {
         Write-LogInfo "Resume pull complete. Files processed: $count, newly copied: $copied."
 
         if ($Verify) {
-            $localRootAfter = $Dest
-            $localCount = Get-LocalFileCount -Path $localRootAfter
-            $localBytes = Get-LocalDirSize  -Path $localRootAfter
-            $remoteCount = Get-RemoteFileCount -RemoteParent $parent -RemoteLeaf $leaf
-            $remoteSizeMB = if ($totalBytes -gt 0) { [math]::Round($totalBytes / 1MB) } else { $null }
-
-            $beforeFiles = $LocalFilesBefore
-            $afterFiles = $localCount
-            $deltaFiles = $afterFiles - $beforeFiles
-
-            $beforeMB = [math]::Round($LocalBytesBefore / 1MB)
-            $afterMB = [math]::Round($localBytes / 1MB)
-            $deltaMB = $afterMB - $beforeMB
-
-            $rows = @(
-                [pscustomobject]@{
-                    Scope  = 'Local'
-                    Files  = ("{0} → {1} (+{2})" -f $beforeFiles, $afterFiles, $deltaFiles)
-                    SizeMB = ("{0} → {1} (+{2})" -f $beforeMB, $afterMB, $deltaMB)
-                }
-                [pscustomobject]@{
-                    Scope  = 'Remote'
-                    Files  = $remoteCount
-                    SizeMB = $remoteSizeMB
-                }
-            )
-            $rows | Format-Table -AutoSize | Out-String | Write-Host
-
-            if ($remoteCount -gt 0 -and $localCount -lt $remoteCount) {
-                Write-LogWarning "Local file count < remote file count. Some files may be missing."
-            }
+            Write-VerifySummary -LocalRoot $Dest `
+                -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
+                -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
+                -WarnMessage "Local file count < remote file count. Some files may be missing."
         }
     }
     else {
@@ -752,37 +799,10 @@ if ($Mode -eq 'pull') {
             # adb pull usually creates a subfolder under Dest named $leaf
             $verifyRoot = Join-Path $Dest $leaf
             $localRootAfter = (Test-Path $verifyRoot) ? $verifyRoot : $Dest
-
-            $localCount = Get-LocalFileCount -Path $localRootAfter
-            $localBytes = Get-LocalDirSize  -Path $localRootAfter
-            $remoteCount = Get-RemoteFileCount -RemoteParent $parent -RemoteLeaf $leaf
-            $remoteSizeMB = if ($totalBytes -gt 0) { [math]::Round($totalBytes / 1MB) } else { $null }
-
-            $beforeFiles = $LocalFilesBefore
-            $afterFiles = $localCount
-            $deltaFiles = $afterFiles - $beforeFiles
-
-            $beforeMB = [math]::Round($LocalBytesBefore / 1MB)
-            $afterMB = [math]::Round($localBytes / 1MB)
-            $deltaMB = $afterMB - $beforeMB
-
-            $rows = @(
-                [pscustomobject]@{
-                    Scope  = 'Local'
-                    Files  = ("{0} → {1} (+{2})" -f $beforeFiles, $afterFiles, $deltaFiles)
-                    SizeMB = ("{0} → {1} (+{2})" -f $beforeMB, $afterMB, $deltaMB)
-                }
-                [pscustomobject]@{
-                    Scope  = 'Remote'
-                    Files  = $remoteCount
-                    SizeMB = $remoteSizeMB
-                }
-            )
-            $rows | Format-Table -AutoSize | Out-String | Write-Host
-
-            if ($remoteCount -gt 0 -and $localCount -lt $remoteCount) {
-                Write-LogWarning "Local file count < remote file count. Some files may be missing."
-            }
+            Write-VerifySummary -LocalRoot $localRootAfter `
+                -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
+                -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
+                -WarnMessage "Local file count < remote file count. Some files may be missing."
         }
     }
 }
@@ -799,37 +819,10 @@ else {
         Write-LogInfo "Streaming tar extraction finished. Verify contents."
 
         if ($Verify) {
-            $localRootAfter = $Dest
-            $localCount = Get-LocalFileCount -Path $localRootAfter
-            $localBytes = Get-LocalDirSize  -Path $localRootAfter
-            $remoteCount = Get-RemoteFileCount -RemoteParent $parent -RemoteLeaf $leaf
-            $remoteSizeMB = if ($totalBytes -gt 0) { [math]::Round($totalBytes / 1MB) } else { $null }
-
-            $beforeFiles = $LocalFilesBefore
-            $afterFiles = $localCount
-            $deltaFiles = $afterFiles - $beforeFiles
-
-            $beforeMB = [math]::Round($LocalBytesBefore / 1MB)
-            $afterMB = [math]::Round($localBytes / 1MB)
-            $deltaMB = $afterMB - $beforeMB
-
-            $rows = @(
-                [pscustomobject]@{
-                    Scope  = 'Local'
-                    Files  = ("{0} → {1} (+{2})" -f $beforeFiles, $afterFiles, $deltaFiles)
-                    SizeMB = ("{0} → {1} (+{2})" -f $beforeMB, $afterMB, $deltaMB)
-                }
-                [pscustomobject]@{
-                    Scope  = 'Remote'
-                    Files  = $remoteCount
-                    SizeMB = $remoteSizeMB
-                }
-            )
-            $rows | Format-Table -AutoSize | Out-String | Write-Host
-
-            if ($remoteCount -gt 0 -and $localCount -lt $remoteCount) {
-                Write-LogWarning "Extracted count < remote count. Some files may be missing."
-            }
+            Write-VerifySummary -LocalRoot $Dest `
+                -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
+                -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
+                -WarnMessage "Extracted count < remote count. Some files may be missing."
         }
     }
     else {
@@ -880,37 +873,10 @@ else {
                 tar -xf $tarFile -C $Dest
 
                 if ($Verify) {
-                    $localRootAfter = $Dest
-                    $localCount = Get-LocalFileCount -Path $localRootAfter
-                    $localBytes = Get-LocalDirSize  -Path $localRootAfter
-                    $remoteCount = Get-RemoteFileCount -RemoteParent $parent -RemoteLeaf $leaf
-                    $remoteSizeMB = if ($totalBytes -gt 0) { [math]::Round($totalBytes / 1MB) } else { $null }
-
-                    $beforeFiles = $LocalFilesBefore
-                    $afterFiles = $localCount
-                    $deltaFiles = $afterFiles - $beforeFiles
-
-                    $beforeMB = [math]::Round($LocalBytesBefore / 1MB)
-                    $afterMB = [math]::Round($localBytes / 1MB)
-                    $deltaMB = $afterMB - $beforeMB
-
-                    $rows = @(
-                        [pscustomobject]@{
-                            Scope  = 'Local'
-                            Files  = ("{0} → {1} (+{2})" -f $beforeFiles, $afterFiles, $deltaFiles)
-                            SizeMB = ("{0} → {1} (+{2})" -f $beforeMB, $afterMB, $deltaMB)
-                        }
-                        [pscustomobject]@{
-                            Scope  = 'Remote'
-                            Files  = $remoteCount
-                            SizeMB = $remoteSizeMB
-                        }
-                    )
-                    $rows | Format-Table -AutoSize | Out-String | Write-Host
-
-                    if ($remoteCount -gt 0 -and $localCount -lt $remoteCount) {
-                        Write-Warning "Extracted count < remote count. Some files may be missing."
-                    }
+                    Write-VerifySummary -LocalRoot $Dest `
+                        -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
+                        -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
+                        -WarnMessage "Extracted count < remote count. Some files may be missing."
                 }
 
                 # Cleanup


### PR DESCRIPTION
## Summary

Refactored post-transfer verification logic in `Copy-AndroidFiles.ps1` by extracting a reusable `Write-VerifySummary` helper function. This eliminates ~95 lines of duplicated code across all four transfer modes and fixes a logging bug in tar-to-file mode.

## Key Changes

- **Extracted `Write-VerifySummary` helper function** that encapsulates post-transfer verification:
  - Calculates local file counts and sizes after transfer
  - Retrieves remote file counts
  - Displays comparative statistics in table format
  - Emits properly-logged warnings when local count falls below remote count
  - Accepts parameterized inputs: `LocalRoot`, `FilesBefore`, `BytesBefore`, `RemoteParent`, `RemoteLeaf`, `TotalBytes`, and `WarnMessage`

- **Replaced duplicated verification blocks** in all four transfer modes:
  - Resume pull mode
  - Standard pull mode
  - Stream-tar mode
  - Tar-to-file mode

- **Fixed logging bug in tar-to-file mode**: The original code called `Write-Warning` (built-in cmdlet) instead of `Write-LogWarning` (PowerShellLoggingFramework), causing warnings to appear on-screen only and not be persisted to log files. The extracted helper consistently uses `Write-LogWarning` across all modes.

## Implementation Details

The new `Write-VerifySummary` function:
- Centralizes all verification output logic in a single, well-documented location
- Maintains consistent warning behavior across all transfer modes
- Reduces code duplication from ~95 lines to a single parameterized function call per mode
- Includes comprehensive documentation with SYNOPSIS, DESCRIPTION, PARAMETER, and OUTPUTS sections

Version bumped to 2.1.0 with changelog entries documenting both the refactoring and bug fix.

https://claude.ai/code/session_018YFu4zeupZrXpJzUceaepH