### PR TITLE
docs(file-management): consolidate FileDistributor 4.6.x/4.7.x rollups

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -199,26 +199,18 @@
 
 #### Changed
 
-- **Option A — module consolidation.**
-
-- **Eliminated double-loading of private module files.** `FileDistributor.ps1` previously dot-sourced all six `Private/*.ps1` files after importing the module, causing each private function to be defined twice (once in module scope, once in script scope). The script-scope copies shadowed the module-scope copies for script-level callers.
-- **Eliminated duplicate `ErrorHandling`/`FileOperations` imports from `FileDistributor.psm1`.** Both Core modules are now imported once, by `FileDistributor.ps1`, before the `FileDistributor.psd1` module is loaded. Removed the redundant `Import-Module` calls from the module loader.
-- **Moved orchestration functions to the module as public functions.** The following functions, which previously existed only in `FileDistributor.ps1` and depended on private module helpers, have been promoted to `Public/` files in `FileManagement/FileDistributor` and exported by the module: `Initialize-FileDistributorPaths`, `Invoke-ParameterValidation`, `Invoke-RestoreCheckpoint`, `New-CheckpointPayload`, `Invoke-DistributionPhase`, `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-PostRunCleanup`, `Invoke-DistributionLockRelease`.
-- **Fixed `LogMessage` calls in private module files.** `Private/FileLock.ps1`, `Private/State.ps1`, and `Private/Serialization.ps1` called `LogMessage` (a script-scope function defined only in `FileDistributor.ps1`), causing `CommandNotFoundException` when those private functions were invoked from module scope. All `LogMessage` calls have been replaced with the appropriate `Write-Log*` framework calls (`Write-LogInfo`, `Write-LogWarning`, `Write-LogError`, `Write-LogDebug`).
-- **Moved `Test-EndOfScriptCondition` to `Private/OrchestratorHelpers.ps1`** so it is available to the module-scope `Invoke-EndOfScriptDeletion`.
-- **Removed dead `Write-DistributionSummary` duplicate** from `FileDistributor.ps1`. The function was never called from the script; the canonical version lives in `Private/Distribution.ps1`.
+- Consolidated `FileDistributor` module loading so private helpers are loaded once in module scope instead of being re-dot-sourced in `FileDistributor.ps1`.
+- Removed redundant `ErrorHandling` and `FileOperations` imports from `FileDistributor.psm1`; these Core modules are now imported once in `FileDistributor.ps1` before loading `FileDistributor.psd1`.
+- Promoted orchestration functions to module `Public/` exports: `Initialize-FileDistributorPaths`, `Invoke-ParameterValidation`, `Invoke-RestoreCheckpoint`, `New-CheckpointPayload`, `Invoke-DistributionPhase`, `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-PostRunCleanup`, and `Invoke-DistributionLockRelease`.
+- Replaced remaining private-module `LogMessage` calls with framework-native `Write-Log*` functions in `Private/FileLock.ps1`, `Private/State.ps1`, and `Private/Serialization.ps1`.
+- Moved `Test-EndOfScriptCondition` to `Private/OrchestratorHelpers.ps1` to support module-scope `Invoke-EndOfScriptDeletion`.
+- Removed the dead `Write-DistributionSummary` duplicate from `FileDistributor.ps1`; the canonical implementation remains in `Private/Distribution.ps1`.
 - Bumped `FileDistributor` module version to `1.2.0`.
 - Bumped script version to `4.8.0`.
 
-#### Fixed
-
-- Removed a vestigial `[int]$TotalFiles` parameter from `Invoke-TargetRedistribution` in `src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1`. The parameter was not used anywhere in the function body and had become stale after redistribution progress was refactored to use per-phase totals. Updated the `FileDistributor.ps1` call site in `Invoke-DistributionPhase` to stop passing `-TotalFiles 0`.
-- Removed a dead inner null-subfolder guard inside the root-redistribution block of `Invoke-TargetRedistribution` (`if ($normalizedSubfolders.Count -eq 0) { ... }`). This branch was unreachable because the earlier normalization guard already guarantees at least one destination subfolder by creating an emergency subfolder when needed.
-- Bumped `FileDistributor` module version to `1.1.13`.
-
 ### 4.7.x (rollup) — 2026-04-01 to 2026-04-05
 
-Addresses script-scope coupling issues that surfaced after functions were moved into the `FileDistributor` module in 4.7.0. Module versions advanced from `1.1.0` to `1.1.12`.
+Addresses script-scope coupling issues that surfaced after functions were moved into the `FileDistributor` module in 4.7.0. Module versions advanced from `1.1.0` to `1.1.13`.
 
 #### Changed
 
@@ -250,6 +242,8 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 #### Fixed
 
 - Fixed `-Files` parameter type in `Invoke-FileDistribution` from `[string[]]` to `[object[]]` so `FileSystemInfo` inputs are not silently coerced to strings at binding time.
+- Removed vestigial `[int]$TotalFiles` from `Invoke-TargetRedistribution` and updated `Invoke-DistributionPhase` call sites to stop passing `-TotalFiles 0`.
+- Removed an unreachable inner `if ($normalizedSubfolders.Count -eq 0)` guard in `Invoke-TargetRedistribution`; the earlier normalization guard already ensures at least one valid destination subfolder.
 
 #### Added
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -51,21 +51,12 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
     set. Pass pull-only parameters to use pull mode; pass tar-only parameters (or none) for tar mode.
   - Made `-PhonePath` and `-Dest` mandatory; personal hard-coded default values removed.
 - **FileDistributor.ps1 v4.8.0** (module v1.2.0)
