### PR TITLE
refactor(Copy-AndroidFiles): enhance Android ADB Helpers Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ pip install -e .
 - **[FileSystem](src/powershell/modules/Core/FileSystem/)** (v1.0.0) – Common file system operations (directory creation, file accessibility checks, path validation, file locking detection)
 - **[FileQueue](src/powershell/modules/FileManagement/FileQueue/)** (v1.0.0) – File queue management for distribution operations with state persistence and session tracking
 - **[FileDistributor](src/powershell/modules/FileManagement/FileDistributor/)** (v1.2.0) – Private support helpers for FileDistributor orchestration (path handling, state persistence, and state-file locking)
+- **[AdbHelpers](src/powershell/modules/Android/AdbHelpers/)** (v1.0.0) – Shared Android Debug Bridge helpers for device checks, remote shell execution, and remote path metadata queries
 
 **Python Modules:**
 

--- a/config/modules/deployment.txt
+++ b/config/modules/deployment.txt
@@ -49,6 +49,7 @@ PurgeLogs|src\powershell\modules\Core\Logging\PurgeLogs.psm1|System|Manoj Bhaska
 # Utility and media processing modules
 RandomName|src\powershell\modules\Utilities\RandomName|System|Manoj Bhaskaran|Generates Windows-safe random file names using a conservative allow-list
 Videoscreenshot|src\powershell\modules\Media\Videoscreenshot|System|Manoj Bhaskaran|Video frame capture via VLC or GDI+ with optional Python cropper integration
+AdbHelpers|src\powershell\modules\Android\AdbHelpers|System|Manoj Bhaskaran|Reusable Android Debug Bridge helpers for device validation, remote shell execution, and remote metadata queries
 
 # Shared utility modules (error handling, file operations, progress reporting)
 ErrorHandling|src\powershell\modules\Core\ErrorHandling|System|Manoj Bhaskaran|Standardized error handling and retry logic with exponential backoff

--- a/docs/architecture/module-dependencies.md
+++ b/docs/architecture/module-dependencies.md
@@ -27,6 +27,7 @@ graph TD
 
     subgraph "PowerShell Modules"
         LOG[PowerShellLoggingFramework<br/>v2.0.0]
+        ADBH[AdbHelpers<br/>v1.0.0]
         ERR[ErrorHandling<br/>v1.0.0]
         FOPS[FileOperations<br/>v1.0.0]
         PGBAK[PostgresBackup<br/>v2.0.0]
@@ -37,6 +38,7 @@ graph TD
     end
 
     subgraph "External Dependencies"
+        ADBCLI[Android Platform-Tools<br/>adb and device tar]
         PGCLIENT[PostgreSQL Client<br/>pg_dump]
         VLCPLAYER[VLC Media Player]
         PYCROP[Python Image Cropper]
@@ -45,6 +47,7 @@ graph TD
     %% Script to Module Dependencies
     BACKUP --> PGBAK
     BACKUP --> LOG
+    FILE --> ADBH
     FILE --> FOPS
     FILE --> LOG
     MEDIA --> VID
@@ -64,6 +67,7 @@ graph TD
 
     %% Module to External Dependencies
     PGBAK --> PGCLIENT
+    ADBH --> ADBCLI
     VID --> VLCPLAYER
     VID -.Optional.-> PYCROP
 
@@ -72,9 +76,9 @@ graph TD
     classDef script fill:#50C878,stroke:#2E7D4E,color:#fff
     classDef external fill:#F5A623,stroke:#D68910,color:#fff
 
-    class LOG,ERR,FOPS,PGBAK,PROG,PURGE,RND,VID module
+    class LOG,ADBH,ERR,FOPS,PGBAK,PROG,PURGE,RND,VID module
     class BACKUP,FILE,MEDIA,SYSTEM,CLOUD,GIT script
