### PR TITLE
chore(filedistributor): deduplicate script version source of truth

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG — FileDistributor
 
+## 4.8.3 — 2026-04-12
+
+### Changed
+
+- Made `$script:Version` the single hand-maintained script-version literal in `FileDistributor.ps1`.
+  The comment-based help `.VERSION` field and `.NOTES` version line now reference `$script:Version`
+  instead of duplicating hardcoded numeric values.
+- Added CI-covered drift protection via a dedicated Pester test that checks script version metadata
+  and verifies the latest `FileDistributor.CHANGELOG.md` release heading matches `$script:Version`.
+- Documented the versioning model distinction: script version (`FileDistributor.ps1`) and module
+  version (`FileDistributor.psd1`) are intentionally independent.
+
 ## 4.8.2 — 2026-04-11
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -6,7 +6,7 @@ The script recursively enumerates files from the source directory and ensures th
 The script ensures that files are evenly distributed across subfolders in the target directory, adhering to a configurable file limit per subfolder. If the limit is exceeded, new subfolders are created dynamically. Files in the target folder (not in subfolders) are also redistributed.
 
  .VERSION
- 4.8.2
+ See `$script:Version`.
 
   CHANGELOG:
     See FileDistributor.CHANGELOG.md in this directory for full release history.
@@ -226,7 +226,7 @@ To display the script's help text:
 .\FileDistributor.ps1 -Help
 
 .NOTES
-Version: 4.8.2 (2026-04-11).
+Version: see `$script:Version` (runtime script version; module version is independently versioned).
 
 For full release history (including v4.7.1 and v4.7.2), see:
 - ./FileDistributor.CHANGELOG.md
@@ -323,7 +323,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.2"
+$script:Version = "4.8.3"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -376,11 +376,11 @@ $_paths = Initialize-FileDistributorPaths `
     -UserStatePath $StateFilePath `
     -CallerScriptRoot $script:ScriptRoot
 
-$script:LogFilePath   = $_paths.LogFilePath
+$script:LogFilePath = $_paths.LogFilePath
 $script:StateFilePath = $_paths.StateFilePath
 
 # From here on, use the resolved script-scoped variables
-$LogFilePath   = $script:LogFilePath
+$LogFilePath = $script:LogFilePath
 $StateFilePath = $script:StateFilePath
 
 # Initialize logger with the resolved log directory

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -36,6 +36,13 @@ Scripts for file operations, distribution, copying, and archiving.
 
 All scripts use the PowerShell Logging Framework and write logs to the standard logs directory.
 
+## FileDistributor Versioning
+
+- `FileDistributor.ps1` uses `$script:Version` as the script runtime/versioning source of truth.
+- `src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1` `ModuleVersion` versions
+  the support module API and implementation.
+- These versions are intentionally independent and may advance separately under SemVer.
+
 ## Recent Updates
 
 - **Documentation (2026-04-11)**

--- a/tests/powershell/file-management/FileDistributor.Version.Tests.ps1
+++ b/tests/powershell/file-management/FileDistributor.Version.Tests.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+Version consistency tests for FileDistributor metadata.
+
+.DESCRIPTION
+Ensures script metadata references the single authoritative script version and that
+FileDistributor release notes stay in sync with the runtime script version.
+#>
+
+BeforeAll {
+    $script:FileDistributorPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'file-management' 'FileDistributor.ps1'
+    $script:FileDistributorChangelogPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'file-management' 'FileDistributor.CHANGELOG.md'
+
+    if (-not (Test-Path -LiteralPath $script:FileDistributorPath)) {
+        throw "FileDistributor script not found: $script:FileDistributorPath"
+    }
+
+    if (-not (Test-Path -LiteralPath $script:FileDistributorChangelogPath)) {
+        throw "FileDistributor changelog not found: $script:FileDistributorChangelogPath"
+    }
+
+    $script:ScriptContent = Get-Content -LiteralPath $script:FileDistributorPath -Raw
+    $script:ChangelogContent = Get-Content -LiteralPath $script:FileDistributorChangelogPath -Raw
+
+    $versionMatch = [regex]::Match($script:ScriptContent, '(?m)^\$script:Version\s*=\s*"(?<v>\d+\.\d+\.\d+)"\s*$')
+    if (-not $versionMatch.Success) {
+        throw 'Unable to resolve $script:Version from FileDistributor.ps1'
+    }
+
+    $script:ScriptVersion = $versionMatch.Groups['v'].Value
+}
+
+Describe 'FileDistributor script version metadata' {
+    It '.VERSION references $script:Version instead of a hardcoded literal' {
+        $script:ScriptContent | Should -Match '(?ms)^\s*\.VERSION\s*\r?\n\s*See `\$script:Version`?\.'
+    }
+
+    It '.NOTES version line references $script:Version instead of a hardcoded literal' {
+        $script:ScriptContent | Should -Match '(?m)^Version:\s*see\s+`\$script:Version\b'
+    }
+
+    It 'latest FileDistributor changelog heading matches $script:Version' {
+        $headingMatch = [regex]::Match($script:ChangelogContent, '(?m)^##\s+(?<v>\d+\.\d+\.\d+)\b')
+        $headingMatch.Success | Should -Be $true
+        $headingMatch.Groups['v'].Value | Should -Be $script:ScriptVersion
+    }
+}


### PR DESCRIPTION
Make script version the only hand-maintained version literal in FileDistributor.ps1.

Replace hardcoded .VERSION/.NOTES values with references, add drift tests, document independent script and module versioning, and bump script to 4.8.3.