### PR TITLE
Refactor Get-BestReceiver to module-private scope and improve error handling

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -192,6 +192,19 @@
 
 ## FileDistributor
 
+### 4.8.1 — 2026-04-11
+
+#### Changed
+
+- Moved `Get-BestReceiver` helper out of the nested function definition inside `Invoke-FolderRebalance`
+  and into module-private scope (`Private/Distribution.ps1`), alongside the other distribution
+  helpers. The function is no longer re-defined on every call to `Invoke-FolderRebalance` and can
+  now be unit-tested in isolation.
+- Changed `Remove-Item -Path $StateFilePath -Force` in `Invoke-PostRunCleanup` to use
+  `-LiteralPath` and `-ErrorAction SilentlyContinue` so a missing or already-removed state file
+  no longer emits a spurious non-terminating error on clean first runs.
+- Bumped `FileDistributor` module version to `1.2.1`.
+
 ### 4.8.0 — 2026-04-05
 
 #### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.8.0
+ 4.8.1
 
  CHANGELOG:
    See CHANGELOG.md in this directory for full release history.
@@ -226,7 +226,7 @@ To display the script's help text:
 .\FileDistributor.ps1 -Help
 
 .NOTES
-Version: 4.8.0 (2026-04-05).
+Version: 4.8.1 (2026-04-11).
 
 For full release history (including v4.7.1 and v4.7.2), see:
 - ./CHANGELOG.md (FileDistributor section)
@@ -388,7 +388,7 @@ if ($Help) {
 }
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.0"
+$script:Version = "4.8.1"
 $script:Warnings = 0
 $script:Errors = 0
 

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.0'
+    ModuleVersion     = '1.2.1'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/Distribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/Distribution.ps1
@@ -72,6 +72,17 @@ function Get-SubfolderFileCounts {
     return $folderCounts
 }
 
+function Get-BestReceiver([hashtable]$map) {
+    if ($map.Keys.Count -eq 0) { return $null }
+    $bestKey = $null; $bestVal = -1
+    foreach ($k in $map.Keys) {
+        $v = [int]$map[$k]
+        if ($v -gt $bestVal) { $bestVal = $v; $bestKey = $k }
+    }
+    if ($bestVal -le 0) { return $null }
+    return $bestKey
+}
+
 function Write-DistributionSummary {
     param(
         [Parameter(Mandatory)][hashtable]$FolderCounts,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderRebalance.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderRebalance.ps1
@@ -113,17 +113,6 @@ function Invoke-FolderRebalance {
     $receiverMap = @{}
     foreach ($r in $receivers) { $receiverMap[$r.Path] = [int]$r.Deficit }
 
-    function Get-BestReceiver([hashtable]$map) {
-        if ($map.Keys.Count -eq 0) { return $null }
-        $bestKey = $null; $bestVal = -1
-        foreach ($k in $map.Keys) {
-            $v = [int]$map[$k]
-            if ($v -gt $bestVal) { $bestVal = $v; $bestKey = $k }
-        }
-        if ($bestVal -le 0) { return $null }
-        return $bestKey
-    }
-
     $GlobalFileCounter.Value = 0
     $totalMoved = 0
     $totalFailed = 0

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostRunCleanup.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostRunCleanup.ps1
@@ -44,7 +44,7 @@ function Invoke-PostRunCleanup {
     Write-LogInfo "Total errors: $($ErrorCount.Value)"
 
     if ($FileLockRef.Value) { Unlock-DistributionStateFile -FileStream $FileLockRef.Value; $FileLockRef.Value = $null }
-    Remove-Item -Path $StateFilePath -Force
+    Remove-Item -LiteralPath $StateFilePath -Force -ErrorAction SilentlyContinue
 
     if ($CleanupDuplicates -and $ScriptRoot) {
         $dupScript = Join-Path -Path $ScriptRoot -ChildPath "Remove-DuplicateFiles.ps1"


### PR DESCRIPTION
## Summary
This PR refactors the `Get-BestReceiver` helper function out of the nested scope within `Invoke-FolderRebalance` and into module-private scope, improving testability and code organization. Additionally, error handling in the cleanup routine is improved to prevent spurious errors on clean first runs.

## Key Changes

- **Moved `Get-BestReceiver` to module-private scope**: Extracted the helper function from its nested definition inside `Invoke-FolderRebalance` and relocated it to `Private/Distribution.ps1` alongside other distribution helpers. This eliminates redundant re-definition on every call and enables unit testing in isolation.

- **Improved error handling in `Invoke-PostRunCleanup`**: Changed `Remove-Item -Path $StateFilePath -Force` to use `-LiteralPath` and `-ErrorAction SilentlyContinue`, preventing spurious non-terminating errors when the state file is missing or already removed on clean first runs.

- **Version bumps**: Updated FileDistributor module version from `1.2.0` to `1.2.1` and script version from `4.8.0` to `4.8.1` (dated 2026-04-11).

## Implementation Details

The `Get-BestReceiver` function finds the key with the highest value in a hashtable, returning `null` if the map is empty or all values are non-positive. By moving it to module-private scope, it becomes a reusable utility function that can be independently tested and potentially used by other distribution functions in the future.

The error handling improvement uses `-LiteralPath` instead of `-Path` for more precise path handling and `-ErrorAction SilentlyContinue` to suppress expected errors when the state file doesn't exist, resulting in cleaner output on initial runs.

https://claude.ai/code/session_01S7saGGrpfLgxUT4Qm8LTDF