### PR TITLE
feat(cloud): extract privilege checks and optimize discovery prefetch

### DIFF
--- a/src/python/cloud/CHANGELOG.md
+++ b/src/python/cloud/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.17.0] - 2026-04-11
+
+### Changed
+
+- **Issue #856:** Extracted dry-run privilege checks from `gdrive_recover.py` into new `gdrive_privileges.py` with `DrivePrivilegeChecker`.
+  - `DriveTrashRecoveryTool` now delegates `_check_privileges`, `_check_untrash_privilege`, `_check_download_privilege`, `_check_trash_delete_privileges`, and `_test_operation_privileges` through `self.privileges`.
+- Added server-side `modifiedTime >` clause to Drive discovery query when `--after-date` is set, while keeping client-side filtering as a guard.
+- Improved target download-path collision handling by switching from iterative `exists()` probing to a single collision fallback using a short UUID suffix.
+- Aligned `DEFAULT_WORKERS` with documented guidance by setting it to `min(8, (os.cpu_count() or 1) * 2)`.
+- `RecoveryItem.post_restore_action` now defaults via `PostRestorePolicy.TRASH`.
+
+### Fixed
+
+- Prevented unnecessary duplicate file-ID prefetch API calls by reusing existing prefetch caches when metadata has already been collected.
+- Added explicit warning when `--clear-id-cache` is enabled to clarify that metadata will be re-fetched in discovery/streaming phases.
+
 ## [1.16.0] - 2026-04-11
 
 ### Changed