-    class PGCLIENT,VLCPLAYER,PYCROP external
+    class ADBCLI,PGCLIENT,VLCPLAYER,PYCROP external
 ```
 
 **Legend**:
@@ -287,6 +291,34 @@ Invoke-WithRetry -ScriptBlock { Copy-Item $src $dest } -MaxRetries 3
 ```powershell
 Remove-OldLogs -LogDirectory "C:\Logs" -RetentionDays 30
 ```
+
+---
+
+#### 9. AdbHelpers (v1.0.0)
+
+**Purpose**: Reusable Android Debug Bridge helpers for device validation, remote shell execution, and remote path metadata lookups.
+
+**Dependencies**:
+- Android Platform-Tools (`adb`) on PATH
+- Host `tar` and device-side `tar` only when tar workflows are requested
+
+**Dependents**:
+- `Copy-AndroidFiles.ps1`
+- Future Android device automation and backup scripts
+
+**Key Functions**:
+- `Test-Adb`: Verify `adb.exe` is available on the host
+- `Confirm-Device`: Verify an authorized Android device is connected
+- `Invoke-AdbSh`: Run normalized POSIX shell snippets on the device safely
+- `Get-RemoteSize`: Return best-effort remote byte counts for Android paths
+- `Get-RemoteFileCount`: Return best-effort remote file counts for Android paths
+- `Test-HostTar` and `Test-PhoneTar`: Validate tar support for tar-based transfer workflows
+
+**External Requirements**:
+- Android Platform-Tools installed and available on PATH
+- USB debugging enabled and authorized on the connected device
+
+**Location**: `src/powershell/modules/Android/AdbHelpers/`
 
 ---
 

--- a/psmodule.toml
+++ b/psmodule.toml
@@ -74,6 +74,14 @@ description = "Video frame capture via VLC or GDI+ with optional Python cropper 
 author = "Manoj Bhaskaran"
 dependencies = []
 [[modules]]
+name = "AdbHelpers"
+source = "src/powershell/modules/Android/AdbHelpers"
+auto-deploy = true
+test-on-deploy = true
+description = "Reusable Android Debug Bridge helpers for device validation, remote shell execution, and remote metadata queries"
+author = "Manoj Bhaskaran"
+dependencies = []
+[[modules]]
 name = "ErrorHandling"
 source = "src/powershell/modules/Core/ErrorHandling"
 auto-deploy = true

--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -1,18 +1,30 @@
 # CHANGELOG
 
 ## Table of Contents
+
 - [Copy-AndroidFiles](#copy-androidfiles)
 - [FileDistributor](#filedistributor)
 
 ## Copy-AndroidFiles
 
+### 2.3.2 — 2026-04-11
+
+#### Changed
+
+- **Extracted reusable ADB helpers into a new `Android/AdbHelpers` PowerShell module.**
+  `Copy-AndroidFiles.ps1` now imports `src/powershell/modules/Android/AdbHelpers/AdbHelpers.psd1`
+  and consumes the shared `Test-Adb`, `Confirm-Device`, `Test-HostTar`, `Test-PhoneTar`,
+  `Invoke-AdbSh`, `Get-RemoteSize`, and `Get-RemoteFileCount` functions instead of defining them
+  inline.
+- **Made ADB helper state explicit at call sites.** `Invoke-AdbSh`, `Test-PhoneTar`,
+  `Get-RemoteSize`, and `Get-RemoteFileCount` now accept debug log inputs as parameters, and tar
+  prechecks accept the active transfer mode explicitly instead of relying on script scope.
 
 ### 2.3.1 — 2026-04-10
 
 #### Changed
 
 - **Consolidated `Copy-AndroidFiles.ps1` version history into this changelog.** Removed the long inline multi-version `CHANGELOG` block from the script's comment-based help `.NOTES` section and replaced it with a concise version stamp plus a pointer to `CHANGELOG.md`, while preserving the existing `PREREQUISITES` and `TROUBLESHOOTING` help content unchanged.
-
 
 ### 2.3.0 — 2026-04-10
 
@@ -32,7 +44,6 @@
 - **Made `-PhonePath` and `-Dest` mandatory.** Personal hard-coded default values for both
   parameters have been removed. Both paths must be supplied explicitly on every invocation.
 
-
 ### 2.2.0 — 2026-04-10
 
 #### Changed
@@ -46,7 +57,6 @@
   branches, and calls `Write-Progress -Completed` before returning. The hard-coded `Start-Sleep 1`
   in tar mode is replaced by the explicit `-IntervalSeconds 1` argument, making the interval
   visible and documentable.
-
 
 ### 2.1.0 — 2026-04-07
 
@@ -67,7 +77,6 @@
   were displayed on-screen but not written to log files. The extracted `Write-VerifySummary`
   helper always uses `Write-LogWarning`, fixing the bug for all modes.
 
-
 ### 2.0.0 — 2025-11-16
 
 #### Changed
@@ -79,7 +88,6 @@
 - Retained ADB-specific `DebugMode` for low-level adb diagnostics.
 - All log messages are now written to standardized log files.
 
-
 ### 1.3.9 — 2025-08-27
 
 #### Changed
@@ -89,7 +97,6 @@
   - pull (default): baseline = `$Dest\$leaf` if that subfolder is used by adb; otherwise `$Dest`
   - pull `-Resume`, tar (stream or file): baseline = `$Dest`
 - Remote values remain best-effort counts/sizes; no transfer-logic change.
-
 
 ### 1.3.8 — 2025-08-27
 
@@ -101,7 +108,6 @@
   - Now uses conditional splatting so redirection keys are set only when `DebugMode` is on.
 - Eliminates `RedirectStandardError` validation errors when running without `DebugMode`.
 
-
 ### 1.3.7 — 2025-08-27
 
 #### Changed
@@ -111,7 +117,6 @@
   - Added deduplication of whitespace-only lines.
   - Standardized left-hand-side `$null` comparisons.
 - Improves stability of phone-side script execution on toybox/busybox shells.
-
 
 ### 1.3.6 — 2025-08-27
 
@@ -126,7 +131,6 @@
 
 - Updated documentation for `DebugMode` behavior, log location, and sharing caveats.
 
-
 ### 1.3.5 — 2025-08-27
 
 #### Changed
@@ -137,7 +141,6 @@
 - `Test-PhoneTar` now prefers `command -v tar` with `--help` fallback, while keeping toybox/busybox fallback.
 - Hardened parsing of adb outputs to avoid null/empty `Trim()` crashes.
 
-
 ### 1.3.4 — 2025-08-27
 
 #### Fixed
@@ -146,7 +149,6 @@
   `tar --help` instead of requiring `tar --version`.
 - Maintains fallback to `toybox tar` / `busybox tar`.
 - Resolves false negatives introduced in 1.3.3 on devices where `--version` is unsupported.
-
 
 ### 1.3.3 — 2025-08-27
 
@@ -157,7 +159,6 @@
 - Restored full comment-based help for all functions.
 - Retained awk-free remote size logic (`du`/`stat`/`find` + shell arithmetic).
 
-
 ### 1.3.2 — 2025-08-27
 
 #### Changed
@@ -165,7 +166,6 @@
 - Removed awk usage from `Get-RemoteSize`; replaced with POSIX shell arithmetic using `du`/`stat`/`find`.
 - Hardened adb quoting and timestamped warnings (including `$ts:` parse fix).
 - Inlined remote path argument to satisfy analyzers.
-
 
 ### 1.3.1 — 2025-08-27
 
@@ -175,7 +175,6 @@
 - Added timestamped warnings/retries and verify summary table (Local vs Remote counts/sizes).
 - Reduced pull progress polling to 5 seconds (configurable).
 
-
 ### 1.3.0 — 2025-08-27
 
 #### Added
@@ -183,17 +182,15 @@
 - Added `-Verify` and local/remote file-count helpers.
 - Logged local/remote summaries after TAR extraction and after pull.
 
-
 ### 1.2.x — 2025-08-27
 
 #### Added
 
 - Added disk-space precheck, resumable pull, TAR retries/cleanup, and `-StreamTar`.
 
-
 ---
-## FileDistributor
 
+## FileDistributor
 
 ### 4.8.0 — 2026-04-05
 
@@ -234,7 +231,7 @@ Addresses script-scope coupling issues that surfaced after functions were moved 
 #### Changed
 
 - Refactored `Save-DistributionState`, `Restore-DistributionState`, and `Write-JsonAtomically` in `Private/State.ps1` to accept `$StateFilePath`, `$RetryDelay`, `$RetryCount`, and `$MaxBackoff` as explicit parameters instead of reading from outer script scope. Updated checkpoint/restart call sites in `FileDistributor.ps1` accordingly.
- 
+
 #### Fixed
 
 - Fixed CP3 `New-CheckpointPayload` call in `Invoke-DistributionPhase` to include `-IncludeSourceFiles` and `-SourceFiles $RunState.sourceFiles`, preventing a restart from CP3 from silently skipping the distribution phase.

--- a/src/powershell/file-management/Copy-AndroidFiles.ps1
+++ b/src/powershell/file-management/Copy-AndroidFiles.ps1
@@ -119,7 +119,7 @@
     Android Platform-Tools: https://developer.android.com/studio/releases/platform-tools
 
 .NOTES
-    Version: 2.3.1
+    Version: 2.3.2
     See CHANGELOG.md in this directory for full version history.
 
     PREREQUISITES
@@ -193,6 +193,7 @@ param(
 
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
+Import-Module "$PSScriptRoot\..\modules\Android\AdbHelpers\AdbHelpers.psd1" -Force
 
 # Initialize logger (script name will be extracted from the script file name)
 Initialize-Logger -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
@@ -203,235 +204,6 @@ $DebugLog = $null
 if ($DebugMode) {
     $DebugLog = Join-Path ($Dest) ("adb_debug_{0}.log" -f (Get-Date -Format 'yyyyMMdd_HHmmss'))
     Write-Host "Debug mode: logging to $DebugLog"
-}
-
-function Test-Adb {
-    <#
-.SYNOPSIS
-    Verifies adb.exe is available in PATH.
-.DESCRIPTION
-    Uses Get-Command to locate 'adb'. Throws a terminating error if not found.
-.OUTPUTS
-    None. Throws on failure.
-.NOTES
-    Install Android SDK Platform-Tools and add its folder to PATH.
-#>
-    $adb = Get-Command adb -ErrorAction SilentlyContinue
-    if (-not $adb) { throw "adb.exe not found. Install Platform-Tools and add to PATH." }
-}
-
-function Confirm-Device {
-    <#
-.SYNOPSIS
-    Confirms an authorized Android device is connected.
-.DESCRIPTION
-    Runs 'adb devices' and checks for a line ending with 'device'. If the device shows 'unauthorized' or nothing, throws guidance.
-.OUTPUTS
-    None. Throws on failure.
-.NOTES
-    Ensure the phone is unlocked and USB debugging is enabled/authorized.
-#>
-    $out = adb devices | Select-String "device`$"
-    if (-not $out) {
-        throw "No authorized device. Check cable, unlock phone, enable USB debugging, and allow this PC."
-    }
-}
-
-function Test-HostTar {
-    <#
-.SYNOPSIS
-    Verifies tar.exe is available on Windows when using tar mode.
-.DESCRIPTION
-    Ensures 'tar' can be invoked from PATH; otherwise suggests switching to pull mode or installing tar.
-.OUTPUTS
-    None. Throws on failure if using tar mode.
-#>
-    if ($PSCmdlet.ParameterSetName -eq 'Tar') {
-        $tar = Get-Command tar -ErrorAction SilentlyContinue
-        if (-not $tar) {
-            throw "Windows tar.exe not found. Use pull mode (-Resume) or install tar and add to PATH."
-        }
-    }
-}
-
-function Invoke-AdbSh {
-    <#
-.SYNOPSIS
-    Runs a shell script on the device safely from PowerShell.
-.DESCRIPTION
-    - Normalizes CRLF/CR to LF
-    - Filters blank lines
-    - Joins lines with token awareness:
-        * Keeps a newline between control-structure boundaries (if/then/elif/else/fi, for/do/done,
-          while/do/done, until/do/done, case...esac) to avoid "then;" style syntax errors on toybox sh
-        * Uses "; " between ordinary statement lines
-    - Returns raw stdout (or empty string on error)
-.PARAMETER Script
-    The shell script text to execute on the device.
-.OUTPUTS
-    [string] Raw stdout from the device (may be empty if the command produces no output).
-#>
-    param([Parameter(Mandatory = $true)][string]$Script)
-
-    try {
-        # Normalize EOLs and split
-        $norm = ($Script -replace "`r`n", "`n" -replace "`r", "`n").Trim()
-        $lines = $norm -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
-
-        # Build with awareness of POSIX sh control keywords
-        $out = New-Object System.Text.StringBuilder
-        $prev = $null
-        foreach ($l in $lines) {
-            $currStartsCtl = $l -match '^(elif|fi|done|esac|then|do|else)\b'
-            $prevEndsCtl = $false
-            if ($null -ne $prev) {
-                $prevEndsCtl = $prev -match '\b(then|do|else)$'
-            }
-
-            if ($null -ne $prev) {
-                # If current starts with a control token OR previous ended with one, keep newline
-                if ($currStartsCtl -or $prevEndsCtl) {
-                    [void]$out.Append("`n")
-                } else {
-                    [void]$out.Append("; ")
-                }
-            }
-            [void]$out.Append($l)
-            $prev = $l
-        }
-
-        $one = $out.ToString()
-
-        if ($DebugMode -and $DebugLog) {
-            Add-Content -Path $DebugLog -Value ("[{0}] adb shell << {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $one)
-        }
-
-        $result = adb shell $one
-
-        if ($DebugMode -and $DebugLog) {
-            $len = if ($result) { $result.Length } else { 0 }
-            $prefix = if ($result -and $result.Length -gt 1000) { $result.Substring(0, 1000) + '…' } else { $result }
-            Add-Content -Path $DebugLog -Value ("[{0}] stdout({1} chars): {2}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $len, $prefix)
-        }
-
-        return $result
-    } catch {
-        if ($DebugMode -and $DebugLog) {
-            Add-Content -Path $DebugLog -Value ("[{0}] ERROR: {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $_)
-        }
-        return ""
-    }
-}
-
-function Test-PhoneTar {
-    <#
-.SYNOPSIS
-    Verifies phone-side tar availability for TAR mode.
-.DESCRIPTION
-    Detects tar availability on the phone.
-    Prefers `command -v tar` (accepting --help if --version is unsupported),
-    then falls back to `toybox tar` and `busybox tar`.
-.OUTPUTS
-    None. Throws on failure if using tar mode.
-#>
-    if ($PSCmdlet.ParameterSetName -ne 'Tar') { return }
-
-    $script = @'
-if command -v tar >/dev/null 2>&1; then
-  tar --help >/dev/null 2>&1 || true
-  echo 0
-elif command -v toybox >/dev/null 2>&1 && toybox tar --help >/dev/null 2>&1; then
-  echo 0
-elif command -v busybox >/dev/null 2>&1 && busybox tar --help >/dev/null 2>&1; then
-  echo 0
-else
-  echo 1
-fi
-'@
-
-    $rc = (Invoke-AdbSh $script).Trim()
-    if ([string]::IsNullOrEmpty($rc)) {
-        throw "Phone-side tar check failed (no response). Reconnect the device and try again."
-    }
-    if ($rc -ne '0') {
-        throw "Phone-side tar not found. Switch to pull mode (use -Resume instead of tar-mode parameters)."
-    }
-}
-
-function Get-RemoteSize {
-    <#
-.SYNOPSIS
-    Returns total bytes for a remote (phone) path (best-effort, awk-free).
-.DESCRIPTION
-    Prefers 'du' (native/toybox/busybox). Falls back to summing file sizes via 'stat' in a find loop.
-    Avoids awk and avoids 'sh -lc' to prevent quoting issues on toybox shells.
-    Executed via Invoke-AdbSh to avoid line-ending parsing issues on toybox/busybox shells.
-.PARAMETER RemoteParent
-    Parent directory (POSIX path), e.g., /sdcard/DCIM.
-.PARAMETER RemoteLeaf
-    Leaf entry (file or directory), e.g., Camera.
-.OUTPUTS
-    [Int64] total size in bytes (0 if unknown/error).
-.NOTES
-    This may take time on very large trees when falling back to find+stat.
-#>
-    param([string]$RemoteParent, [string]$RemoteLeaf)
-
-    $remotePath = "$RemoteParent/$RemoteLeaf"
-    # Single-quoted here-string preserved; we inject the path by placeholder replacement to avoid escaping hell.
-    $script = @'
-path="__REMOTE_PATH__"
-
-# Prefer du; parse first field with "set --" to avoid awk dependency
-if du -sb "$path" >/dev/null 2>&1; then
-  set -- $(du -sb "$path"); echo "$1"; exit 0
-fi
-if command -v toybox >/dev/null 2>&1 && toybox du -b "$path" >/dev/null 2>&1; then
-  set -- $(toybox du -b "$path"); echo "$1"; exit 0
-fi
-if command -v busybox >/dev/null 2>&1 && busybox du -s "$path" >/dev/null 2>&1; then
-  set -- $(busybox du -s "$path"); echo $(( $1 * 1024 )); exit 0
-fi
-
-# Fall back: sum file sizes with stat
-sum=0
-if command -v stat >/dev/null 2>&1; then
-  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
-    sz=$(stat -c %s "$f" 2>/dev/null || echo 0)
-    sum=$(( sum + ${sz:-0} ))
-  done
-  echo "$sum"; exit 0
-fi
-
-if command -v toybox >/dev/null 2>&1; then
-  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
-    sz=$(toybox stat -c %s "$f" 2>/dev/null || echo 0)
-    sum=$(( sum + ${sz:-0} ))
-  done
-  echo "$sum"; exit 0
-fi
-
-if command -v busybox >/dev/null 2>&1; then
-  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
-    sz=$(busybox stat -c %s "$f" 2>/dev/null || echo 0)
-    sum=$(( sum + ${sz:-0} ))
-  done
-  echo "$sum"; exit 0
-fi
-
-echo 0
-'@
-    $cmd = $script.Replace('__REMOTE_PATH__', $remotePath)
-
-    try {
-        $bytesText = Invoke-AdbSh $cmd
-        if ([string]::IsNullOrWhiteSpace($bytesText)) { return 0 }
-        $bytes = 0L
-        [void][int64]::TryParse($bytesText.Trim(), [ref]$bytes)
-        return $bytes
-    } catch {
-        return 0
-    }
 }
 
 function Get-LocalDirSize {
@@ -506,48 +278,6 @@ function Get-LocalFileCount {
     } catch { 0 }
 }
 
-function Get-RemoteFileCount {
-    <#
-.SYNOPSIS
-    Best-effort count of remote (phone) files for a given path.
-.DESCRIPTION
-    Uses find | wc -l via toybox/busybox if needed. Returns 0 if unavailable.
-    Executed via Invoke-AdbSh to avoid line-ending parsing issues on toybox/busybox shells.
-.PARAMETER RemoteParent
-    Parent directory on the device (POSIX).
-.PARAMETER RemoteLeaf
-    Leaf (file or directory) name on the device.
-.OUTPUTS
-    [Int64] count (0 if unknown).
-#>
-    param([string]$RemoteParent, [string]$RemoteLeaf)
-
-    $remotePath = "$RemoteParent/$RemoteLeaf"
-    $script = @'
-path="__REMOTE_PATH__"
-if command -v find >/dev/null 2>&1; then
-  find "$path" -type f 2>/dev/null | wc -l
-elif command -v toybox >/dev/null 2>&1; then
-  toybox find "$path" -type f 2>/dev/null | wc -l
-elif command -v busybox >/dev/null 2>&1; then
-  busybox find "$path" -type f 2>/dev/null | wc -l
-else
-  echo 0
-fi
-'@
-    $cmd = $script.Replace('__REMOTE_PATH__', $remotePath)
-
-    try {
-        $out = Invoke-AdbSh $cmd
-        if ([string]::IsNullOrWhiteSpace($out)) { return 0 }
-        $n = 0L
-        [void][int64]::TryParse($out.Trim(), [ref]$n)
-        return $n
-    } catch {
-        return 0
-    }
-}
-
 function Write-VerifySummary {
     <#
 .SYNOPSIS
@@ -580,12 +310,14 @@ function Write-VerifySummary {
         [string]$RemoteParent,
         [string]$RemoteLeaf,
         [int64]$TotalBytes,
-        [string]$WarnMessage
+        [string]$WarnMessage,
+        [switch]$DebugMode,
+        [string]$DebugLog
     )
 
     $localCount = Get-LocalFileCount  -Path $LocalRoot
     $localBytes = Get-LocalDirSize    -Path $LocalRoot
-    $remoteCount = Get-RemoteFileCount -RemoteParent $RemoteParent -RemoteLeaf $RemoteLeaf
+    $remoteCount = Get-RemoteFileCount -RemoteParent $RemoteParent -RemoteLeaf $RemoteLeaf -DebugMode:$DebugMode -DebugLog $DebugLog
     $remoteSizeMB = if ($TotalBytes -gt 0) { [math]::Round($TotalBytes / 1MB) } else { $null }
 
     $afterFiles = $localCount
@@ -661,12 +393,12 @@ New-Item -ItemType Directory -Force -Path $Dest | Out-Null
 # Pre-checks
 Test-Adb
 Confirm-Device
-Test-HostTar
-Test-PhoneTar
+Test-HostTar -Mode $PSCmdlet.ParameterSetName
+Test-PhoneTar -Mode $PSCmdlet.ParameterSetName -DebugMode:$DebugMode -DebugLog $DebugLog
 
 # Common path split & remote size (for progress/space checks)
 $parent, $leaf = Split-RemotePath -PosixPath $PhonePath
-$totalBytes = Get-RemoteSize -RemoteParent $parent -RemoteLeaf $leaf
+$totalBytes = Get-RemoteSize -RemoteParent $parent -RemoteLeaf $leaf -DebugMode:$DebugMode -DebugLog $DebugLog
 
 # Baseline local stats for Verify deltas
 # For non-resume pull, adb creates a subfolder ($leaf) under $Dest → baseline that path.
@@ -730,7 +462,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Pull') {
             Write-VerifySummary -LocalRoot $Dest `
                 -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
                 -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
-                -WarnMessage "Local file count < remote file count. Some files may be missing."
+                -WarnMessage "Local file count < remote file count. Some files may be missing." `
+                -DebugMode:$DebugMode -DebugLog $DebugLog
         }
     } else {
         Write-LogInfo "ADB pull `"$PhonePath`" → `"$Dest`""
@@ -763,7 +496,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Pull') {
             Write-VerifySummary -LocalRoot $localRootAfter `
                 -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
                 -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
-                -WarnMessage "Local file count < remote file count. Some files may be missing."
+                -WarnMessage "Local file count < remote file count. Some files may be missing." `
+                -DebugMode:$DebugMode -DebugLog $DebugLog
         }
     }
 } else {
@@ -782,7 +516,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Pull') {
             Write-VerifySummary -LocalRoot $Dest `
                 -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
                 -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
-                -WarnMessage "Extracted count < remote count. Some files may be missing."
+                -WarnMessage "Extracted count < remote count. Some files may be missing." `
+                -DebugMode:$DebugMode -DebugLog $DebugLog
         }
     } else {
         $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
@@ -825,7 +560,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Pull') {
                     Write-VerifySummary -LocalRoot $Dest `
                         -FilesBefore $LocalFilesBefore -BytesBefore $LocalBytesBefore `
                         -RemoteParent $parent -RemoteLeaf $leaf -TotalBytes $totalBytes `
-                        -WarnMessage "Extracted count < remote count. Some files may be missing."
+                        -WarnMessage "Extracted count < remote count. Some files may be missing." `
+                        -DebugMode:$DebugMode -DebugLog $DebugLog
                 }
 
                 # Cleanup

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -16,9 +16,12 @@ Scripts for file operations, distribution, copying, and archiving.
 ## Dependencies
 
 ### PowerShell Modules
