### PR TITLE
docs(changelog): normalize file-management changelog hierarchy and formatting

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
----
+## Table of Contents
+- [Copy-AndroidFiles](#copy-androidfiles)
+- [FileDistributor](#filedistributor)
 
 ## Copy-AndroidFiles
 
----
 
 ### 2.3.1 — 2026-04-10
 
@@ -12,7 +13,6 @@
 
 - **Consolidated `Copy-AndroidFiles.ps1` version history into this changelog.** Removed the long inline multi-version `CHANGELOG` block from the script's comment-based help `.NOTES` section and replaced it with a concise version stamp plus a pointer to `CHANGELOG.md`, while preserving the existing `PREREQUISITES` and `TROUBLESHOOTING` help content unchanged.
 
----
 
 ### 2.3.0 — 2026-04-10
 
@@ -32,7 +32,6 @@
 - **Made `-PhonePath` and `-Dest` mandatory.** Personal hard-coded default values for both
   parameters have been removed. Both paths must be supplied explicitly on every invocation.
 
----
 
 ### 2.2.0 — 2026-04-10
 
@@ -48,7 +47,6 @@
   in tar mode is replaced by the explicit `-IntervalSeconds 1` argument, making the interval
   visible and documentable.
 
----
 
 ### 2.1.0 — 2026-04-07
 
@@ -69,7 +67,6 @@
   were displayed on-screen but not written to log files. The extracted `Write-VerifySummary`
   helper always uses `Write-LogWarning`, fixing the bug for all modes.
 
----
 
 ### 2.0.0 — 2025-11-16
 
@@ -82,7 +79,6 @@
 - Retained ADB-specific `DebugMode` for low-level adb diagnostics.
 - All log messages are now written to standardized log files.
 
----
 
 ### 1.3.9 — 2025-08-27
 
@@ -94,7 +90,6 @@
   - pull `-Resume`, tar (stream or file): baseline = `$Dest`
 - Remote values remain best-effort counts/sizes; no transfer-logic change.
 
----
 
 ### 1.3.8 — 2025-08-27
 
@@ -106,7 +101,6 @@
   - Now uses conditional splatting so redirection keys are set only when `DebugMode` is on.
 - Eliminates `RedirectStandardError` validation errors when running without `DebugMode`.
 
----
 
 ### 1.3.7 — 2025-08-27
 
@@ -118,7 +112,6 @@
   - Standardized left-hand-side `$null` comparisons.
 - Improves stability of phone-side script execution on toybox/busybox shells.
 
----
 
 ### 1.3.6 — 2025-08-27
 
@@ -133,7 +126,6 @@
 
 - Updated documentation for `DebugMode` behavior, log location, and sharing caveats.
 
----
 
 ### 1.3.5 — 2025-08-27
 
@@ -145,7 +137,6 @@
 - `Test-PhoneTar` now prefers `command -v tar` with `--help` fallback, while keeping toybox/busybox fallback.
 - Hardened parsing of adb outputs to avoid null/empty `Trim()` crashes.
 
----
 
 ### 1.3.4 — 2025-08-27
 
@@ -156,7 +147,6 @@
 - Maintains fallback to `toybox tar` / `busybox tar`.
 - Resolves false negatives introduced in 1.3.3 on devices where `--version` is unsupported.
 
----
 
 ### 1.3.3 — 2025-08-27
 
@@ -167,7 +157,6 @@
 - Restored full comment-based help for all functions.
 - Retained awk-free remote size logic (`du`/`stat`/`find` + shell arithmetic).
 
----
 
 ### 1.3.2 — 2025-08-27
 
@@ -177,7 +166,6 @@
 - Hardened adb quoting and timestamped warnings (including `$ts:` parse fix).
 - Inlined remote path argument to satisfy analyzers.
 
----
 
 ### 1.3.1 — 2025-08-27
 
@@ -187,7 +175,6 @@
 - Added timestamped warnings/retries and verify summary table (Local vs Remote counts/sizes).
 - Reduced pull progress polling to 5 seconds (configurable).
 
----
 
 ### 1.3.0 — 2025-08-27
 
@@ -196,7 +183,6 @@
 - Added `-Verify` and local/remote file-count helpers.
 - Logged local/remote summaries after TAR extraction and after pull.
 
----
 
 ### 1.2.x — 2025-08-27
 
@@ -204,15 +190,16 @@
 
 - Added disk-space precheck, resumable pull, TAR retries/cleanup, and `-StreamTar`.
 
----
 
+---
 ## FileDistributor
 
----
 
-## 4.8.0 — 2026-04-05
+### 4.8.0 — 2026-04-05
 
-### Changed (Option A — module consolidation)
+#### Changed
+
+- **Option A — module consolidation.**
 
 - **Eliminated double-loading of private module files.** `FileDistributor.ps1` previously dot-sourced all six `Private/*.ps1` files after importing the module, causing each private function to be defined twice (once in module scope, once in script scope). The script-scope copies shadowed the module-scope copies for script-level callers.
 - **Eliminated duplicate `ErrorHandling`/`FileOperations` imports from `FileDistributor.psm1`.** Both Core modules are now imported once, by `FileDistributor.ps1`, before the `FileDistributor.psd1` module is loaded. Removed the redundant `Import-Module` calls from the module loader.
@@ -223,45 +210,54 @@
 - Bumped `FileDistributor` module version to `1.2.0`.
 - Bumped script version to `4.8.0`.
 
-### Fixed
+#### Fixed
 
 - Removed a vestigial `[int]$TotalFiles` parameter from `Invoke-TargetRedistribution` in `src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1`. The parameter was not used anywhere in the function body and had become stale after redistribution progress was refactored to use per-phase totals. Updated the `FileDistributor.ps1` call site in `Invoke-DistributionPhase` to stop passing `-TotalFiles 0`.
 - Removed a dead inner null-subfolder guard inside the root-redistribution block of `Invoke-TargetRedistribution` (`if ($normalizedSubfolders.Count -eq 0) { ... }`). This branch was unreachable because the earlier normalization guard already guarantees at least one destination subfolder by creating an emergency subfolder when needed.
 - Bumped `FileDistributor` module version to `1.1.13`.
 
-## 4.7.x (rollup) — 2026-04-01 to 2026-04-05
+### 4.7.x (rollup) — 2026-04-01 to 2026-04-05
 
 Addresses script-scope coupling issues that surfaced after functions were moved into the `FileDistributor` module in 4.7.0. Module versions advanced from `1.1.0` to `1.1.12`.
 
-### Logging replacement
+#### Changed
 
 - Replaced all `LogMessage` calls (a script-scope helper defined only in `FileDistributor.ps1`) with framework-native `Write-Log*` functions (`Write-LogInfo`, `Write-LogWarning`, `Write-LogError`, `Write-LogDebug`) in `Private/PathHelpers.ps1` (`Resolve-SubfolderPath`), `Private/Distribution.ps1` (`Write-DistributionSummary`), and the post-processing functions `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, and `Invoke-DistributionRandomize`. Removed the stale `Write-Host` completion line from `Invoke-FileDistribution` in favour of `Write-LogInfo`.
 
-### State persistence fixes
+#### Changed
 
 - Refactored `Save-DistributionState`, `Restore-DistributionState`, and `Write-JsonAtomically` in `Private/State.ps1` to accept `$StateFilePath`, `$RetryDelay`, `$RetryCount`, and `$MaxBackoff` as explicit parameters instead of reading from outer script scope. Updated checkpoint/restart call sites in `FileDistributor.ps1` accordingly.
+ 
+#### Fixed
+
 - Fixed CP3 `New-CheckpointPayload` call in `Invoke-DistributionPhase` to include `-IncludeSourceFiles` and `-SourceFiles $RunState.sourceFiles`, preventing a restart from CP3 from silently skipping the distribution phase.
 - Fixed `Invoke-EndOfScriptDeletion` using unqualified `$Warnings`/`$Errors` instead of `$script:Warnings`/`$script:Errors`, which could silently yield `0` and allow deletion to proceed despite accumulated warnings or errors.
 
-### Reference counting
+#### Changed
 
 - Restored warning/error accounting for module-scope functions: added optional `[ref]$WarningCount` and `[ref]$ErrorCount` parameters to `Invoke-FileMove`, `Invoke-FileDistribution`, `Invoke-TargetRedistribution`, and `Resolve-SubfolderPath`; all `Write-LogWarning`/`Write-LogError` call sites now increment the provided counter refs. Call sites in `Invoke-DistributionPhase` and post-processing functions pass `([ref]$script:Warnings)` / `([ref]$script:Errors)`, preserving the `EndOfScriptDeletionCondition` gate.
 - Propagated `$MaxBackoff` to `Remove-DistributionFile` and to `Invoke-FolderRebalance`, `Invoke-FolderConsolidation`, and `Invoke-DistributionRandomize`, threading it through to every `Invoke-FileMove` and `Invoke-WithRetry` call site so a user-supplied value is no longer silently ignored during post-processing.
 
-### Algorithm fixes
+#### Changed
 
 - Moved post-processing algorithms `RebalanceSubfoldersByAverage`, `RandomizeDistributionAcrossFolders`, and `ConsolidateSubfoldersToMinimum` into `FileManagement/FileDistributor/Public` as `Invoke-FolderRebalance`, `Invoke-DistributionRandomize`, and `Invoke-FolderConsolidation`; updated `Invoke-PostProcessingPhase` accordingly.
+
+#### Fixed
+
 - Fixed division-by-zero / flood logging in `Invoke-FolderRebalance` and `Invoke-DistributionRandomize`: replaced inline division expressions in progress-log guards with a pre-computed `$threshold` set to `[int]::MaxValue` when the denominator is 0.
 - Fixed a race condition in `Invoke-TargetRedistribution` where `Get-Random -Count $excess` could throw if files were deleted between the cached snapshot and the actual enumeration; excess count is now clamped with `[Math]::Min()`.
 
-### Minor corrections
+#### Fixed
 
 - Fixed `-Files` parameter type in `Invoke-FileDistribution` from `[string[]]` to `[object[]]` so `FileSystemInfo` inputs are not silently coerced to strings at binding time.
+
+#### Added
+
 - Added a unit test asserting `Invoke-FileDistribution` exposes `System.Object[]` for `-Files`.
 
-## 4.7.0 — 2026-04-01
+### 4.7.0 — 2026-04-01
 
-### Changed
+#### Changed
 
 - Moved `DistributeFilesToSubfolders` → `Invoke-FileDistribution` (public) and `RedistributeFilesInTarget` → `Invoke-TargetRedistribution` (public) from `FileDistributor.ps1` into `Public/Invoke-FileDistribution.ps1` and `Public/Invoke-TargetRedistribution.ps1` in the `FileManagement/FileDistributor` module.
 - Moved retry I/O helpers (`Invoke-WithRetry`, `Copy-ItemWithRetry`, `Remove-ItemWithRetry`, `Rename-ItemWithRetry`) from `FileDistributor.ps1` into new `Private/RetryOps.ps1` in the module; replaced `LogMessage` calls with `Write-LogInfo`/`Write-LogWarning`/`Write-LogError` and added `$MaxBackoff` parameter to the `*-ItemWithRetry` wrappers.
@@ -271,9 +267,9 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - Bumped `FileDistributor` module version to `1.1.0`; updated `FunctionsToExport` in `FileDistributor.psd1` to include `Invoke-FileDistribution` and `Invoke-TargetRedistribution`.
 - Script reduces by ~475 lines (2102 → 1627).
 
-## 4.6.x (module-extraction sprint rollup) — 2026-03-26 to 2026-04-01
+### 4.6.x (module-extraction sprint rollup) — 2026-03-26 to 2026-04-01
 
-### Changed
+#### Changed
 
 - Split `FileDistributor.ps1` orchestration into phase functions and extracted shared algorithm helpers (including `Invoke-FileMove`, `Get-SubfolderFileCounts`, and `New-CheckpointPayload`) to remove duplicated copy/move/checkpoint/counting logic across distribution and post-processing flows.
 - Introduced the internal `FileManagement/FileDistributor` module scaffold and migrated serialization, path, file/folder operation, and state-adjacent helper functions out of script scope into module private files with approved PowerShell verb naming.
@@ -281,20 +277,20 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - Reduced script-scope coupling by threading runtime values explicitly through checkpoint/orchestration paths (`SessionId`, `DeleteMode`, `SourceFolder`, `MaxFilesToCopy`, `FilesPerFolderLimit`) and by standardizing helper contracts around explicit parameters.
 - Moved detailed FileDistributor release notes from script `.NOTES` to this standalone changelog and kept script header notes concise with a direct changelog pointer.
 
-### Fixed
+#### Fixed
 
 - Restored queue-signal integrity and safety checks during modularization: EndOfScript queue failures are surfaced as warnings, single-item checkpoint payloads are accepted, and subfolder candidate normalization enforces target-root containment with fallback candidate handling on scan failures.
 - Restored post-run file-count integrity validation/warnings for both distribution and rebalance-only modes, preserving discrepancy detection that regressed during early 4.6 refactors.
 
-## 4.5.0 — 2026-03-25
+### 4.5.0 — 2026-03-25
 
-### Added
+#### Added
 
 - **`.mp4` file extension support:** Added `.mp4` to the list of allowed file extensions for distribution.
 
-## 4.4.1 — 2026-01-05
+### 4.4.1 — 2026-01-05
 
-### Fixed
+#### Fixed
 
 - **Console feedback for rebalancing operations:** Added console output for early exit conditions in `-RebalanceToAverage`, `-ConsolidateToMinimum`, and `-RandomizeDistribution` modes. Users now see clear messages when operations are skipped due to:
   - All subfolders already balanced within tolerance
@@ -310,9 +306,9 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
   - File count summary shows only target count in rebalance-only mode
   - Separate "File Rebalancing Summary" with relevant information only (excludes source file counts, skipped extensions, and files selected for copying)
 
-## 4.4.0 — 2026-01-05
+### 4.4.0 — 2026-01-05
 
-### Added
+#### Added
 
 - **Optional SourceFolder for rebalance-only mode:** SourceFolder parameter is now optional. When omitted, the script automatically runs in rebalance-only mode (no files copied from source).
   - **Use case:** Run `-RebalanceToAverage`, `-ConsolidateToMinimum`, or `-RandomizeDistribution` on existing target files without providing a source folder.
@@ -322,20 +318,20 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
     - `.\FileDistributor.ps1 -TargetFolder "C:\Target" -RandomizeDistribution`
   - **Automatic behavior:** When SourceFolder is not provided, `MaxFilesToCopy` is automatically set to 0 and source enumeration is skipped.
 
-### Changed
+#### Changed
 
 - Parameter validation logic: SourceFolder omission automatically enables rebalance-only mode
 - Source file enumeration is completely skipped when running in rebalance-only mode
 - State file restoration handles empty SourceFolder gracefully for rebalance-only sessions
 
-### Notes
+#### Notes
 
 - No breaking changes. Existing behavior unchanged when SourceFolder is provided.
 - Enhanced UX: Users no longer need to specify `-MaxFilesToCopy 0` for rebalance-only operations.
 
-## 4.3.0 — 2026-01-05
+### 4.3.0 — 2026-01-05
 
-### Added
+#### Added
 
 - **`-RandomizeDistribution` parameter:** New optional switch to perform full randomized redistribution of ALL files across ALL existing subfolders. Completely ignores current distribution and redistributes from scratch.
   - **Behavior:** Enumerates all files in all subfolders, shuffles them randomly, then redistributes evenly using round-robin assignment through the shuffled list.
@@ -344,63 +340,63 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
   - **Safety:** Respects `FilesPerFolderLimit`, uses existing `DeleteMode` for handling originals, supports progress tracking and retries.
   - **Mutual exclusivity:** Cannot be used with `-ConsolidateToMinimum` or `-RebalanceToAverage` (script will error).
 
-### Restart semantics
+#### Notes
 
-- Introduces **Checkpoint 8** recorded after randomization. Randomization runs when `-RandomizeDistribution` is specified and `lastCheckpoint < 8`; otherwise it is skipped.
+- **Restart semantics:** Introduces **Checkpoint 8** recorded after randomization. Randomization runs when `-RandomizeDistribution` is specified and `lastCheckpoint < 8`; otherwise it is skipped.
 
-### Notes
+#### Notes
 
 - No breaking changes. Feature is opt-in and not performed unless `-RandomizeDistribution` is specified.
 
-## 4.2.0 — 2026-01-05
+### 4.2.0 — 2026-01-05
 
-### Added
+#### Added
 
 - **`-RebalanceTolerance` parameter:** New optional parameter to configure the tolerance percentage for the `-RebalanceToAverage` feature. Defaults to 10, meaning folders are rebalanced to be within ±10% of the average file count.
   - **Usage:** `-RebalanceTolerance 15` will rebalance folders to be within ±15% of average instead of the default ±10%.
   - **Flexibility:** Allows users to control how strictly folders should be balanced. Lower values (e.g., 5) create tighter balance; higher values (e.g., 20) allow more variance.
   - The tolerance is applied to both donor identification (folders above `avg * (1 + tolerance/100)`) and receiver identification (folders below `avg * (1 - tolerance/100)`).
 
-### Notes
+#### Notes
 
 - No breaking changes. Default behavior remains ±10% when `-RebalanceTolerance` is not specified.
 
-## 4.1.0 — 2026-01-05
+### 4.1.0 — 2026-01-05
 
-### Changed
+#### Changed
 
 - **Distribution algorithm:** Switched from "fill emptiest folder first" to **weighted random selection** based on available capacity. Files are now distributed randomly across multiple eligible folders, with probability weighted by each folder's remaining capacity (`FilesPerFolderLimit - currentCount`).
   - **Benefit:** Prevents all files from a batch going to a single newly-created folder. When new folders are created due to existing folders reaching the limit, files are spread across multiple folders rather than sequentially filling one at a time.
   - **Behavior:** Folders with more available capacity have higher probability of receiving files, but all eligible folders can receive files from the same batch, maintaining better distribution randomness.
   - The change applies to both source-to-target distribution and within-target redistribution phases.
 
-### Notes
+#### Notes
 
 - No breaking changes or new parameters. Existing scripts will work unchanged but will see improved file distribution across folders.
 
-## 3.5.0 — 2025-10-02
+### 3.5.0 — 2025-10-02
 
-### Added
+#### Added
 
 - **`-RebalanceToAverage` (opt-in):** After Source→Target and target-root redistribution, compute the **average files per existing subfolder** and move files so every subfolder is within **±10%** of that average. No subfolders are created or deleted, and `FilesPerFolderLimit` is always respected.
   - Identifies **donor** folders (`count > ceil(avg*1.1)` capped by limit) and **receiver** folders (`count < floor(avg*0.9)`), then transfers randomly selected files to meet deficits without exceeding per-folder limits.
   - Rebalancing uses existing safety semantics (randomized destination names, `DeleteMode`, retries, progress).
 
-### Incompatibility
+#### Notes
 
-- `-RebalanceToAverage` is **mutually exclusive** with `-ConsolidateToMinimum`; specifying both results in an error.
+- **Incompatibility:** `-RebalanceToAverage` is **mutually exclusive** with `-ConsolidateToMinimum`; specifying both results in an error.
 
-### Restart semantics
+#### Notes
 
-- Introduces **Checkpoint 7** recorded after rebalancing. Rebalancing runs when `-RebalanceToAverage` is specified and `lastCheckpoint < 7`; otherwise it is skipped.
+- **Restart semantics:** Introduces **Checkpoint 7** recorded after rebalancing. Rebalancing runs when `-RebalanceToAverage` is specified and `lastCheckpoint < 7`; otherwise it is skipped.
 
-### Notes
+#### Notes
 
 - No breaking changes; feature is _not_ performed unless `-RebalanceToAverage` is passed.
 
-## 3.4.0 — 2025-10-02
+### 3.4.0 — 2025-10-02
 
-### Added
+#### Added
 
 - **`-ConsolidateToMinimum` (opt-in):** New command-line switch that packs files into the **minimum number of subfolders** while honoring `FilesPerFolderLimit`. Runs **after** Source→Target copy and target-root redistribution **only when specified**.
   - Computes `needed = ceil(total_files / FilesPerFolderLimit)`.
@@ -408,49 +404,49 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
   - Deletes subfolders that become empty after the move.
   - Uses existing safety semantics (randomized destination names, `DeleteMode`, retries, progress).
 
-### Restart semantics
+#### Notes
 
-- Introduces **Checkpoint 6** recorded after consolidation. Consolidation runs when `-ConsolidateToMinimum` is specified and `lastCheckpoint < 6`; otherwise it is skipped.
+- **Restart semantics:** Introduces **Checkpoint 6** recorded after consolidation. Consolidation runs when `-ConsolidateToMinimum` is specified and `lastCheckpoint < 6`; otherwise it is skipped.
 
-### Notes
+#### Notes
 
 - No breaking changes. Consolidation is _not_ performed unless `-ConsolidateToMinimum` is passed.
 
-## 3.3.0 — 2025-10-02
+### 3.3.0 — 2025-10-02
 
-### Added
+#### Added
 
 - **Checkpoint 4 + Source → Target distribution phase:** Selected source files (subject to `-MaxFilesToCopy`) are now copied into eligible target subfolders **before** any within-target redistribution (root or overloaded folders). This phase respects `-FilesPerFolderLimit` and your `-DeleteMode` (including `EndOfScript`, which queues originals for final cleanup).
 
-### Changed
+#### Changed
 
 - The earlier “within-target redistribution completed” checkpoint has been **renumbered from CP4 to CP5**.
 
-### Restart semantics
+#### Notes
 
-- Resume at **CP3** → runs the new Source→Target copy and saves **CP4**.
+- **Restart semantics:** Resume at **CP3** → runs the new Source→Target copy and saves **CP4**.
 - Resume at **CP4** → skips Source→Target copy and runs within-target redistribution, then saves **CP5**.
 - Resume at **CP5** → skips redistribution and proceeds to end-of-script actions (e.g., deletions).
 
-### Notes
+#### Notes
 
 - No breaking parameter changes. Logging now includes a banner: _“Distributing N source file(s) to subfolders…”_ for the new phase.
 
-## 3.2.0 — 2025-09-30
+### 3.2.0 — 2025-09-30
 
-### Added
+#### Added
 
 - **Conditional debug logging:** Debug messages ("DEBUG:") are now only written to the log file and console (via Write-Debug) when the script is run with the built-in -Debug switch. Added [CmdletBinding()] to enable common parameters, $script:DebugMode to detect mode, [switch]$IsDebug to LogMessage, and conditioned logging/output accordingly. This reduces log clutter in normal runs.
 
-## 3.1.0–3.1.26 (rollup) — 2025-09-28 → 2025-09-30
+### 3.1.0–3.1.26 (rollup) — 2025-09-28 → 2025-09-30
 
-### Added
+#### Added
 
 - **`-MaxFilesToCopy`:** Cap per-run copies (`-1` all, `0` none, `N` first N); persisted and restart-aware.
 - **Deeper diagnostics:** DEBUG tracing across enumeration, conversions, state I/O, candidate counts (eligible/min/candidates), and pre-normalization destination selection. `Resolve-SubfolderPath` logs `GetFullPath` attempts/exceptions.
 - **Defensive last-mile checks:** Re-validate final destination; if invalid or the target root, auto-select a safe validated subfolder (create an emergency one if needed).
 
-### Changed
+#### Changed
 
 - **Chooser hardening:** `DistributeFilesToSubfolders` builds candidates from a fresh enumeration of the target root plus caller input; canonicalizes with `GetFullPath`, enforces “under target root & not the root,” and dedupes. Wildcard tests removed.
 - **State & restarts:** Persist enumeration totals and deterministic _selected_ files; restarts must match.
@@ -459,7 +455,7 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - **Locking/backoff:** State-file locking now uses capped exponential backoff + small jitter and logs the last exception on failure; sidecar contention wait reduced 10s → 1s (still honors max-attempt backoff).
 - **Typo fix:** Log label now prints `FilesPerFolderLimit`.
 
-### Fixed
+#### Fixed
 
 - **Root safety:** Block writes to the target **root** even if “under target”; reroute to a validated subfolder.
 - **Normalization & escapes:** Replace wildcard checks with `[IO.Path]::GetFullPath(...)` + case-insensitive `StartsWith(...)` against a normalized target root; prevent root escapes, mixed-case false positives, and accidental root placement.
@@ -469,22 +465,24 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - **Input/path hygiene:** Early-reject `C`, `C:`, `C:foo` forms; anchor relatives under `TargetRoot`; preserve special chars `()!@$~`.
 - **Stability:** `ReleaseFileLock` is null-safe; enumeration filter no longer zeroes valid directories; sidecar writes (`FileDistributor-State.json.sha256`) are retried with clearer errors.
 
-### Notes
+#### Notes
 
 - Eliminates spurious warnings like “Sanitizing non-rooted destination folder ''” and “using subfolder 'D'.”
 - No breaking parameter/state changes beyond persisting `MaxFilesToCopy`; behavior is stricter and diagnostics clearer.
 
-## 3.0.0–3.0.9 (rollup) — 2025-09-18 → 2025-09-25
+### 3.0.0–3.0.9 (rollup) — 2025-09-18 → 2025-09-25
 
-### Changed (⚠️ Breaking)
+#### Changed
+
+- **⚠️ Breaking.**
 
 - **Random name provider is module-only.** Removed legacy `randomname.ps1` and `-RandomNameScriptPath`. Import order: `-RandomNameModulePath` → script-root `powershell\module\RandomName\RandomName.psd1/.psm1` → `Import-Module RandomName` from `$env:PSModulePath`.
 
-### Added
+#### Added
 
 - **`-RandomNameModulePath`** to explicitly point to the RandomName module.
 
-### Fixed
+#### Fixed
 
 - **Path safety & normalization**
   - Block **relative/drive-like destinations** (e.g., `D\file.jpg`, `D`, `D:`). Non-absolute subfolder strings are remapped under **-TargetFolder**; chosen destinations are verified to be rooted and existing before copy.
@@ -510,21 +508,23 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - **Log/State path handling**
   - If `-LogFilePath`/`-StateFilePath` points to an **existing directory**, automatically use `FileDistributor-log.txt` / `FileDistributor-State.json` inside it and ensure directories/files exist before first write.
 
-### Notes
+#### Notes
 
 - If you previously ran with `-Restart`, delete stale state files (and `.bak`/`.sha256`) before rerunning to avoid inheriting malformed subfolder lists.
 
-## 2.0.0 — 2025-09-14
+### 2.0.0 — 2025-09-14
 
-### Changed (⚠️ Breaking)
+#### Changed
+
+- **⚠️ Breaking.**
 
 - **Source enumeration is now recursive by default (and only behavior):** All files under `-SourceFolder` (including nested subdirectories) are processed. Previously only top-level files were handled.
 - Help/description updated to reflect recursion.
 - Limitations updated (top-level only note removed).
 
-## 1.0.0–1.7.0 (rollup) — 2025-09-14
+### 1.0.0–1.7.0 (rollup) — 2025-09-14
 
-### Added
+#### Added
 
 - Exponential I/O retry wrappers (copy/delete/Recycle Bin moves) with `-ErrorAction Stop` and backoff.
 - `-MaxBackoff` parameter to cap exponential backoff (default 60s).
@@ -533,7 +533,7 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - Robust state-file handling: atomic write via same-directory `*.tmp` then replace, persistent `.bak`, `.sha256` integrity sidecar, auto-recovery from `.bak`, quarantine of corrupt primaries.
 - Script header `.VERSION` and `CHANGELOG` sections.
 
-### Changed
+#### Changed
 
 - **Distribution**: switched from round-robin to random-balanced placement biased to least-filled subfolders; applies to initial distribution and redistribution.
 - **Naming**: removed upfront renaming of sources; destination names always randomized at copy time while preserving extensions.
@@ -546,7 +546,7 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 - **Paths & config**: removed user-specific defaults for `-SourceFolder`/`-TargetFolder` (must be provided); `LogFilePath`/`StateFilePath` now follow the dynamic resolution order; dropped hard-coded `$ScriptDirectory`.
 - **Logging & docs**: centralized error/warning counting via `LogMessage`; updated `RetryDelay`/`RetryCount` docs; expanded examples (retry tuning, restart, end-of-script deletion); fixed `-RetryCount` default doc drift to 3.
 
-### Notes
+#### Notes
 
 - State saves now include `WarningsSoFar`, `ErrorsSoFar`, and `SessionId` to enable safe resumptions.
 - No functional changes in the 1.0.x patch rollup; behavior remained identical to 1.0.0 aside from documentation and traceability improvements.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -34,6 +34,11 @@ Scripts for file operations, distribution, copying, and archiving.
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 ## Recent Updates
 
+- **Documentation (2026-04-10)**
+  - Normalized `src/powershell/file-management/CHANGELOG.md` structure across **Copy-AndroidFiles** and **FileDistributor** sections.
+  - Added a short changelog table of contents for faster navigation.
+  - Standardized FileDistributor release/category heading hierarchy and category naming for consistency.
+  - Standardized horizontal-rule usage to a single section separator between the two script sections.
 - **Copy-AndroidFiles.ps1 v2.3.1** (2026-04-10)
   - Script header `.NOTES` now keeps only the current version and points to `CHANGELOG.md` for full version history.
   - Historical entries previously kept in the script header are now consolidated in `CHANGELOG.md` (including `1.2.x` through `2.x` milestones).


### PR DESCRIPTION
### Motivation

- Make the file-management changelog easier to navigate and machine-validate by using a consistent heading hierarchy and a single separator between script sections.
- Reduce ad-hoc category headings and unify release/category formatting so downstream tooling and readers can reliably parse the `FileDistributor` section.

### Description

- Updated `src/powershell/file-management/CHANGELOG.md` to add a short Table of Contents and enforce a single horizontal rule between the `Copy-AndroidFiles` and `FileDistributor` sections.
- Normalized release headings to `### <version> — <date>` and standardized category subsections to `#### Added/Changed/Fixed/Removed/Notes`, converting special-case headings (e.g., restart/incompatibility) into inline `Notes` entries where applicable.
- Folded miscellaneous nonstandard subsection labels into the standard category structure and adjusted wording/markers (e.g., added bold inline labels) while preserving existing release content.
- Updated `src/powershell/file-management/README.md` `Recent Updates` to document the changelog normalization pass and point to `CHANGELOG.md` for details.

### Testing

- Ran a structural Python validation script that verifies there is exactly one `---` separator, all `FileDistributor` release headings are H3, and all `FileDistributor` category headings are H4 within the allowed set; the script completed successfully (`ok`).
- Inspected the modified files (`src/powershell/file-management/CHANGELOG.md` and `src/powershell/file-management/README.md`) to ensure content was preserved and formatting changes applied consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d945145de883258a3fb3f2a3bba196)