### PR TITLE
Replace exit calls with throw in Backup-PostgresDatabase error handling

### DIFF
--- a/src/powershell/modules/Database/PostgresBackup/Public/Backup-PostgresDatabase.ps1
+++ b/src/powershell/modules/Database/PostgresBackup/Public/Backup-PostgresDatabase.ps1
@@ -79,7 +79,7 @@ function Backup-PostgresDatabase {
     catch {
         $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
         Add-Content -Path $log_file -Value "[$timestamp] ${dbname}: Backup failed: $_" -Encoding utf8
-        exit 1
+        throw
     }
 
     try {
@@ -94,6 +94,6 @@ function Backup-PostgresDatabase {
     catch {
         $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
         Add-Content -Path $log_file -Value "[$timestamp] ${dbname}: Backup file cleanup failed: $_" -Encoding utf8
-        exit 1
+        throw
     }
 }


### PR DESCRIPTION
## Summary
Updated error handling in the `Backup-PostgresDatabase` function to use PowerShell's `throw` statement instead of `exit 1` for exception propagation.

## Key Changes
- Replaced `exit 1` with `throw` in the backup operation catch block (line 82)
- Replaced `exit 1` with `throw` in the backup file cleanup catch block (line 97)

## Implementation Details
This change improves error handling by allowing exceptions to propagate through the PowerShell call stack rather than terminating the entire process. This enables:
- Proper error handling by calling scripts or functions
- Better integration with PowerShell's error handling pipeline
- Ability to catch and handle specific errors at higher levels
- More graceful failure modes in automated workflows

The logged error messages are preserved, ensuring diagnostic information is still captured before the exception is thrown.

https://claude.ai/code/session_01V8DqHA6vtuunYZVY3SkHiB