+
 - **PowerShellLoggingFramework** (`src/powershell/modules/Core/Logging/`) - Structured logging
+- **AdbHelpers** (`src/powershell/modules/Android/AdbHelpers/`) - Shared ADB/device helpers used by `Copy-AndroidFiles.ps1`
 
 ### External Tools
+
 - PowerShell 5.1 or later
 - Windows API access for file handle operations
 
@@ -32,11 +35,14 @@ Scripts for file operations, distribution, copying, and archiving.
 ## Logging
 
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
+
 ## Recent Updates
 
 - **Documentation (2026-04-11)**
   - Condensed FileDistributor changelog history for the `v3.3.0–v3.5.0` and `v4.1.0–v4.5.0` feature/checkpoint eras into rollup entries.
   - Preserved the checkpoint progression summary (`CP4`/`CP5`/`CP6`/`CP7`/`CP8`) and mode-level behavior without repeating long per-version prose.
+- **Copy-AndroidFiles.ps1 v2.3.2** (2026-04-11)
+  - Extracted shared ADB helpers into the reusable `Android/AdbHelpers` module and updated `Copy-AndroidFiles.ps1` to import that module instead of carrying inline ADB helper definitions.
 - **Documentation (2026-04-10)**
   - Normalized `src/powershell/file-management/CHANGELOG.md` structure across **Copy-AndroidFiles** and **FileDistributor** sections.
   - Added a short changelog table of contents for faster navigation.

