### PR TITLE
feat(filedistributor): add SupportsShouldProcess to entry script and copy/redistribution phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Changed
 
+- **FileDistributor ShouldProcess support** (issue #932)
+  - Added `SupportsShouldProcess` to `src/powershell/file-management/FileDistributor.ps1` so the entry script now supports `-WhatIf` / `-Confirm`.
+  - Updated copy/redistribution phases to honor `ShouldProcess` in `Invoke-DistributionPhase`, `Invoke-FileDistribution`, `Invoke-TargetRedistribution`, and `Invoke-FileMove`.
+  - Bumped versions: `FileDistributor.ps1` to `4.8.5` and `FileManagement/FileDistributor` module to `1.2.2`.
+
 - **FileDistributor logging refactor** (issue #929)
   - Removed the script-local `LogMessage` wrapper in `src/powershell/file-management/FileDistributor.ps1` and switched script-level logging calls to direct `Write-Log*` framework APIs.
   - Added warning/error counter APIs to `PowerShellLoggingFramework` (`Get-LogWarningCount`, `Get-LogErrorCount`, `Reset-LogCounters`) and updated FileDistributor end-of-script/summary paths to source totals from the logging framework.

--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG — FileDistributor
 
+## 4.8.5 — 2026-04-12
+
+### Changed
+
+- Added `SupportsShouldProcess` to `FileDistributor.ps1` so the entry script now honors PowerShell `-WhatIf` / `-Confirm`.
+- Added `SupportsShouldProcess` support to copy/redistribution execution paths in the `FileDistributor` module (`Invoke-DistributionPhase`, `Invoke-FileDistribution`, `Invoke-TargetRedistribution`, and `Invoke-FileMove`), and guarded folder creation/copy/delete queue actions with `ShouldProcess`.
+- Bumped `FileDistributor` module version to `1.2.2`.
+
 ## 4.8.4 — 2026-04-12
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -274,7 +274,7 @@ Limitations:
  - The script processes files only (directories are ignored) and will recurse all nested folders under the specified source.
 #>
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param(
     [string]$SourceFolder = $null,
     [string]$TargetFolder = $null,
@@ -323,7 +323,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.4"
+$script:Version = "4.8.5"
 $script:Warnings = 0
 $script:Errors = 0
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,9 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.8.5** (module v1.2.2) (2026-04-12)
+  - Added `SupportsShouldProcess` to the entry script so `-WhatIf`/`-Confirm` flow is available at invocation time.
+  - Added `ShouldProcess` guards to copy and redistribution execution paths (including folder creation and source post-copy handling) in the `FileDistributor` support module.
 - **FileDistributor.ps1 v4.8.4** (2026-04-12)
   - Removed the script-local `LogMessage` wrapper and migrated script-level logging calls to direct `Write-Log*` framework APIs.
   - Aligned warning/error accounting with framework counter APIs for end-of-script gating and summary output.

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.1'
+    ModuleVersion     = '1.2.2'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/FolderOps.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/FolderOps.ps1
@@ -19,6 +19,7 @@ function Resolve-DistributionFileName {
 }
 
 function New-DistributionSubfolders {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [string]$TargetPath,
         [int]$NumberOfFolders,
@@ -36,12 +37,14 @@ function New-DistributionSubfolders {
             $folderPath = Join-Path -Path $TargetPath -ChildPath $randomFolderName
         } while (Test-Path -Path $folderPath)
 
-        # Create the new directory and keep a DirectoryInfo so we retain FullName later
-        $dirInfo = New-Item -ItemType Directory -Path $folderPath -Force
-        $createdFolders += $dirInfo
+        if ($PSCmdlet.ShouldProcess($folderPath, "Create distribution subfolder")) {
+            # Create the new directory and keep a DirectoryInfo so we retain FullName later
+            $dirInfo = New-Item -ItemType Directory -Path $folderPath -Force
+            $createdFolders += $dirInfo
 
-        # Log the creation of the folder
-        Write-LogInfo "Created folder: $folderPath"
+            # Log the creation of the folder
+            Write-LogInfo "Created folder: $folderPath"
+        }
 
         # Show progress if enabled
         if ($ShowProgress -and ($i % $UpdateFrequency -eq 0)) {
@@ -118,6 +121,7 @@ function Remove-DistributionFile {
 }
 
 function Invoke-FileMove {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory = $true)][string]$SourceFilePath,
         [Parameter(Mandatory = $true)][string]$OriginalFileName,
@@ -153,6 +157,15 @@ function Invoke-FileMove {
         $copyFailureHandled = $true
     }
     else {
+        if (-not $PSCmdlet.ShouldProcess($destinationFile, "Copy '$SourceFilePath'")) {
+            Write-LogInfo "Skipped copy due to ShouldProcess: '$SourceFilePath' -> '$destinationFile'"
+            return [pscustomobject]@{
+                Success         = $false
+                DestinationFile = $destinationFile
+                QueueQueued     = $null
+            }
+        }
+
         try {
             Copy-FileWithRetry -Source $SourceFilePath -Destination $destinationFile -RetryDelay $RetryDelay -MaxRetries $RetryCount -MaxBackoff $MaxBackoff | Out-Null
             $copySucceeded = Test-Path -LiteralPath $destinationFile
@@ -178,17 +191,23 @@ function Invoke-FileMove {
         $FolderCountRef.Value++
         try {
             if ($DeleteMode -eq "RecycleBin") {
-                Move-ToRecycleBin -FilePath $SourceFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
+                if ($PSCmdlet.ShouldProcess($SourceFilePath, "Move source file to Recycle Bin after successful copy")) {
+                    Move-ToRecycleBin -FilePath $SourceFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
+                }
             }
             elseif ($DeleteMode -eq "Immediate") {
-                Remove-DistributionFile -FilePath $SourceFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
+                if ($PSCmdlet.ShouldProcess($SourceFilePath, "Delete source file after successful copy")) {
+                    Remove-DistributionFile -FilePath $SourceFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
+                }
             }
             elseif ($DeleteMode -eq "EndOfScript") {
-                $queueResult = Add-FileToQueue -Queue $FilesToDelete -FilePath $SourceFilePath -ValidateFile $false
-                $queuedForEndOfScriptDeletion = [bool]$queueResult
-                if (-not $queuedForEndOfScriptDeletion) {
-                    Write-LogWarning "Failed to queue file for deletion: $SourceFilePath"
-                    if ($WarningCount) { $WarningCount.Value++ }
+                if ($PSCmdlet.ShouldProcess($SourceFilePath, "Queue source file for EndOfScript deletion")) {
+                    $queueResult = Add-FileToQueue -Queue $FilesToDelete -FilePath $SourceFilePath -ValidateFile $false
+                    $queuedForEndOfScriptDeletion = [bool]$queueResult
+                    if (-not $queuedForEndOfScriptDeletion) {
+                        Write-LogWarning "Failed to queue file for deletion: $SourceFilePath"
+                        if ($WarningCount) { $WarningCount.Value++ }
+                    }
                 }
             }
         }

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionPhase.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionPhase.ps1
@@ -1,6 +1,7 @@
 # Invoke-DistributionPhase.ps1 - Main distribution phase orchestration (public module function)
 
 function Invoke-DistributionPhase {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [hashtable]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
@@ -1,6 +1,7 @@
 # Invoke-FileDistribution.ps1 - Core file distribution algorithm (public module function)
 
 function Invoke-FileDistribution {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [object[]]$Files,
         [object[]]$Subfolders,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1
@@ -1,6 +1,7 @@
 # Invoke-TargetRedistribution.ps1 - Target-folder redistribution algorithm (public module function)
 
 function Invoke-TargetRedistribution {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [string]$TargetFolder,
         [object[]]$Subfolders,
@@ -30,7 +31,9 @@ function Invoke-TargetRedistribution {
         if ($WarningCount) { $WarningCount.Value++ }
         $randomName = Get-RandomFileName
         $newFolder = Join-Path -Path $TargetFolder -ChildPath $randomName
-        New-Item -Path $newFolder -ItemType Directory -Force | Out-Null
+        if ($PSCmdlet.ShouldProcess($newFolder, "Create emergency redistribution subfolder")) {
+            New-Item -Path $newFolder -ItemType Directory -Force | Out-Null
+        }
         $normalizedSubfolders = @($newFolder)
         $folderFilesMap[$newFolder] = 0
     }
@@ -101,12 +104,16 @@ function Invoke-TargetRedistribution {
             # Create a new subfolder using Get-RandomFileName
             $randomName = Get-RandomFileName
             $newFolder = Join-Path -Path $TargetFolder -ChildPath $randomName
-            New-Item -Path $newFolder -ItemType Directory -Force | Out-Null
-            Write-LogInfo "Created new target subfolder: $newFolder for redistribution from overloaded folder $sourceFolder."
+            if ($PSCmdlet.ShouldProcess($newFolder, "Create redistribution subfolder for overloaded folder '$sourceFolder'")) {
+                New-Item -Path $newFolder -ItemType Directory -Force | Out-Null
+                Write-LogInfo "Created new target subfolder: $newFolder for redistribution from overloaded folder $sourceFolder."
+            }
 
             # Update maps
             $eligibleTargets = @($newFolder)
-            $Subfolders += (Get-Item -LiteralPath $newFolder)
+            if (Test-Path -LiteralPath $newFolder -PathType Container) {
+                $Subfolders += (Get-Item -LiteralPath $newFolder)
+            }
             $folderFilesMap[$newFolder] = 0
         }
 

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -41,6 +41,11 @@ Describe "FileDistributor Script Existence" {
     It "Script should be a PowerShell file" {
         $script:ScriptPath | Should -Match '\.ps1$'
     }
+
+    It "Script should declare SupportsShouldProcess in CmdletBinding" {
+        $scriptContent = Get-Content -LiteralPath $script:ScriptPath -Raw
+        $scriptContent | Should -Match '\[CmdletBinding\(SupportsShouldProcess\s*=\s*\$true'
+    }
 }
 
 Describe "FileDistributor Help" {
@@ -283,6 +288,19 @@ Describe 'FileDistributor Module Public API' {
         $filesParam = (Get-Command Invoke-FileDistribution -ErrorAction Stop).Parameters['Files']
 
         $filesParam.ParameterType.FullName | Should -Be 'System.Object[]'
+    }
+
+    It 'Should expose SupportsShouldProcess on copy/redistribution public functions' {
+        $distribution = Get-Command Invoke-DistributionPhase -ErrorAction Stop
+        $copy = Get-Command Invoke-FileDistribution -ErrorAction Stop
+        $redistribution = Get-Command Invoke-TargetRedistribution -ErrorAction Stop
+
+        $distribution.CmdletBinding | Should -Be $true
+        $distribution.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $copy.CmdletBinding | Should -Be $true
+        $copy.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $redistribution.CmdletBinding | Should -Be $true
+        $redistribution.Parameters.ContainsKey('WhatIf') | Should -Be $true
     }
 
     It 'Should expose the complete expected function API through module exports' {


### PR DESCRIPTION
### Motivation

- Enable standard PowerShell dry-run/confirm semantics (`-WhatIf` / `-Confirm`) for FileDistributor so callers can safely preview destructive operations during copy/redistribution.  

### Description

- Added `SupportsShouldProcess = $true` to the FileDistributor entry script `CmdletBinding` and bumped the script version to `4.8.5` (`src/powershell/file-management/FileDistributor.ps1`).
- Added `CmdletBinding(SupportsShouldProcess = $true)` to public distribution functions `Invoke-DistributionPhase`, `Invoke-FileDistribution`, and `Invoke-TargetRedistribution` so module exports expose `WhatIf`/`Confirm` (`src/powershell/modules/FileManagement/FileDistributor/Public/*`).
- Guarded folder-creation and copy/post-copy actions with `ShouldProcess` in `New-DistributionSubfolders`, `Invoke-FileMove`, and redistribution folder-creation paths, and conditioned adding files to the EndOfScript deletion queue behind `ShouldProcess` (`src/powershell/modules/FileManagement/FileDistributor/Private/FolderOps.ps1` and `src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-TargetRedistribution.ps1`).
- Bumped module `ModuleVersion` from `1.2.1` to `1.2.2` (`src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1`).
- Updated changelogs and documentation to record the new `4.8.5` / `1.2.2` changes (`CHANGELOG.md`, `src/powershell/file-management/FileDistributor.CHANGELOG.md`, and `src/powershell/file-management/README.md`).
- Added/updated Pester assertions to verify the script declares `SupportsShouldProcess` and that `Invoke-DistributionPhase`, `Invoke-FileDistribution`, and `Invoke-TargetRedistribution` expose `WhatIf` (`tests/powershell/unit/FileDistributor.Tests.ps1`).

### Testing

- Attempted to run the FileDistributor Pester unit tests with `pwsh` via `Invoke-Pester tests/powershell/unit/FileDistributor.Tests.ps1`, but `pwsh` is not installed in the execution environment so tests could not be executed here (environment limitation).  
- Attempted the same with Windows `powershell`, which is also not available in this environment, so no automated PowerShell tests were run locally.  
- Changes were committed on branch with a commit message following commitizen style: `feat(filedistributor): add SupportsShouldProcess to distribution phases`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb3e80ae88325af120013198c4dfb)