--- a/src/python/cloud/README.md
+++ b/src/python/cloud/README.md
@@ -14,6 +14,7 @@ Python scripts for cloud service integration, primarily Google Drive operations.
 - **gdrive_discovery.py** - Discovery and trashed file resolution helpers extracted from gdrive_recover.py (issue #791)
 - **gdrive_download.py** - File download subsystem (chunked streaming, atomic placement, Windows/OneDrive retry, partial cleanup) extracted from gdrive_recover.py (issue #853)
 - **gdrive_operations.py** - Recovery and post-restore execution helpers extracted from gdrive_recover.py (issue #854)
+- **gdrive_privileges.py** - Dry-run privilege-check subsystem (Drive capability checks and local-writability checks) extracted from gdrive_recover.py (issue #856)
 - **gdrive_report.py** - Recovery reporting/presentation layer (dry-run plan output, progress, and summaries) extracted from gdrive_recover.py (issue #855)
 - **gdrive_retry.py** - Shared retry/backoff utility used across recovery/discovery operations
 - **google_drive_root_files_delete.py** - Cleans up files in Google Drive root directory
@@ -130,6 +131,9 @@ All scripts use the Python Logging Framework located in `src/python/modules/logg
 - `gdrive_operations.py` owns per-item recovery execution (`_recover_file`, `_apply_post_restore_policy`, and `_process_item`) plus post-restore helper logic.
   - Exposes `DriveOperations`; used by `DriveTrashRecoveryTool` via `self.ops`.
   - `DriveOperations` holds no reference to `DriveTrashRecoveryTool`; all dependencies (`args`, `logger`, `auth`, `downloader`, `state_manager`, `stats`, `stats_lock`) are injected at construction time.
+- `gdrive_privileges.py` owns dry-run privilege checking concerns (`_check_privileges`, `_check_untrash_privilege`, `_check_download_privilege`, `_check_trash_delete_privileges`, `_test_operation_privileges`, `_get_file_info`).
+  - Exposes `DrivePrivilegeChecker`; used by `DriveTrashRecoveryTool` via `self.privileges`.
+  - `DrivePrivilegeChecker` receives auth, execute function, logger, and item list via dependency injection; it has no back-reference to `DriveTrashRecoveryTool`.
 - `gdrive_report.py` owns user-facing presentation for recovery and dry-run paths.
   - Exposes `RecoveryReporter`; used by `DriveTrashRecoveryTool` via `self.reporter`.
   - `RecoveryReporter` formats symbols/messages, plan rendering, progress lines, and execution summary output while honoring `--no-emoji`.

--- a/src/python/cloud/gdrive_constants.py
+++ b/src/python/cloud/gdrive_constants.py
@@ -12,7 +12,7 @@ import os
 # ---------------------------------------------------------------------------
 # Version
 # ---------------------------------------------------------------------------
-VERSION = "1.16.0"
+VERSION = "1.17.0"
 
 # ---------------------------------------------------------------------------
 # API / OAuth
@@ -28,7 +28,7 @@ DEFAULT_PROCESS_BATCH = 500
 MAX_RETRIES = 3
 RETRY_DELAY = 2  # seconds
 PAGE_SIZE = 1000
-DEFAULT_WORKERS = 5
+DEFAULT_WORKERS = min(8, (os.cpu_count() or 1) * 2)
 INFERRED_MODIFY_ERROR = "Cannot modify file (inferred from untrash check)"
 
 # ---------------------------------------------------------------------------

--- a/src/python/cloud/gdrive_discovery.py
+++ b/src/python/cloud/gdrive_discovery.py
@@ -113,7 +113,7 @@ class DriveTrashDiscovery:
                 return True
         return False
 
-    def _matches_time_filter(self, item_data: Dict[str, Any]) -> bool:
+    def _matches_time_filter(self, item_data: Mapping[str, Any]) -> bool:
         if not self.args.after_date:
             return True
         try:
@@ -289,6 +289,16 @@ class DriveTrashDiscovery:
         for fid in fids:
             if self._should_skip_invalid_id(fid, buckets):
                 continue
+            cached = self._classify_prefetched_id(
+                fid,
+                buckets,
+                transient_errors,
+                transient_ids,
+                skipped_non_trashed,
+                err_count,
+            )
+            if cached:
+                continue
             self._fetch_and_handle_metadata(
                 service,
                 fid,
@@ -307,6 +317,34 @@ class DriveTrashDiscovery:
             skipped_non_trashed[0],
             err_count[0],
         )
+
+    def _classify_prefetched_id(
+        self,
+        fid: str,
+        buckets: Dict[str, List[str]],
+        transient_errors: List[int],
+        transient_ids: List[str],
+        skipped_non_trashed: List[int],
+        err_count: List[int],
+    ) -> bool:
+        if fid in self._id_prefetch_errors:
+            err = self._id_prefetch_errors[fid]
+            if err == HTTP_404_LABEL:
+                buckets["not_found"].append(fid)
+            elif err == HTTP_403_LABEL:
+                buckets["no_access"].append(fid)
+            else:
+                transient_errors[0] += 1
+                transient_ids.append(fid)
+                err_count[0] += 1
+            return True
+        if self._id_prefetch_non_trashed.get(fid, False):
+            skipped_non_trashed[0] += 1
+            return True
+        if fid in self._id_prefetch:
+            buckets["ok"].append(fid)
+            return True
+        return False
 
     def _emit_parity_metrics(
         self, buckets: Dict[str, List[str]], skipped_non_trashed: int, err_count: int
@@ -364,6 +402,9 @@ class DriveTrashDiscovery:
                 )
                 return False
         if getattr(self.args, "clear_id_cache", False):
+            self._print_warn(
+                "--clear-id-cache enabled: metadata cache will be cleared and IDs re-fetched during discovery/streaming."
+            )
             self._clear_id_caches()
         return self._report_validation_outcome(buckets, transient_errors, transient_ids)
 
@@ -388,8 +429,9 @@ class DriveTrashDiscovery:
                 base_query += f" and {extensions_query}"
 
         if self.args.after_date:
-            self.logger.warning(
-                "Time-based filtering (--after-date) will be applied client-side due to Drive API limitations"
+            base_query += f" and modifiedTime > '{self.args.after_date}'"
+            self.logger.info(
+                "Time-based filtering (--after-date) is applied server-side and revalidated client-side as a safety guard"
             )
 
         return base_query
@@ -401,8 +443,13 @@ class DriveTrashDiscovery:
         if not self._matches_time_filter(file_data):
             return None
 
+        file_id = file_data.get("id")
+        if not file_id:
+            self.logger.debug("Skipping file metadata without id: %s", file_data)
+            return None
+
         item = RecoveryItem(
-            id=file_data["id"],
+            id=str(file_id),
             name=file_data.get("name", "Unknown"),
             size=int(file_data.get("size", 0)),
             mime_type=file_data.get("mimeType", ""),
@@ -563,6 +610,8 @@ class DriveTrashDiscovery:
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """Fetch one Drive files.list page for discovery paths."""
         service = self.auth._get_service()
+        if service is None:
+            raise RuntimeError("Drive service not initialized")
         fields = self._id_discovery_fields()
         response = self._execute(
             service.files().list(

--- a/src/python/cloud/gdrive_models.py
+++ b/src/python/cloud/gdrive_models.py
@@ -43,9 +43,13 @@ class RecoveryItem:
     will_recover: bool = True
     will_download: bool = False
     target_path: str = ""
-    post_restore_action: str = "trash"  # canonical default
+    post_restore_action: str = ""
     status: str = "pending"  # pending, recovered, downloaded, failed
     error_message: str = ""
+
+    def __post_init__(self):
+        if not self.post_restore_action:
+            self.post_restore_action = PostRestorePolicy.TRASH
 
 
 @dataclass

--- a/src/python/cloud/gdrive_privileges.py
+++ b/src/python/cloud/gdrive_privileges.py
@@ -1,0 +1,173 @@
+"""Privilege checking helpers for Google Drive trash recovery dry-run paths."""
+
+import shutil
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from gdrive_constants import INFERRED_MODIFY_ERROR
+from gdrive_models import FileMeta, RecoveryItem
+
+try:
+    from googleapiclient.errors import HttpError
+except Exception:  # pragma: no cover - only used when google libs are unavailable
+
+    class HttpError(Exception):
+        """Fallback HttpError type for environments without googleapiclient."""
+
+
+class DrivePrivilegeChecker:
+    """Encapsulates Drive and local privilege checks used by dry-run."""
+
+    def __init__(self, auth, execute_fn, logger: logging.Logger, items: List[RecoveryItem]):
+        self.auth = auth
+        self._execute = execute_fn
+        self.logger = logger
+        self.items = items
+
+    def _get_file_info(self, file_id: str, fields: str) -> FileMeta:
+        api_ctx = f"files.get(fileId={file_id}, fields={fields})"
+        try:
+            service = self.auth._get_service()
+            return self._execute(service.files().get(fileId=file_id, fields=fields))
+        except HttpError as e:  # type: ignore[misc]
+            status = getattr(getattr(e, "resp", None), "status", None)
+            payload = getattr(e, "content", b"")
+            detail = payload.decode(errors="ignore") if hasattr(payload, "decode") else str(e)
+            self.logger.error(f"{api_ctx} failed: HTTP {status}: {detail}")
+            return {"error": f"HTTP {status}: {detail}"}
+        except (OSError, IOError) as e:
+            self.logger.error(f"{api_ctx} I/O error: {e}")
+            return {"error": f"I/O error: {e}"}
+        except Exception as e:
+            self.logger.error(f"{api_ctx} unexpected error: {e}")
+            return {"error": f"Unexpected error: {e}"}  # type: ignore[return-value]
+
+    def _check_untrash_privilege(self, file_id: str) -> Dict[str, Any]:
+        result = {"status": "unknown", "error": None}
+        file_info = self._get_file_info(file_id, "id,trashed,capabilities")
+        if "error" in file_info:
+            result["status"] = "fail"
+            result["error"] = file_info["error"]
+            return result
+        if not file_info.get("trashed", False):
+            result["status"] = "skip"
+            result["error"] = "Test file is not trashed - cannot validate untrash permission"
+            return result
+        capabilities = file_info.get("capabilities", {})
+        if "canUntrash" in capabilities:
+            result["status"] = "pass" if capabilities["canUntrash"] else "fail"
+            if not capabilities["canUntrash"]:
+                result["error"] = "File capabilities indicate untrash not allowed"
+        else:
+            result["status"] = "pass"
+        return result
+
+    def _check_download_privilege(self, file_id: str) -> Dict[str, Any]:
+        result = {"status": "unknown", "error": None}
+        file_info = self._get_file_info(file_id, "id,size,mimeType,capabilities")
+        if "error" in file_info:
+            result["status"] = "fail"
+            result["error"] = file_info["error"]
+            return result
+        if "size" not in file_info:
+            result["status"] = "fail"
+            result["error"] = "File is not downloadable (Google Docs format or no size)"
+            return result
+        capabilities = file_info.get("capabilities", {})
+        if "canDownload" in capabilities:
+            result["status"] = "pass" if capabilities["canDownload"] else "fail"
+            if not capabilities["canDownload"]:
+                result["error"] = "File capabilities indicate download not allowed"
+        else:
+            result["status"] = "pass"
+        return result
+
+    def _check_trash_delete_privileges(
+        self, file_id: str, untrash_status: str
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        trash_result = {
+            "status": untrash_status,
+            "error": INFERRED_MODIFY_ERROR if untrash_status == "fail" else None,
+        }
+        delete_result = {
+            "status": untrash_status,
+            "error": INFERRED_MODIFY_ERROR if untrash_status == "fail" else None,
+        }
+        file_info = self._get_file_info(file_id, "id,capabilities")
+        if "error" in file_info:
+            trash_result["status"] = "fail"
+            trash_result["error"] = file_info["error"]
+            delete_result["status"] = "fail"
+            delete_result["error"] = file_info["error"]
+            return trash_result, delete_result
+        capabilities = file_info.get("capabilities", {})
+        if "canTrash" in capabilities:
+            trash_result["status"] = "pass" if capabilities["canTrash"] else "fail"
+            trash_result["error"] = (
+                None if capabilities["canTrash"] else "File capabilities indicate trash not allowed"
+            )
+        if "canDelete" in capabilities:
+            delete_result["status"] = "pass" if capabilities["canDelete"] else "fail"
+            delete_result["error"] = (
+                None
+                if capabilities["canDelete"]
+                else "File capabilities indicate delete not allowed"
+            )
+        elif trash_result["status"] == "pass":
+            delete_result["status"] = "pass"
+            delete_result["error"] = None
+        return trash_result, delete_result
+
+    def _test_operation_privileges(self, test_items: List[RecoveryItem]) -> Dict[str, Any]:
+        privileges = {
+            "untrash": {"status": "unknown", "error": None},
+            "download": {"status": "unknown", "error": None},
+            "trash": {"status": "unknown", "error": None},
+            "delete": {"status": "unknown", "error": None},
+        }
+        if not test_items:
+            return privileges
+        test_item = test_items[0]
+        privileges["untrash"] = self._check_untrash_privilege(test_item.id)
+        privileges["download"] = self._check_download_privilege(test_item.id)
+        privileges["trash"], privileges["delete"] = self._check_trash_delete_privileges(
+            test_item.id, privileges["untrash"]["status"]
+        )
+        return privileges
+
+    def _check_privileges(self, args) -> Dict[str, Any]:
+        checks = {
+            "drive_access": False,
+            "drive_error": None,
+            "operation_privileges": {},
+            "local_writable": False,
+            "local_error": None,
+            "disk_space": 0,
+            "estimated_needed": 0,
+        }
+        try:
+            service = self.auth._get_service()
+            service.files().list(pageSize=1).execute()
+            checks["drive_access"] = True
+            sample_items = self.items[:1] if self.items else []
+            checks["operation_privileges"] = self._test_operation_privileges(sample_items)
+        except Exception as e:
+            checks["drive_error"] = str(e)
+        dl_dir = getattr(args, "download_dir", None)
+        if dl_dir:
+            try:
+                download_path = Path(dl_dir)
+                download_path.mkdir(parents=True, exist_ok=True)
+                test_file = download_path / ".write_test"
+                test_file.write_text("test")
+                test_file.unlink()
+                checks["local_writable"] = True
+                if hasattr(shutil, "disk_usage"):
+                    _, _, free_bytes = shutil.disk_usage(download_path)
+                    checks["disk_space"] = free_bytes
+                    total_size = sum(item.size for item in self.items if item.will_download)
+                    checks["estimated_needed"] = total_size
+            except Exception as e:
+                checks["local_error"] = str(e)
+        return checks

--- a/src/python/cloud/gdrive_recover.py
+++ b/src/python/cloud/gdrive_recover.py
@@ -19,7 +19,6 @@ See CHANGELOG.md in this directory for version history.
 import os
 import time
 import logging
-import shutil
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Tuple, Optional, Mapping
 from pathlib import Path
@@ -31,28 +30,23 @@ import uuid
 # v1.9.0: static configuration constants extracted to dedicated module
 from gdrive_constants import (
     VERSION,
-    EXTENSION_MIME_TYPES,
     DEFAULT_PROCESS_BATCH,
-    PAGE_SIZE,
-    DEFAULT_WORKERS,
-    INFERRED_MODIFY_ERROR,
 )
 
 __version__ = VERSION
 
 # v1.10.0: data model types extracted to dedicated module
-from gdrive_models import FileMeta, RecoveryItem, PostRestorePolicy
+from gdrive_models import RecoveryItem, PostRestorePolicy
 from gdrive_state import RecoveryStateManager
 
 # v1.12.0: authentication extracted to dedicated module (issue #789)
 from gdrive_auth import DriveAuthManager
 from gdrive_rate_limiter import RateLimiter
 from gdrive_operations import DriveOperations
+from gdrive_privileges import DrivePrivilegeChecker
 from gdrive_report import RecoveryReporter
 
 try:
-    from googleapiclient.errors import HttpError
-
     # v1.12.3: discovery module uses googleapiclient.errors, so import under same guard.
     from gdrive_discovery import DriveTrashDiscovery
 
@@ -131,6 +125,8 @@ class DriveTrashRecoveryTool:
             self.stats_lock,
         )
         self.reporter = RecoveryReporter(self.args, self.logger, self.stats)
+        # v1.17.0: privilege checks extracted to DrivePrivilegeChecker (issue #856).
+        self.privileges = DrivePrivilegeChecker(self.auth, self._execute, self.logger, self.items)
 
     @property
     def _seen_total(self) -> int:
@@ -183,167 +179,40 @@ class DriveTrashRecoveryTool:
     def _generate_target_path(self, item: Mapping[str, Any] | RecoveryItem) -> str:
         if not self.args.download_dir:
             return ""
+        item_name = item.get("name", "") if isinstance(item, Mapping) else item.name
+        item_id = item.get("id", "") if isinstance(item, Mapping) else item.id
         safe_name = "".join(
-            c for c in item.name if c.isalnum() or c in (" ", "-", "_", ".")
+            c for c in str(item_name) if c.isalnum() or c in (" ", "-", "_", ".")
         ).rstrip()
         if not safe_name:
-            safe_name = f"file_{item.id}"
+            safe_name = f"file_{item_id}"
         base_path = Path(self.args.download_dir) / safe_name
         if base_path.exists():
-            stem = base_path.stem
+            stem = base_path.stem or f"file_{item_id}"
             suffix = base_path.suffix
-            counter = 1
-            while base_path.exists():
-                base_path = base_path.parent / f"{stem}_{counter}{suffix}"
-                counter += 1
+            base_path = base_path.parent / f"{stem}_{uuid.uuid4().hex[:6]}{suffix}"
         return str(base_path)
 
-    def _get_file_info(self, file_id: str, fields: str) -> FileMeta:
-        api_ctx = f"files.get(fileId={file_id}, fields={fields})"
-        try:
-            service = self.auth._get_service()
-            return self._execute(service.files().get(fileId=file_id, fields=fields))
-        except HttpError as e:
-            status = getattr(e.resp, "status", None)
-            payload = getattr(e, "content", b"")
-            detail = payload.decode(errors="ignore") if hasattr(payload, "decode") else str(e)
-            self.logger.error(f"{api_ctx} failed: HTTP {status}: {detail}")
-            return {"error": f"HTTP {status}: {detail}"}
-        except (OSError, IOError) as e:
-            self.logger.error(f"{api_ctx} I/O error: {e}")
-            return {"error": f"I/O error: {e}"}
-        except Exception as e:
-            self.logger.error(f"{api_ctx} unexpected error: {e}")
-            return {"error": f"Unexpected error: {e}"}  # type: ignore[return-value]
-
     def _check_untrash_privilege(self, file_id: str) -> Dict[str, Any]:
-        result = {"status": "unknown", "error": None}
-        file_info = self._get_file_info(file_id, "id,trashed,capabilities")
-        if "error" in file_info:
-            result["status"] = "fail"
-            result["error"] = file_info["error"]
-            return result
-        if not file_info.get("trashed", False):
-            result["status"] = "skip"
-            result["error"] = "Test file is not trashed - cannot validate untrash permission"
-            return result
-        capabilities = file_info.get("capabilities", {})
-        if "canUntrash" in capabilities:
-            result["status"] = "pass" if capabilities["canUntrash"] else "fail"
-            if not capabilities["canUntrash"]:
-                result["error"] = "File capabilities indicate untrash not allowed"
-        else:
-            result["status"] = "pass"  # Fallback
-        return result
+        return self.privileges._check_untrash_privilege(file_id)
 
     def _check_download_privilege(self, file_id: str) -> Dict[str, Any]:
-        result = {"status": "unknown", "error": None}
-        file_info = self._get_file_info(file_id, "id,size,mimeType,capabilities")
-        if "error" in file_info:
-            result["status"] = "fail"
-            result["error"] = file_info["error"]
-            return result
-        if "size" not in file_info:
-            result["status"] = "fail"
-            result["error"] = "File is not downloadable (Google Docs format or no size)"
-            return result
-        capabilities = file_info.get("capabilities", {})
-        if "canDownload" in capabilities:
-            result["status"] = "pass" if capabilities["canDownload"] else "fail"
-            if not capabilities["canDownload"]:
-                result["error"] = "File capabilities indicate download not allowed"
-        else:
-            result["status"] = "pass"  # Fallback
-        return result
+        return self.privileges._check_download_privilege(file_id)
 
     def _check_trash_delete_privileges(
         self, file_id: str, untrash_status: str
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        trash_result = {
-            "status": untrash_status,
-            "error": INFERRED_MODIFY_ERROR if untrash_status == "fail" else None,
-        }
-        delete_result = {
-            "status": untrash_status,
-            "error": INFERRED_MODIFY_ERROR if untrash_status == "fail" else None,
-        }
-        file_info = self._get_file_info(file_id, "id,capabilities")
-        if "error" in file_info:
-            trash_result["status"] = "fail"
-            trash_result["error"] = file_info["error"]
-            delete_result["status"] = "fail"
-            delete_result["error"] = file_info["error"]
-            return trash_result, delete_result
-        capabilities = file_info.get("capabilities", {})
-        if "canTrash" in capabilities:
-            trash_result["status"] = "pass" if capabilities["canTrash"] else "fail"
-            trash_result["error"] = (
-                None if capabilities["canTrash"] else "File capabilities indicate trash not allowed"
-            )
-        if "canDelete" in capabilities:
-            delete_result["status"] = "pass" if capabilities["canDelete"] else "fail"
-            delete_result["error"] = (
-                None
-                if capabilities["canDelete"]
-                else "File capabilities indicate delete not allowed"
-            )
-        elif trash_result["status"] == "pass":
-            delete_result["status"] = "pass"
-            delete_result["error"] = None
-        return trash_result, delete_result
+        return self.privileges._check_trash_delete_privileges(file_id, untrash_status)
 
     def _test_operation_privileges(self, test_items: List[RecoveryItem]) -> Dict[str, Any]:
-        privileges = {
-            "untrash": {"status": "unknown", "error": None},
-            "download": {"status": "unknown", "error": None},
-            "trash": {"status": "unknown", "error": None},
-            "delete": {"status": "unknown", "error": None},
-        }
-        if not test_items:
-            return privileges
-        test_item = test_items[0]
-        privileges["untrash"] = self._check_untrash_privilege(test_item.id)
-        privileges["download"] = self._check_download_privilege(test_item.id)
-        privileges["trash"], privileges["delete"] = self._check_trash_delete_privileges(
-            test_item.id, privileges["untrash"]["status"]
-        )
-        return privileges
+        return self.privileges._test_operation_privileges(test_items)
 
     def _check_privileges(self) -> Dict[str, Any]:
-        checks = {
-            "drive_access": False,
-            "drive_error": None,
-            "operation_privileges": {},
-            "local_writable": False,
-            "local_error": None,
-            "disk_space": 0,
-            "estimated_needed": 0,
-        }
-        try:
-            service = self.auth._get_service()
-            service.files().list(pageSize=1).execute()
-            checks["drive_access"] = True
-            sample_items = self.items[:1] if self.items else []
-            checks["operation_privileges"] = self._test_operation_privileges(sample_items)
-        except Exception as e:
-            checks["drive_error"] = str(e)
-        dl_dir = getattr(self.args, "download_dir", None)
-        if dl_dir:
-            try:
-                download_path = Path(dl_dir)
-                download_path.mkdir(parents=True, exist_ok=True)
-                test_file = download_path / ".write_test"
-                test_file.write_text("test")
-                test_file.unlink()
-                checks["local_writable"] = True
-                if hasattr(shutil, "disk_usage"):
-                    _, _, free_bytes = shutil.disk_usage(download_path)
-                    checks["disk_space"] = free_bytes
-                    total_size = sum(item.size for item in self.items if item.will_download)
-                    checks["estimated_needed"] = total_size
-            except Exception as e:
-                checks["local_error"] = str(e)
-        return checks
+        self.privileges.items = self.items
+        return self.privileges._check_privileges(self.args)
+
+    def _validate_file_ids(self) -> bool:
+        return self.discovery._validate_file_ids()
 
     def dry_run(self) -> bool:
         self.reporter.print_dry_run_banner()

--- a/tests/python/unit/test_gdrive_discovery_retry_classification.py
+++ b/tests/python/unit/test_gdrive_discovery_retry_classification.py
@@ -21,6 +21,8 @@ if "dateutil" not in sys.modules:
 
 googleapiclient_module = ModuleType("googleapiclient")
 errors_module = ModuleType("googleapiclient.errors")
+discovery_module = ModuleType("googleapiclient.discovery")
+http_module = ModuleType("googleapiclient.http")
 
 
 class HttpError(Exception):
@@ -31,9 +33,22 @@ class HttpError(Exception):
 
 
 errors_module.HttpError = HttpError
+discovery_module.build = lambda *args, **kwargs: None
+
+
+class MediaIoBaseDownload:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+http_module.MediaIoBaseDownload = MediaIoBaseDownload
 googleapiclient_module.errors = errors_module
+googleapiclient_module.discovery = discovery_module
+googleapiclient_module.http = http_module
 sys.modules["googleapiclient"] = googleapiclient_module
 sys.modules["googleapiclient.errors"] = errors_module
+sys.modules["googleapiclient.discovery"] = discovery_module
+sys.modules["googleapiclient.http"] = http_module
 
 from gdrive_discovery import DriveTrashDiscovery
 
@@ -147,3 +162,59 @@ def test_fetch_and_handle_metadata_routes_no_access_by_status(monkeypatch):
     )
 
     assert buckets["no_access"] == ["fid"]
+
+
+def test_build_query_includes_server_side_after_date_filter():
+    discovery = _make_discovery()
+    discovery.args.after_date = "2026-01-01T00:00:00+00:00"
+
+    q = discovery._build_query()
+
+    assert "modifiedTime > '2026-01-01T00:00:00+00:00'" in q
+
+
+def test_prefetch_reuses_cached_metadata_without_second_api_call():
+    discovery = _make_discovery()
+    discovery.args.file_ids = ["abcdefghijklmnopqrstuvwxyz123"]
+
+    service = MagicMock()
+    service.files.return_value.get.return_value = object()
+    discovery.auth._get_service.return_value = service
+
+    calls = {"n": 0}
+
+    def _fake_with_retries(*args, **kwargs):
+        calls["n"] += 1
+        return ({"id": "fid", "trashed": True}, None, None)
+
+    from gdrive_discovery import with_retries as _orig_with_retries
+
+    try:
+        import gdrive_discovery as module
+
+        module.with_retries = _fake_with_retries
+        discovery._prefetch_ids_metadata(discovery.args.file_ids)
+        discovery._prefetch_ids_metadata(discovery.args.file_ids)
+    finally:
+        import gdrive_discovery as module
+
+        module.with_retries = _orig_with_retries
+
+    assert calls["n"] == 1
+
+
+def test_validate_file_ids_clear_cache_warns(monkeypatch):
+    discovery = _make_discovery()
+    discovery.args.file_ids = ["abcdefghijklmnopqrstuvwxyz123"]
+    discovery.args.clear_id_cache = True
+
+    monkeypatch.setattr(
+        discovery,
+        "_prefetch_ids_metadata",
+        lambda *_: ({"ok": [], "invalid": [], "not_found": [], "no_access": []}, 0, [], 0, 0),
+    )
+
+    discovery._print_warn = MagicMock()
+
+    assert discovery._validate_file_ids() is True
+    discovery._print_warn.assert_called_once()

--- a/tests/python/unit/test_gdrive_privileges.py
+++ b/tests/python/unit/test_gdrive_privileges.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import sys
+from types import ModuleType
+
+cloud_dir = Path(__file__).parent.parent.parent / "src" / "python" / "cloud"
+if str(cloud_dir) not in sys.path:
+    sys.path.insert(0, str(cloud_dir))
+
+# Lightweight googleapiclient stub for environments where dependency is absent.
+if "googleapiclient" not in sys.modules:
+    googleapiclient_module = ModuleType("googleapiclient")
+    errors_module = ModuleType("googleapiclient.errors")
+    discovery_module = ModuleType("googleapiclient.discovery")
+    http_module = ModuleType("googleapiclient.http")
+
+    class HttpError(Exception):
+        def __init__(self, resp=None, content=b"", *args, **kwargs):
+            super().__init__(*args)
+            self.resp = resp
+            self.content = content
+
+    errors_module.HttpError = HttpError
+    discovery_module.build = lambda *args, **kwargs: None
+
+    class MediaIoBaseDownload:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    http_module.MediaIoBaseDownload = MediaIoBaseDownload
+    googleapiclient_module.errors = errors_module
+    googleapiclient_module.discovery = discovery_module
+    googleapiclient_module.http = http_module
+    sys.modules["googleapiclient"] = googleapiclient_module
+    sys.modules["googleapiclient.errors"] = errors_module
+    sys.modules["googleapiclient.discovery"] = discovery_module
+    sys.modules["googleapiclient.http"] = http_module
+
+from gdrive_models import RecoveryItem
+from gdrive_privileges import DrivePrivilegeChecker
+
+
+def _make_checker(tmp_path):
+    auth = MagicMock()
+    logger = MagicMock()
+    execute_fn = MagicMock()
+    items = [
+        RecoveryItem(
+            id="id1",
+            name="name1",
+            size=100,
+            mime_type="text/plain",
+            created_time="",
+            will_download=True,
+        )
+    ]
+    return DrivePrivilegeChecker(auth, execute_fn, logger, items), auth
+
+
+def test_check_privileges_success_and_local_writable(tmp_path):
+    checker, auth = _make_checker(tmp_path)
+    args = SimpleNamespace(download_dir=str(tmp_path))
+
+    service = MagicMock()
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    auth._get_service.return_value = service
+
+    out = checker._check_privileges(args)
+
+    assert out["drive_access"] is True
+    assert out["local_writable"] is True
+    assert out["estimated_needed"] == 100
+
+
+def test_operation_privileges_empty_items():
+    checker = DrivePrivilegeChecker(MagicMock(), MagicMock(), MagicMock(), [])
+    out = checker._test_operation_privileges([])
+    assert out["untrash"]["status"] == "unknown"
+    assert out["download"]["status"] == "unknown"
+
+
+def test_download_privilege_uses_capabilities(tmp_path):
+    checker, _ = _make_checker(tmp_path)
+    checker._get_file_info = MagicMock(
+        return_value={"size": 12, "capabilities": {"canDownload": False}}
+    )
+
+    out = checker._check_download_privilege("fid")
+
+    assert out["status"] == "fail"
+    assert "download not allowed" in str(out["error"])

--- a/tests/python/unit/test_gdrive_privileges.py
+++ b/tests/python/unit/test_gdrive_privileges.py
@@ -39,7 +39,7 @@ if "googleapiclient" not in sys.modules:
     sys.modules["googleapiclient.http"] = http_module
 
 from gdrive_models import RecoveryItem
-from gdrive_privileges import DrivePrivilegeChecker
+from gdrive_privileges import DrivePrivilegeChecker, HttpError
 
 
 def _make_checker(tmp_path):
@@ -91,3 +91,117 @@ def test_download_privilege_uses_capabilities(tmp_path):
 
     assert out["status"] == "fail"
     assert "download not allowed" in str(out["error"])
+
+
+def test_get_file_info_handles_http_error(tmp_path):
+    checker, auth = _make_checker(tmp_path)
+
+    class FakeHttpError(HttpError):
+        def __init__(self):
+            self.resp = SimpleNamespace(status=403)
+            self.content = b"denied"
+
+    service = MagicMock()
+    service.files.return_value.get.return_value = object()
+    auth._get_service.return_value = service
+    checker._execute = MagicMock(side_effect=FakeHttpError())
+
+    out = checker._get_file_info("fid", "id")
+
+    assert "error" in out
+    assert "HTTP 403" in str(out["error"])
+
+
+def test_get_file_info_handles_io_and_unexpected_error(tmp_path):
+    checker, auth = _make_checker(tmp_path)
+    service = MagicMock()
+    service.files.return_value.get.return_value = object()
+    auth._get_service.return_value = service
+
+    checker._execute = MagicMock(side_effect=OSError("disk issue"))
+    io_out = checker._get_file_info("fid", "id")
+    assert "I/O error" in str(io_out["error"])
+
+    checker._execute = MagicMock(side_effect=RuntimeError("boom"))
+    generic_out = checker._get_file_info("fid", "id")
+    assert "Unexpected error" in str(generic_out["error"])
+
+
+def test_untrash_privilege_variants(tmp_path):
+    checker, _ = _make_checker(tmp_path)
+
+    checker._get_file_info = MagicMock(return_value={"error": "no access"})
+    fail_out = checker._check_untrash_privilege("fid")
+    assert fail_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(return_value={"trashed": False, "capabilities": {}})
+    skip_out = checker._check_untrash_privilege("fid")
+    assert skip_out["status"] == "skip"
+
+    checker._get_file_info = MagicMock(
+        return_value={"trashed": True, "capabilities": {"canUntrash": False}}
+    )
+    denied_out = checker._check_untrash_privilege("fid")
+    assert denied_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(return_value={"trashed": True, "capabilities": {}})
+    fallback_out = checker._check_untrash_privilege("fid")
+    assert fallback_out["status"] == "pass"
+
+
+def test_download_privilege_size_and_fallback(tmp_path):
+    checker, _ = _make_checker(tmp_path)
+
+    checker._get_file_info = MagicMock(return_value={"error": "bad"})
+    fail_out = checker._check_download_privilege("fid")
+    assert fail_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(return_value={"capabilities": {"canDownload": True}})
+    no_size_out = checker._check_download_privilege("fid")
+    assert no_size_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(return_value={"size": 12, "capabilities": {}})
+    fallback_out = checker._check_download_privilege("fid")
+    assert fallback_out["status"] == "pass"
+
+
+def test_trash_delete_privilege_branches(tmp_path):
+    checker, _ = _make_checker(tmp_path)
+
+    checker._get_file_info = MagicMock(return_value={"error": "bad"})
+    trash_out, delete_out = checker._check_trash_delete_privileges("fid", "fail")
+    assert trash_out["status"] == "fail"
+    assert delete_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(
+        return_value={"capabilities": {"canTrash": True, "canDelete": False}}
+    )
+    trash_out, delete_out = checker._check_trash_delete_privileges("fid", "pass")
+    assert trash_out["status"] == "pass"
+    assert delete_out["status"] == "fail"
+
+    checker._get_file_info = MagicMock(return_value={"capabilities": {"canTrash": True}})
+    trash_out, delete_out = checker._check_trash_delete_privileges("fid", "pass")
+    assert trash_out["status"] == "pass"
+    assert delete_out["status"] == "pass"
+
+
+def test_check_privileges_drive_and_local_errors(tmp_path):
+    checker, auth = _make_checker(tmp_path)
+
+    auth._get_service.side_effect = RuntimeError("auth failed")
+    out = checker._check_privileges(SimpleNamespace(download_dir=None))
+    assert out["drive_access"] is False
+    assert "auth failed" in str(out["drive_error"])
+
+    auth._get_service.side_effect = None
+    service = MagicMock()
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    auth._get_service.return_value = service
+    bad_args = SimpleNamespace(download_dir=str(tmp_path / "file_as_dir"))
+    (tmp_path / "file_as_dir").write_text("x")
+
+    out = checker._check_privileges(bad_args)
+    assert out["drive_access"] is True
+    assert out["local_writable"] is False
+    assert out["local_error"] is not None

--- a/tests/python/unit/test_gdrive_recover.py
+++ b/tests/python/unit/test_gdrive_recover.py
@@ -289,8 +289,8 @@ def test_privilege_checks_and_file_info(tmp_path, monkeypatch):
         "size": 1024,
     }
 
-    # monkeypatch _get_file_info to return our fake_file when called
-    tool._get_file_info = MagicMock(return_value=fake_file)
+    # monkeypatch privilege checker fetch helper to return our fake_file when called
+    tool.privileges._get_file_info = MagicMock(return_value=fake_file)
     status = tool._check_untrash_privilege("fid")
     assert status["status"] == "pass"
 
@@ -324,10 +324,21 @@ def test_check_privileges_samples_single_item(tmp_path, monkeypatch):
         captured["items"] = items
         return {}
 
-    tool._test_operation_privileges = fake_test_operation_privileges
+    tool.privileges._test_operation_privileges = fake_test_operation_privileges
 
     checks = tool._check_privileges()
 
     assert checks["drive_access"] is True
     assert len(captured["items"]) == 1
     assert captured["items"][0].id == "one"
+
+
+def test_validate_file_ids_delegates_to_discovery(tmp_path, monkeypatch):
+    monkeypatch.setattr("gdrive_recover.DriveAuthManager", MagicMock())
+    from gdrive_recover import DriveTrashRecoveryTool
+
+    tool = DriveTrashRecoveryTool(_build_dummy_args(tmp_path))
+    tool.discovery._validate_file_ids = MagicMock(return_value=True)
+
+    assert tool._validate_file_ids() is True
+    tool.discovery._validate_file_ids.assert_called_once_with()


### PR DESCRIPTION
- extract dry-run privilege subsystem into gdrive_privileges.py

- reuse file-id prefetch cache and warn when --clear-id-cache forces refetch

- add server-side modifiedTime filtering for --after-date

- replace iterative target path collision probing with UUID suffix fallback

- align DEFAULT_WORKERS with documented guidance and bump version to 1.17.0

- update README/CHANGELOG and add unit coverage for privileges and cache reuse