--- a/src/powershell/modules/Android/AdbHelpers/AdbHelpers.psd1
+++ b/src/powershell/modules/Android/AdbHelpers/AdbHelpers.psd1
@@ -1,0 +1,28 @@
+@{
+    RootModule        = 'AdbHelpers.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = '067f1c0e-5a83-4f49-af4f-bc293167659e'
+    Author            = 'Manoj Bhaskaran'
+    CompanyName       = 'Unknown'
+    Copyright         = '(c) 2026. All rights reserved.'
+    Description       = 'Reusable Android ADB helper functions for device validation, remote shell execution, and remote file metadata queries.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @(
+        'Confirm-Device',
+        'Get-RemoteFileCount',
+        'Get-RemoteSize',
+        'Invoke-AdbSh',
+        'Test-Adb',
+        'Test-HostTar',
+        'Test-PhoneTar'
+    )
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+    PrivateData       = @{
+        PSData = @{
+            Tags       = @('Android', 'ADB', 'Utilities', 'FileManagement')
+            ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
+        }
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/AdbHelpers.psm1
+++ b/src/powershell/modules/Android/AdbHelpers/AdbHelpers.psm1
@@ -1,0 +1,18 @@
+$privateDir = Join-Path $PSScriptRoot 'Private'
+if (Test-Path -LiteralPath $privateDir) {
+    Get-ChildItem -Path $privateDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+}
+
+$publicDir = Join-Path $PSScriptRoot 'Public'
+if (Test-Path -LiteralPath $publicDir) {
+    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+}
+
+$publicFunctions = if (Test-Path -LiteralPath $publicDir) {
+    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | Select-Object -ExpandProperty BaseName
+}
+else {
+    @()
+}
+
+Export-ModuleMember -Function $publicFunctions

--- a/src/powershell/modules/Android/AdbHelpers/Private/Invoke-AdbCommand.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Private/Invoke-AdbCommand.ps1
@@ -1,0 +1,14 @@
+function Invoke-AdbCommand {
+    <#
+.SYNOPSIS
+    Invokes adb with passthrough arguments.
+.DESCRIPTION
+    Thin wrapper around the adb executable to keep external process invocation mockable in tests.
+#>
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Arguments
+    )
+
+    & adb @Arguments
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Confirm-Device.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Confirm-Device.ps1
@@ -1,0 +1,16 @@
+function Confirm-Device {
+    <#
+.SYNOPSIS
+    Confirms an authorized Android device is connected.
+.DESCRIPTION
+    Runs 'adb devices' and checks for a line ending with 'device'. If the device shows 'unauthorized' or nothing, throws guidance.
+.OUTPUTS
+    None. Throws on failure.
+.NOTES
+    Ensure the phone is unlocked and USB debugging is enabled and authorized.
+#>
+    $out = adb devices | Select-String "device`$"
+    if (-not $out) {
+        throw 'No authorized device. Check cable, unlock phone, enable USB debugging, and allow this PC.'
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Get-RemoteFileCount.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Get-RemoteFileCount.ps1
@@ -1,0 +1,52 @@
+function Get-RemoteFileCount {
+    <#
+.SYNOPSIS
+    Returns a best-effort file count for a remote path on the device.
+.DESCRIPTION
+    Uses find and wc -l via native, toybox, or busybox commands. Uses Invoke-AdbSh to avoid device shell line-ending issues.
+.PARAMETER RemoteParent
+    Parent directory on the device.
+.PARAMETER RemoteLeaf
+    Leaf file or directory name on the device.
+.PARAMETER DebugMode
+    Enables debug logging for the remote shell probe.
+.PARAMETER DebugLog
+    Optional log file path used when DebugMode is enabled.
+.OUTPUTS
+    [Int64] file count (0 if unavailable).
+#>
+    param(
+        [string]$RemoteParent,
+        [string]$RemoteLeaf,
+        [switch]$DebugMode,
+        [string]$DebugLog
+    )
+
+    $remotePath = "$RemoteParent/$RemoteLeaf"
+    $script = @'
+path="__REMOTE_PATH__"
+if command -v find >/dev/null 2>&1; then
+  find "$path" -type f 2>/dev/null | wc -l
+elif command -v toybox >/dev/null 2>&1; then
+  toybox find "$path" -type f 2>/dev/null | wc -l
+elif command -v busybox >/dev/null 2>&1; then
+  busybox find "$path" -type f 2>/dev/null | wc -l
+else
+  echo 0
+fi
+'@
+    $cmd = $script.Replace('__REMOTE_PATH__', $remotePath)
+
+    try {
+        $out = Invoke-AdbSh -Script $cmd -DebugMode:$DebugMode -DebugLog $DebugLog
+        if ([string]::IsNullOrWhiteSpace($out)) {
+            return 0
+        }
+
+        $count = 0L
+        [void][int64]::TryParse($out.Trim(), [ref]$count)
+        return $count
+    } catch {
+        return 0
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Get-RemoteSize.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Get-RemoteSize.ps1
@@ -1,0 +1,80 @@
+function Get-RemoteSize {
+    <#
+.SYNOPSIS
+    Returns total bytes for a remote path on the device.
+.DESCRIPTION
+    Prefers du, then falls back to summing file sizes via stat in a find loop. Uses Invoke-AdbSh to avoid device shell line-ending issues.
+.PARAMETER RemoteParent
+    Parent directory on the device.
+.PARAMETER RemoteLeaf
+    Leaf file or directory name on the device.
+.PARAMETER DebugMode
+    Enables debug logging for the remote shell probe.
+.PARAMETER DebugLog
+    Optional log file path used when DebugMode is enabled.
+.OUTPUTS
+    [Int64] total size in bytes (0 if unavailable).
+#>
+    param(
+        [string]$RemoteParent,
+        [string]$RemoteLeaf,
+        [switch]$DebugMode,
+        [string]$DebugLog
+    )
+
+    $remotePath = "$RemoteParent/$RemoteLeaf"
+    $script = @'
+path="__REMOTE_PATH__"
+
+if du -sb "$path" >/dev/null 2>&1; then
+  set -- $(du -sb "$path"); echo "$1"; exit 0
+fi
+if command -v toybox >/dev/null 2>&1 && toybox du -b "$path" >/dev/null 2>&1; then
+  set -- $(toybox du -b "$path"); echo "$1"; exit 0
+fi
+if command -v busybox >/dev/null 2>&1 && busybox du -s "$path" >/dev/null 2>&1; then
+  set -- $(busybox du -s "$path"); echo $(( $1 * 1024 )); exit 0
+fi
+
+sum=0
+if command -v stat >/dev/null 2>&1; then
+  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    sz=$(stat -c %s "$f" 2>/dev/null || echo 0)
+    sum=$(( sum + ${sz:-0} ))
+  done
+  echo "$sum"; exit 0
+fi
+
+if command -v toybox >/dev/null 2>&1; then
+  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    sz=$(toybox stat -c %s "$f" 2>/dev/null || echo 0)
+    sum=$(( sum + ${sz:-0} ))
+  done
+  echo "$sum"; exit 0
+fi
+
+if command -v busybox >/dev/null 2>&1; then
+  find "$path" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    sz=$(busybox stat -c %s "$f" 2>/dev/null || echo 0)
+    sum=$(( sum + ${sz:-0} ))
+  done
+  echo "$sum"; exit 0
+fi
+
+echo 0
+'@
+    $cmd = $script.Replace('__REMOTE_PATH__', $remotePath)
+
+    try {
+        $bytesText = Invoke-AdbSh -Script $cmd -DebugMode:$DebugMode -DebugLog $DebugLog
+        if ([string]::IsNullOrWhiteSpace($bytesText)) {
+            return 0
+        }
+
+        $bytes = 0L
+        [void][int64]::TryParse($bytesText.Trim(), [ref]$bytes)
+        return $bytes
+    } catch {
+        return 0
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Invoke-AdbSh.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Invoke-AdbSh.ps1
@@ -53,7 +53,7 @@ function Invoke-AdbSh {
             Add-Content -Path $DebugLog -Value ("[{0}] adb shell << {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $one)
         }
 
-        $result = adb shell $one
+        $result = Invoke-AdbCommand shell $one
 
         if ($DebugMode -and $DebugLog) {
             $len = if ($result) { $result.Length } else { 0 }

--- a/src/powershell/modules/Android/AdbHelpers/Public/Invoke-AdbSh.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Invoke-AdbSh.ps1
@@ -1,0 +1,72 @@
+function Invoke-AdbSh {
+    <#
+.SYNOPSIS
+    Runs a shell script on the device safely from PowerShell.
+.DESCRIPTION
+    Normalizes line endings, filters blank lines, joins ordinary statements with '; ', and preserves newlines at POSIX shell control boundaries.
+.PARAMETER Script
+    The shell script text to execute on the device.
+.PARAMETER DebugMode
+    Enables lightweight debug logging of the generated shell command and stdout prefix.
+.PARAMETER DebugLog
+    Optional log file path used when DebugMode is enabled.
+.OUTPUTS
+    [string] Raw stdout from the device, or an empty string on error.
+#>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Script,
+
+        [switch]$DebugMode,
+
+        [string]$DebugLog
+    )
+
+    try {
+        $norm = ($Script -replace "`r`n", "`n" -replace "`r", "`n").Trim()
+        $lines = $norm -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+
+        $out = New-Object System.Text.StringBuilder
+        $prev = $null
+        foreach ($line in $lines) {
+            $currStartsCtl = $line -match '^(elif|fi|done|esac|then|do|else)\b'
+            $prevEndsCtl = $false
+            if ($null -ne $prev) {
+                $prevEndsCtl = $prev -match '\b(then|do|else)$'
+            }
+
+            if ($null -ne $prev) {
+                if ($currStartsCtl -or $prevEndsCtl) {
+                    [void]$out.Append("`n")
+                } else {
+                    [void]$out.Append('; ')
+                }
+            }
+
+            [void]$out.Append($line)
+            $prev = $line
+        }
+
+        $one = $out.ToString()
+
+        if ($DebugMode -and $DebugLog) {
+            Add-Content -Path $DebugLog -Value ("[{0}] adb shell << {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $one)
+        }
+
+        $result = adb shell $one
+
+        if ($DebugMode -and $DebugLog) {
+            $len = if ($result) { $result.Length } else { 0 }
+            $prefix = if ($result -and $result.Length -gt 1000) { $result.Substring(0, 1000) + '...' } else { $result }
+            Add-Content -Path $DebugLog -Value ("[{0}] stdout({1} chars): {2}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $len, $prefix)
+        }
+
+        return $result
+    } catch {
+        if ($DebugMode -and $DebugLog) {
+            Add-Content -Path $DebugLog -Value ("[{0}] ERROR: {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $_)
+        }
+
+        return ''
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Test-Adb.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Test-Adb.ps1
@@ -1,0 +1,16 @@
+function Test-Adb {
+    <#
+.SYNOPSIS
+    Verifies adb.exe is available in PATH.
+.DESCRIPTION
+    Uses Get-Command to locate 'adb'. Throws a terminating error if not found.
+.OUTPUTS
+    None. Throws on failure.
+.NOTES
+    Install Android SDK Platform-Tools and add its folder to PATH.
+#>
+    $adb = Get-Command adb -ErrorAction SilentlyContinue
+    if (-not $adb) {
+        throw 'adb.exe not found. Install Platform-Tools and add to PATH.'
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Test-HostTar.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Test-HostTar.ps1
@@ -1,0 +1,23 @@
+function Test-HostTar {
+    <#
+.SYNOPSIS
+    Verifies tar.exe is available on the host when using tar mode.
+.PARAMETER Mode
+    Transfer mode. When not Tar, the check is skipped.
+.OUTPUTS
+    None. Throws on failure if tar mode is requested and tar is unavailable.
+#>
+    param(
+        [ValidateSet('Pull', 'Tar')]
+        [string]$Mode = 'Tar'
+    )
+
+    if ($Mode -ne 'Tar') {
+        return
+    }
+
+    $tar = Get-Command tar -ErrorAction SilentlyContinue
+    if (-not $tar) {
+        throw 'Windows tar.exe not found. Use pull mode (-Resume) or install tar and add to PATH.'
+    }
+}

--- a/src/powershell/modules/Android/AdbHelpers/Public/Test-PhoneTar.ps1
+++ b/src/powershell/modules/Android/AdbHelpers/Public/Test-PhoneTar.ps1
@@ -1,0 +1,48 @@
+function Test-PhoneTar {
+    <#
+.SYNOPSIS
+    Verifies phone-side tar availability for tar mode.
+.PARAMETER Mode
+    Transfer mode. When not Tar, the check is skipped.
+.PARAMETER DebugMode
+    Enables debug logging for the remote shell probe.
+.PARAMETER DebugLog
+    Optional log file path used when DebugMode is enabled.
+.OUTPUTS
+    None. Throws on failure if tar mode is requested and tar is unavailable on the device.
+#>
+    param(
+        [ValidateSet('Pull', 'Tar')]
+        [string]$Mode = 'Tar',
+
+        [switch]$DebugMode,
+
+        [string]$DebugLog
+    )
+
+    if ($Mode -ne 'Tar') {
+        return
+    }
+
+    $script = @'
+if command -v tar >/dev/null 2>&1; then
+  tar --help >/dev/null 2>&1 || true
+  echo 0
+elif command -v toybox >/dev/null 2>&1 && toybox tar --help >/dev/null 2>&1; then
+  echo 0
+elif command -v busybox >/dev/null 2>&1 && busybox tar --help >/dev/null 2>&1; then
+  echo 0
+else
+  echo 1
+fi
+'@
+
+    $rc = (Invoke-AdbSh -Script $script -DebugMode:$DebugMode -DebugLog $DebugLog).Trim()
+    if ([string]::IsNullOrEmpty($rc)) {
+        throw 'Phone-side tar check failed (no response). Reconnect the device and try again.'
+    }
+
+    if ($rc -ne '0') {
+        throw 'Phone-side tar not found. Switch to pull mode (use -Resume instead of tar-mode parameters).'
+    }
+}

--- a/src/powershell/modules/README.md
+++ b/src/powershell/modules/README.md
@@ -7,9 +7,11 @@ Reusable PowerShell modules organized by functional category.
 Modules are organized into the following categories:
 
 ### Core Modules (`Core/`)
+
 Fundamental modules used across multiple scripts:
 
 #### Logging (`Core/Logging/`)
+
 - **PowerShellLoggingFramework** - Cross-platform structured logging framework
   - Multiple log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   - JSON output support
@@ -23,9 +25,11 @@ Fundamental modules used across multiple scripts:
   - Integration with PowerShellLoggingFramework
 
 ### Database Modules (`Database/`)
+
 Database-related functionality:
 
 #### PostgresBackup (`Database/PostgresBackup/`)
+
 - PostgreSQL database backup automation
 - Retention management
 - Service control integration
@@ -33,23 +37,38 @@ Database-related functionality:
 - Compression support
 
 ### Utility Modules (`Utilities/`)
+
 General-purpose utility modules:
 
 #### RandomName (`Utilities/RandomName/`)
+
 - Generates Windows-safe random file names
 - Conservative character allow-list
 - Collision detection
 - Configurable length and format
 
 ### Media Modules (`Media/`)
+
 Media processing functionality:
 
 #### Videoscreenshot (`Media/Videoscreenshot/`)
+
 - Video frame capture via VLC or GDI+
 - Batch processing support
 - Optional Python cropper integration
 - PID registry for process management
 - Configurable capture intervals
+
+### Android Modules (`Android/`)
+
+Android device integration helpers:
+
+#### AdbHelpers (`Android/AdbHelpers/`)
+
+- Shared Android Debug Bridge (ADB) validation helpers
+- Remote shell execution with safe POSIX control-structure flattening
+- Remote file count and size probes for Android device paths
+- Reusable tar capability checks for host and device workflows
 
 ## Module Deployment
 
@@ -60,6 +79,7 @@ Configuration file: `config/modules/deployment.txt`
 ### Deployment Targets
 
 Modules can be deployed to:
+
 - **System**: `C:\Program Files\WindowsPowerShell\Modules\`
 - **User**: `%USERPROFILE%\Documents\WindowsPowerShell\Modules\`
 - **Custom**: Alternate paths as configured
@@ -82,6 +102,7 @@ Import-Module "$PSScriptRoot\modules\Core\Logging\PowerShellLoggingFramework.psm
 ### Directory Structure
 
 Each module should follow PowerShell module conventions:
+
 ```
 ModuleName/
 ├── ModuleName.psm1      # Module script file

--- a/testResults.xml
+++ b/testResults.xml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="10" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2026-04-11" time="13:43:48">
+  <environment user-domain="LENOVOLAPTOP" clr-version="10.0.5" nunit-version="2.5.8.0" user="manoj" os-version="10.0.26200" machine-name="LENOVOLAPTOP" cwd="D:\My Scripts" platform="Microsoft Windows 11 Pro|C:\WINDOWS|\Device\Harddisk1\Partition3" />
+  <culture-info current-culture="en-IN" current-uiculture="en-GB" />
+  <test-suite type="TestFixture" name="Pester" executed="True" result="Success" success="True" time="6.1954" asserts="0" description="Pester">
+    <results>
+      <test-suite type="TestFixture" name="D:\My Scripts\tests\powershell\unit\AdbHelpers.Tests.ps1" executed="True" result="Success" success="True" time="6.1954" asserts="0" description="D:\My Scripts\tests\powershell\unit\AdbHelpers.Tests.ps1">
+        <results>
+          <test-suite type="TestFixture" name="AdbHelpers module exports" executed="True" result="Success" success="True" time="1.0215" asserts="0" description="AdbHelpers module exports">
+            <results>
+              <test-case description="exports the expected public commands" name="AdbHelpers module exports.exports the expected public commands" time="0.733" asserts="0" success="True" result="Success" executed="True" />
+            </results>
+          </test-suite>
+          <test-suite type="TestFixture" name="Test-HostTar" executed="True" result="Success" success="True" time="2.1708" asserts="0" description="Test-HostTar">
+            <results>
+              <test-case description="skips tar lookup in pull mode" name="Test-HostTar.skips tar lookup in pull mode" time="0.5279" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="throws when tar is unavailable in tar mode" name="Test-HostTar.throws when tar is unavailable in tar mode" time="0.6132" asserts="0" success="True" result="Success" executed="True" />
+            </results>
+          </test-suite>
+          <test-suite type="TestFixture" name="Test-PhoneTar" executed="True" result="Success" success="True" time="2.5164" asserts="0" description="Test-PhoneTar">
+            <results>
+              <test-case description="skips the adb probe in pull mode" name="Test-PhoneTar.skips the adb probe in pull mode" time="0.0546" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="passes debug parameters through to Invoke-AdbSh" name="Test-PhoneTar.passes debug parameters through to Invoke-AdbSh" time="0.2796" asserts="0" success="True" result="Success" executed="True" />
+            </results>
+          </test-suite>
+          <test-suite type="TestFixture" name="Invoke-AdbSh" executed="True" result="Success" success="True" time="3.179" asserts="0" description="Invoke-AdbSh">
+            <results>
+              <test-case description="preserves control-structure newlines when flattening the shell script" name="Invoke-AdbSh.preserves control-structure newlines when flattening the shell script" time="0.3672" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="writes debug log entries when debug logging is enabled" name="Invoke-AdbSh.writes debug log entries when debug logging is enabled" time="0.285" asserts="0" success="True" result="Success" executed="True" />
+            </results>
+          </test-suite>
+          <test-suite type="TestFixture" name="Remote metadata helpers" executed="True" result="Success" success="True" time="3.4427" asserts="0" description="Remote metadata helpers">
+            <results>
+              <test-case description="parses the remote byte count from Invoke-AdbSh output" name="Remote metadata helpers.parses the remote byte count from Invoke-AdbSh output" time="0.1054" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="returns zero for blank remote byte output" name="Remote metadata helpers.returns zero for blank remote byte output" time="0.0646" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="parses the remote file count from Invoke-AdbSh output" name="Remote metadata helpers.parses the remote file count from Invoke-AdbSh output" time="0.0796" asserts="0" success="True" result="Success" executed="True" />
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/tests/powershell/unit/AdbHelpers.Tests.ps1
+++ b/tests/powershell/unit/AdbHelpers.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Invoke-AdbSh' {
     }
 
     It 'preserves control-structure newlines when flattening the shell script' {
-        Mock adb {
+        Mock Invoke-AdbCommand {
             param([Parameter(ValueFromRemainingArguments = $true)] $Arguments)
             $script:lastAdbArgs = $Arguments
             'ok'
@@ -68,7 +68,7 @@ Describe 'Invoke-AdbSh' {
     }
 
     It 'writes debug log entries when debug logging is enabled' {
-        Mock adb { 'payload' } -ModuleName AdbHelpers
+        Mock Invoke-AdbCommand { 'payload' } -ModuleName AdbHelpers
         Mock Add-Content { } -ModuleName AdbHelpers -ParameterFilter { $Path -eq 'TestDrive:/adb-debug.log' }
 
         Invoke-AdbSh -Script 'echo hi' -DebugMode -DebugLog 'TestDrive:/adb-debug.log' | Out-Null

--- a/tests/powershell/unit/AdbHelpers.Tests.ps1
+++ b/tests/powershell/unit/AdbHelpers.Tests.ps1
@@ -1,0 +1,104 @@
+BeforeAll {
+    $script:modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'modules' 'Android' 'AdbHelpers' 'AdbHelpers.psd1'
+    Import-Module $script:modulePath -Force
+}
+
+Describe 'AdbHelpers module exports' {
+    It 'exports the expected public commands' {
+        $commands = Get-Command -Module AdbHelpers
+
+        $commands.Name | Should -Contain 'Confirm-Device'
+        $commands.Name | Should -Contain 'Get-RemoteFileCount'
+        $commands.Name | Should -Contain 'Get-RemoteSize'
+        $commands.Name | Should -Contain 'Invoke-AdbSh'
+        $commands.Name | Should -Contain 'Test-Adb'
+        $commands.Name | Should -Contain 'Test-HostTar'
+        $commands.Name | Should -Contain 'Test-PhoneTar'
+    }
+}
+
+Describe 'Test-HostTar' {
+    It 'skips tar lookup in pull mode' {
+        Mock Get-Command { throw 'tar lookup should not run in pull mode' } -ModuleName AdbHelpers -ParameterFilter { $Name -eq 'tar' }
+
+        { Test-HostTar -Mode Pull } | Should -Not -Throw
+        Should -Invoke Get-Command -ModuleName AdbHelpers -Times 0 -Exactly -ParameterFilter { $Name -eq 'tar' }
+    }
+
+    It 'throws when tar is unavailable in tar mode' {
+        Mock Get-Command { $null } -ModuleName AdbHelpers -ParameterFilter { $Name -eq 'tar' }
+
+        { Test-HostTar -Mode Tar } | Should -Throw '*Windows tar.exe not found*'
+    }
+}
+
+Describe 'Test-PhoneTar' {
+    It 'skips the adb probe in pull mode' {
+        Mock Invoke-AdbSh { throw 'adb probe should not run in pull mode' } -ModuleName AdbHelpers
+
+        { Test-PhoneTar -Mode Pull } | Should -Not -Throw
+        Should -Invoke Invoke-AdbSh -ModuleName AdbHelpers -Times 0 -Exactly
+    }
+
+    It 'passes debug parameters through to Invoke-AdbSh' {
+        Mock Invoke-AdbSh { '0' } -ModuleName AdbHelpers -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+
+        { Test-PhoneTar -Mode Tar -DebugMode -DebugLog 'TestDrive:/adb-debug.log' } | Should -Not -Throw
+        Should -Invoke Invoke-AdbSh -ModuleName AdbHelpers -Times 1 -Exactly -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+    }
+}
+
+Describe 'Invoke-AdbSh' {
+    BeforeEach {
+        $script:lastAdbArgs = $null
+    }
+
+    It 'preserves control-structure newlines when flattening the shell script' {
+        Mock adb {
+            param([Parameter(ValueFromRemainingArguments = $true)] $Arguments)
+            $script:lastAdbArgs = $Arguments
+            'ok'
+        } -ModuleName AdbHelpers
+
+        $result = Invoke-AdbSh -Script "if true`nthen`necho hi`nfi"
+
+        $result | Should -Be 'ok'
+        $script:lastAdbArgs[0] | Should -Be 'shell'
+        $script:lastAdbArgs[1] | Should -Be "if true`nthen`necho hi`nfi"
+    }
+
+    It 'writes debug log entries when debug logging is enabled' {
+        Mock adb { 'payload' } -ModuleName AdbHelpers
+        Mock Add-Content { } -ModuleName AdbHelpers -ParameterFilter { $Path -eq 'TestDrive:/adb-debug.log' }
+
+        Invoke-AdbSh -Script 'echo hi' -DebugMode -DebugLog 'TestDrive:/adb-debug.log' | Out-Null
+
+        Should -Invoke Add-Content -ModuleName AdbHelpers -Times 2 -ParameterFilter { $Path -eq 'TestDrive:/adb-debug.log' }
+    }
+}
+
+Describe 'Remote metadata helpers' {
+    It 'parses the remote byte count from Invoke-AdbSh output' {
+        Mock Invoke-AdbSh { "4096`n" } -ModuleName AdbHelpers -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+
+        $result = Get-RemoteSize -RemoteParent '/sdcard' -RemoteLeaf 'DCIM' -DebugMode -DebugLog 'TestDrive:/adb-debug.log'
+
+        $result | Should -Be 4096
+        Should -Invoke Invoke-AdbSh -ModuleName AdbHelpers -Times 1 -Exactly -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+    }
+
+    It 'returns zero for blank remote byte output' {
+        Mock Invoke-AdbSh { '' } -ModuleName AdbHelpers
+
+        Get-RemoteSize -RemoteParent '/sdcard' -RemoteLeaf 'DCIM' | Should -Be 0
+    }
+
+    It 'parses the remote file count from Invoke-AdbSh output' {
+        Mock Invoke-AdbSh { "27`n" } -ModuleName AdbHelpers -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+
+        $result = Get-RemoteFileCount -RemoteParent '/sdcard' -RemoteLeaf 'DCIM' -DebugMode -DebugLog 'TestDrive:/adb-debug.log'
+
+        $result | Should -Be 27
+        Should -Invoke Invoke-AdbSh -ModuleName AdbHelpers -Times 1 -Exactly -ParameterFilter { $DebugMode -and $DebugLog -eq 'TestDrive:/adb-debug.log' }
+    }
+}


### PR DESCRIPTION
- Added `AdbHelpers` module for reusable Android Debug Bridge (ADB) functions.
- Implemented core functions: `Confirm-Device`, `Get-RemoteFileCount`, `Get-RemoteSize`, `Invoke-AdbSh`, `Test-Adb`, `Test-HostTar`, and `Test-PhoneTar`.
- Updated `README.md` files to include new module and dependencies.
- Created unit tests for the new module, ensuring functionality and error handling.
- Generated test results XML for Pester tests.