-  - **Option A: module consolidation** — eliminated double-loading of all six private `FileManagement/FileDistributor` module files. The six dot-source lines previously in `FileDistributor.ps1` have been removed; private functions now live exclusively in module scope, loaded once by the module loader.
-  - Removed duplicate `Import-Module` calls for `ErrorHandling` and `FileOperations` from `FileDistributor.psm1`; both Core modules are now imported once by the script before the `FileDistributor` module is loaded.
-  - Promoted orchestration functions (`Initialize-FileDistributorPaths`, `Invoke-ParameterValidation`, `Invoke-RestoreCheckpoint`, `New-CheckpointPayload`, `Invoke-DistributionPhase`, `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-PostRunCleanup`, `Invoke-DistributionLockRelease`) to the module's `Public/` folder and exported them.
-  - Fixed remaining `LogMessage` calls in private module files (`FileLock.ps1`, `State.ps1`, `Serialization.ps1`) that caused `CommandNotFoundException` when those functions were invoked from module scope; replaced with `Write-Log*` framework calls.
-  - Removed dead `Write-DistributionSummary` duplicate from `FileDistributor.ps1`; the canonical version lives in `Private/Distribution.ps1`.
-- **FileDistributor.ps1 v4.7.13**
-  - Removed a vestigial, unused `-TotalFiles` parameter from module function `Invoke-TargetRedistribution` and updated the script call site accordingly.
-  - Removed a dead inner `if ($normalizedSubfolders.Count -eq 0)` guard in `Invoke-TargetRedistribution`; this branch was unreachable because an earlier guard already creates an emergency subfolder whenever no valid subfolders exist.
-  - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.13`.
-- **FileDistributor.ps1 v4.7.12**
-  - Removed direct `Write-Host` completion output from module function `Invoke-FileDistribution`; completion is now logged via `Write-LogInfo` only for consistent framework-managed logging behavior.
-  - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.12`.
-- **FileDistributor.ps1 v4.7.11**
-  - Fixed `Invoke-FileDistribution` parameter typing for `-Files`: changed `[string[]]` to `[object[]]` so `System.IO.FileSystemInfo` inputs are not coerced to strings during parameter binding and the in-function `FileSystemInfo` handling branch remains reachable.
-  - Bumped internal `FileManagement/FileDistributor` module version to `v1.1.11` and added regression coverage for the `-Files` parameter type.
+  - Consolidated module/script loading boundaries: private helpers are now loaded once in module scope, redundant Core module imports were removed, and orchestration helpers were promoted to module `Public/` exports.
+  - Replaced remaining private-module `LogMessage` calls with framework-native `Write-Log*` functions to avoid module-scope `CommandNotFoundException`.
+  - Removed dead script-local duplication (`Write-DistributionSummary`) and aligned helper placement (`Test-EndOfScriptCondition`) with module-scope orchestration.
+- **FileDistributor.ps1 v4.7.x rollup** (v4.7.0–v4.7.13; module v1.1.0→v1.1.13)
+  - Hardened moduleized distribution/post-processing flows by fixing script-scope coupling (`LogMessage` migration, explicit state/retry parameters, warning/error counter propagation, and restart/checkpoint wiring).
+  - Landed stability fixes across redistribution and rebalance logic (`-Files` parameter typing, random-selection race clamp, divide-by-zero logging guards, unused `-TotalFiles` removal, and unreachable normalized-subfolder guard removal).
 - **FileDistributor.ps1 v4.6.x module-extraction sprint (v4.6.0–v4.6.17)**
   - Broke monolithic orchestration into reusable phase helpers and extracted shared move/subfolder/checkpoint helpers to reduce duplicated algorithm logic.
   - Introduced and expanded the internal `FileManagement/FileDistributor` module by moving path/serialization/folder operation helpers out of script scope.


### PR DESCRIPTION
### Motivation
- Clean up and clarify the FileDistributor release notes by consolidating duplicated/fragmented changelog bullets and aligning rollup items with their proper release windows.
- Remove noisy or misplaced sub-sections under 4.8.0 and consolidate the 4.7.x updates into a single rollup entry for easier reading and maintenance.
- Ensure the README recent-updates summary matches the canonical changelog structure and module-version progression.

### Description
- Updated `src/powershell/file-management/CHANGELOG.md` to simplify the `4.8.0` entry, move `Invoke-TargetRedistribution` cleanup notes into the `4.7.x` rollup, and reflect module version progression to `v1.1.13` where appropriate.
- Updated `src/powershell/file-management/README.md` to consolidate the FileDistributor recent updates into a concise `4.8.0` item and a single `4.7.x rollup` paragraph.
- This is a documentation-only change and does not modify runtime code or behavior.

### Testing
- Ran `git diff -- src/powershell/file-management/CHANGELOG.md src/powershell/file-management/README.md` to verify the intended diffs were produced, which showed the documentation edits as expected.
- Ran `git status --short` to confirm the working tree was clean after committing the documentation changes, which succeeded.
- No automated unit or integration tests were required because this change only touches documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d947c779e08325907c14f45dec10b9)