### PR TITLE
docs: align FileDistributor 4.7.x changelog/.NOTES and refresh README metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code Formatting](https://github.com/manoj-bhaskaran/My-Scripts/actions/workflows/code-formatting.yml/badge.svg)](https://github.com/manoj-bhaskaran/My-Scripts/actions/workflows/code-formatting.yml)
 
-**Version:** 2.12.9 | **Last Updated:** 2026-04-05
+**Version:** 2.12.10 | **Last Updated:** 2026-04-05
 
 ---
 
@@ -180,7 +180,7 @@ pip install -e .
 - **[PurgeLogs](src/powershell/modules/Core/Logging/PurgeLogs/)** (v2.0.0) – Log file purging and retention management
 - **[FileSystem](src/powershell/modules/Core/FileSystem/)** (v1.0.0) – Common file system operations (directory creation, file accessibility checks, path validation, file locking detection)
 - **[FileQueue](src/powershell/modules/FileManagement/FileQueue/)** (v1.0.0) – File queue management for distribution operations with state persistence and session tracking
-- **[FileDistributor](src/powershell/modules/FileManagement/FileDistributor/)** (v1.1.11) – Private support helpers for FileDistributor orchestration (path handling, state persistence, and state-file locking)
+- **[FileDistributor](src/powershell/modules/FileManagement/FileDistributor/)** (v1.2.0) – Private support helpers for FileDistributor orchestration (path handling, state persistence, and state-file locking)
 
 **Python Modules:**
 

--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -208,6 +208,21 @@
 - Bumped `FileDistributor` module version to `1.2.0`.
 - Bumped script version to `4.8.0`.
 
+### 4.7.2 — 2026-04-02
+
+#### Fixed
+
+- Updated `Invoke-FileMove` race handling so source files that disappear between discovery and copy are logged as warnings and skipped instead of aborting distribution.
+- Bumped `FileDistributor` module version to `1.1.2`.
+
+### 4.7.1 — 2026-04-02
+
+#### Changed
+
+- Replaced script-local retry/file-operation helpers with shared Core modules (`Core/ErrorHandling` + `Core/FileOperations`) and removed direct `Private/RetryOps.ps1` loading from script orchestration.
+- Updated orchestration call paths to use `Copy-FileWithRetry`, `Remove-FileWithRetry`, and `Invoke-WithRetry -IgnoreFileNotFound`.
+- Bumped `FileDistributor` module version to `1.1.1`.
+
 ### 4.7.x (rollup) — 2026-04-01 to 2026-04-05
 
 Addresses script-scope coupling issues that surfaced after functions were moved into the `FileDistributor` module in 4.7.0. Module versions advanced from `1.1.0` to `1.1.13`.

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -226,26 +226,10 @@ To display the script's help text:
 .\FileDistributor.ps1 -Help
 
 .NOTES
-## 4.7.10 — 2026-04-05
+Version: 4.8.0 (2026-04-05).
 
-- Added explicit `StateFilePath`, `RetryDelay`, `RetryCount`, and `MaxBackoff` parameters to the state persistence helpers in `Private/State.ps1`.
-- Updated checkpoint and restart call sites to pass state path and retry settings explicitly, removing the helpers' dependency on script-scope free variables.
-
-## 4.7.2 — 2026-04-02
-
-- Fixed race handling in `Invoke-FileMove` so missing source files are logged and skipped instead of aborting the run.
-
-## 4.7.1 — 2026-04-02
-
-- Replaced script-local retry/file-operation utilities with shared Core modules (`ErrorHandling` + `FileOperations`) and removed direct `Private/RetryOps.ps1` loading.
-- Updated call paths to use `Copy-FileWithRetry`, `Remove-FileWithRetry`, and module `Invoke-WithRetry -IgnoreFileNotFound` semantics.
-
-## 4.7.0 â€” 2026-04-01
-### Changed
-- Moved `DistributeFilesToSubfolders` â†’ `Invoke-FileDistribution` and `RedistributeFilesInTarget` â†’ `Invoke-TargetRedistribution` into `Public/` files of the `FileManagement/FileDistributor` module.
-- Moved `Get-SubfolderFileCounts` into `Private/Distribution.ps1` and retry helpers (`Invoke-WithRetry`, `Copy-ItemWithRetry`, `Remove-ItemWithRetry`, `Rename-ItemWithRetry`) into `Private/RetryOps.ps1`.
-- Updated `FolderOps.ps1` to call `Write-LogInfo`/`Write-LogWarning`/`Write-LogError` directly and accept retry params explicitly.
-- Full changelog: `./CHANGELOG.md`.
+For full release history (including v4.7.1 and v4.7.2), see:
+- ./CHANGELOG.md (FileDistributor section)
 
 Script Workflow:
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -57,6 +57,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
   - Consolidated module/script loading boundaries: private helpers are now loaded once in module scope, redundant Core module imports were removed, and orchestration helpers were promoted to module `Public/` exports.
   - Replaced remaining private-module `LogMessage` calls with framework-native `Write-Log*` functions to avoid module-scope `CommandNotFoundException`.
   - Removed dead script-local duplication (`Write-DistributionSummary`) and aligned helper placement (`Test-EndOfScriptCondition`) with module-scope orchestration.
+- **FileDistributor.ps1 v4.7.2** (module v1.1.2)
+  - Fixed race handling in `Invoke-FileMove`: missing source files are now warning-and-skip instead of aborting distribution.
+- **FileDistributor.ps1 v4.7.1** (module v1.1.1)
+  - Switched retry/file-operation flows to shared Core modules (`Core/ErrorHandling`, `Core/FileOperations`) and removed direct script loading of `Private/RetryOps.ps1`.
 - **FileDistributor.ps1 v4.7.x rollup** (v4.7.0–v4.7.13; module v1.1.0→v1.1.13)
   - Hardened moduleized distribution/post-processing flows by fixing script-scope coupling (`LogMessage` migration, explicit state/retry parameters, warning/error counter propagation, and restart/checkpoint wiring).
   - Landed stability fixes across redistribution and rebalance logic (`-Files` parameter typing, random-selection race clamp, divide-by-zero logging guards, unused `-TotalFiles` removal, and unreachable normalized-subfolder guard removal).


### PR DESCRIPTION
### Motivation

- Ensure the authoritative `FileDistributor` release history is complete and consistent by surfacing the previously-implicit `v4.7.2` and `v4.7.1` entries in the component changelog and removing stale embedded release prose from the script header `.NOTES`.
- Keep repository-level documentation accurate by updating top-level README metadata to reflect the current release state and module version.

### Description

- Added explicit `4.7.2` and `4.7.1` entries to `src/powershell/file-management/CHANGELOG.md` documenting the race-handling fix and the retry/module-change respectively.
- Simplified the `FileDistributor.ps1` script header `.NOTES` to a concise `Version: 4.8.0 (2026-04-05)` stamp and a pointer to the component `CHANGELOG.md` to avoid duplicated/stale notes.
- Updated `src/powershell/file-management/README.md` to include explicit `v4.7.2` and `v4.7.1` bullets in the "Recent Updates" section.
- Bumped repository README metadata in `README.md` to `Version: 2.12.10` and updated the listed `FileDistributor` module version to `v1.2.0` to match the component changelog.

### Testing

- Ran `git diff --check` with no reportable issues, which succeeded.  
- Ran `python -m compileall -q .` to validate Python files syntax, which exited successfully.  
- Verified working tree was clean after committing changes by checking `git status --short`, which showed no outstanding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fcad9abc8325b231942bfb4f5c04)