### PR TITLE
feat(filedistributor): add ShouldProcess coverage for post-processing and end-of-script deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Entries older than the current minor release line are condensed to architectural
   - Updated copy/redistribution phases to honor `ShouldProcess` in `Invoke-DistributionPhase`, `Invoke-FileDistribution`, `Invoke-TargetRedistribution`, and `Invoke-FileMove`.
   - Bumped versions: `FileDistributor.ps1` to `4.8.5` and `FileManagement/FileDistributor` module to `1.2.2`.
 
+- **FileDistributor ShouldProcess coverage for post-processing/deletion phases** (issue #933)
+  - Added `SupportsShouldProcess` to `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, and `Invoke-DistributionRandomize`.
+  - Guarded consolidation empty-subfolder removal and end-of-script source-file deletion with `ShouldProcess` so `-WhatIf` / `-Confirm` now applies to those operations.
+  - Bumped versions: `FileDistributor.ps1` to `4.8.6` and `FileManagement/FileDistributor` module to `1.2.3`.
+
 - **FileDistributor logging refactor** (issue #929)
   - Removed the script-local `LogMessage` wrapper in `src/powershell/file-management/FileDistributor.ps1` and switched script-level logging calls to direct `Write-Log*` framework APIs.
   - Added warning/error counter APIs to `PowerShellLoggingFramework` (`Get-LogWarningCount`, `Get-LogErrorCount`, `Reset-LogCounters`) and updated FileDistributor end-of-script/summary paths to source totals from the logging framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **FileDistributor EndOfScript queue preservation on denied ShouldProcess** (issue #933)
+  - Updated `Invoke-EndOfScriptDeletion` to peek queue entries first and only dequeue when deletion is approved/attempted, preventing `-WhatIf`/declined `-Confirm` from consuming pending queue items.
+  - When deletion is not approved, the loop now exits after logging the skip so queued entries remain available for a later approved run in the same session.
+  - Bumped versions: `FileDistributor.ps1` to `4.8.7` and `FileManagement/FileDistributor` module to `1.2.4`.
+
 - **Python data smoke import stability:** `src/python/data/seat_assignment.py` now lazy-loads `pandas` and `networkx` via `_get_pandas()` / `_get_networkx()` instead of importing them at module import time, preventing CI smoke-import failures in minimal dependency environments.
 
 ## [2.12.10] - 2026-04-05

--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG — FileDistributor
 
+## 4.8.6 — 2026-04-12
+
+### Changed
+
+- Extended `SupportsShouldProcess` coverage to post-processing and end-of-script deletion module phases by marking `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, and `Invoke-DistributionRandomize` as advanced functions with `SupportsShouldProcess`.
+- Added `ShouldProcess` guard around empty-subfolder deletion in consolidation and around end-of-script source-file deletion, so `-WhatIf`/`-Confirm` now protects these destructive operations.
+- Bumped `FileDistributor` script version to `4.8.6` and module version to `1.2.3`.
+
 ## 4.8.5 — 2026-04-12
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG — FileDistributor
 
+## 4.8.7 — 2026-04-12
+
+### Fixed
+
+- Fixed end-of-script deletion queue semantics when `ShouldProcess` is not approved (`-WhatIf` or declined `-Confirm`): `Invoke-EndOfScriptDeletion` now **peeks** queue entries before approval and only dequeues when deletion is actually approved/attempted.
+- Prevented queue consumption on denied confirmation by breaking out of the deletion loop after logging the `ShouldProcess` skip, preserving pending deletion entries for a later approved run in the same session.
+- Bumped `FileDistributor` script version to `4.8.7` and module version to `1.2.4`.
+
 ## 4.8.6 — 2026-04-12
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -323,7 +323,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.5"
+$script:Version = "4.8.6"
 $script:Warnings = 0
 $script:Errors = 0
 

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -323,7 +323,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.6"
+$script:Version = "4.8.7"
 $script:Warnings = 0
 $script:Errors = 0
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,9 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.8.6** (module v1.2.3) (2026-04-12)
+  - Extended `SupportsShouldProcess` coverage to post-processing/end-of-script-deletion phases in the support module (`Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, `Invoke-DistributionRandomize`).
+  - Added `ShouldProcess` guards for consolidation empty-subfolder deletion and end-of-script source-file deletion so `-WhatIf`/`-Confirm` protects those actions.
 - **FileDistributor.ps1 v4.8.5** (module v1.2.2) (2026-04-12)
   - Added `SupportsShouldProcess` to the entry script so `-WhatIf`/`-Confirm` flow is available at invocation time.
   - Added `ShouldProcess` guards to copy and redistribution execution paths (including folder creation and source post-copy handling) in the `FileDistributor` support module.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,9 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.8.7** (module v1.2.4) (2026-04-12)
+  - Fixed `Invoke-EndOfScriptDeletion` queue handling so denied `ShouldProcess` (`-WhatIf` or declined `-Confirm`) does not consume pending deletion entries.
+  - The function now peeks first and dequeues only when deletion is approved/attempted, preserving queue state for a later confirmed run.
 - **FileDistributor.ps1 v4.8.6** (module v1.2.3) (2026-04-12)
   - Extended `SupportsShouldProcess` coverage to post-processing/end-of-script-deletion phases in the support module (`Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, `Invoke-DistributionRandomize`).
   - Added `ShouldProcess` guards for consolidation empty-subfolder deletion and end-of-script source-file deletion so `-WhatIf`/`-Confirm` protects those actions.

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.2'
+    ModuleVersion     = '1.2.3'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.3'
+    ModuleVersion     = '1.2.4'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionRandomize.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionRandomize.ps1
@@ -1,6 +1,7 @@
 # Invoke-DistributionRandomize.ps1 - Randomize algorithm (public module function)
 
 function Invoke-DistributionRandomize {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory = $true)][string]$TargetFolder,
         [Parameter(Mandatory = $true)][int]$FilesPerFolderLimit,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
@@ -1,6 +1,7 @@
 # Invoke-EndOfScriptDeletion.ps1 - End-of-script deletion phase (public module function)
 
 function Invoke-EndOfScriptDeletion {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [hashtable]$RunState,
         [int]$PriorWarnings,
@@ -39,11 +40,17 @@ function Invoke-EndOfScriptDeletion {
         } catch { Write-LogDebug "Could not stat queued file before deletion: $($_.Exception.Message)" }
 
         if ($okToDelete) {
-            try { Remove-DistributionFile -FilePath $entry.SourcePath -RetryDelay $RetryDelay -RetryCount $RetryCount }
-            catch {
-                Write-LogWarning "Failed to delete file $($entry.SourcePath). Error: $($_.Exception.Message)"
-                $WarningCount.Value++
+            if ($PSCmdlet.ShouldProcess($entry.SourcePath, "Delete source file at end-of-script")) {
+                try { Remove-DistributionFile -FilePath $entry.SourcePath -RetryDelay $RetryDelay -RetryCount $RetryCount }
+                catch {
+                    Write-LogWarning "Failed to delete file $($entry.SourcePath). Error: $($_.Exception.Message)"
+                    $WarningCount.Value++
+                }
+            } else {
+                Write-LogInfo "End-of-script deletion skipped due to ShouldProcess: '$($entry.SourcePath)'."
             }
+        } else {
+            Write-LogDebug "End-of-script deletion: skipped '$($entry.SourcePath)' due to file metadata drift."
         }
     }
 }

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
@@ -27,10 +27,16 @@ function Invoke-EndOfScriptDeletion {
     }
 
     while ($RunState.FilesToDelete.Items.Count -gt 0) {
-        $entry = Get-NextQueueItem -Queue $RunState.FilesToDelete -IncrementAttempts $false
+        $entry = Get-NextQueueItem -Queue $RunState.FilesToDelete -Peek -IncrementAttempts $false
         if ($null -eq $entry) { break }
-        if ($entry.SessionId -ne $RunState.SessionId) { continue }
-        if (-not (Test-Path -Path $entry.SourcePath)) { continue }
+        if ($entry.SessionId -ne $RunState.SessionId) {
+            [void](Get-NextQueueItem -Queue $RunState.FilesToDelete -IncrementAttempts $false)
+            continue
+        }
+        if (-not (Test-Path -Path $entry.SourcePath)) {
+            [void](Get-NextQueueItem -Queue $RunState.FilesToDelete -IncrementAttempts $false)
+            continue
+        }
 
         $okToDelete = $true
         try {
@@ -41,6 +47,7 @@ function Invoke-EndOfScriptDeletion {
 
         if ($okToDelete) {
             if ($PSCmdlet.ShouldProcess($entry.SourcePath, "Delete source file at end-of-script")) {
+                [void](Get-NextQueueItem -Queue $RunState.FilesToDelete -IncrementAttempts $false)
                 try { Remove-DistributionFile -FilePath $entry.SourcePath -RetryDelay $RetryDelay -RetryCount $RetryCount }
                 catch {
                     Write-LogWarning "Failed to delete file $($entry.SourcePath). Error: $($_.Exception.Message)"
@@ -48,9 +55,11 @@ function Invoke-EndOfScriptDeletion {
                 }
             } else {
                 Write-LogInfo "End-of-script deletion skipped due to ShouldProcess: '$($entry.SourcePath)'."
+                break
             }
         } else {
             Write-LogDebug "End-of-script deletion: skipped '$($entry.SourcePath)' due to file metadata drift."
+            [void](Get-NextQueueItem -Queue $RunState.FilesToDelete -IncrementAttempts $false)
         }
     }
 }

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderConsolidation.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderConsolidation.ps1
@@ -1,6 +1,7 @@
 # Invoke-FolderConsolidation.ps1 - Consolidation algorithm (public module function)
 
 function Invoke-FolderConsolidation {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory = $true)][string]$TargetFolder,
         [Parameter(Mandatory = $true)][int]$FilesPerFolderLimit,
@@ -146,11 +147,15 @@ function Invoke-FolderConsolidation {
         try {
             $entries = (Get-ChildItem -LiteralPath $o -Force -ErrorAction Stop | Measure-Object).Count
             if ($entries -eq 0) {
-                Invoke-WithRetry -Operation { Remove-Item -LiteralPath $o -Force -ErrorAction Stop } `
-                    -Description "Consolidation: delete empty subfolder '$o'" `
-                    -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -IgnoreFileNotFound
-                Write-LogInfo "Consolidation: deleted empty subfolder '$o'."
-                $deleted++
+                if ($PSCmdlet.ShouldProcess($o, "Delete empty subfolder after consolidation")) {
+                    Invoke-WithRetry -Operation { Remove-Item -LiteralPath $o -Force -ErrorAction Stop } `
+                        -Description "Consolidation: delete empty subfolder '$o'" `
+                        -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -IgnoreFileNotFound
+                    Write-LogInfo "Consolidation: deleted empty subfolder '$o'."
+                    $deleted++
+                } else {
+                    Write-LogInfo "Consolidation: skipped deleting empty subfolder due to ShouldProcess: '$o'."
+                }
             } else {
                 $skipped++
                 Write-LogWarning "Consolidation: subfolder '$o' not empty after move; skipping deletion."

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderRebalance.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FolderRebalance.ps1
@@ -1,6 +1,7 @@
 # Invoke-FolderRebalance.ps1 - Rebalance algorithm (public module function)
 
 function Invoke-FolderRebalance {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory = $true)][string]$TargetFolder,
         [Parameter(Mandatory = $true)][int]$FilesPerFolderLimit,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostProcessingPhase.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostProcessingPhase.ps1
@@ -1,6 +1,7 @@
 # Invoke-PostProcessingPhase.ps1 - Post-processing phase orchestration (public module function)
 
 function Invoke-PostProcessingPhase {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [hashtable]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -318,6 +318,13 @@ Describe 'FileDistributor Module Public API' {
         $endOfScriptDeletion.Parameters.ContainsKey('WhatIf') | Should -Be $true
     }
 
+    It 'Invoke-EndOfScriptDeletion should peek queue before ShouldProcess-gated deletion' {
+        $functionPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'Public' 'Invoke-EndOfScriptDeletion.ps1'
+        $functionContent = Get-Content -LiteralPath $functionPath -Raw
+
+        $functionContent | Should -Match 'Get-NextQueueItem\s+-Queue\s+\$RunState\.FilesToDelete\s+-Peek'
+    }
+
     It 'Should expose the complete expected function API through module exports' {
         $expectedExports = @(
             'Initialize-FileDistributorPaths',

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -290,10 +290,15 @@ Describe 'FileDistributor Module Public API' {
         $filesParam.ParameterType.FullName | Should -Be 'System.Object[]'
     }
 
-    It 'Should expose SupportsShouldProcess on copy/redistribution public functions' {
+    It 'Should expose SupportsShouldProcess on copy/redistribution/post-processing/deletion public functions' {
         $distribution = Get-Command Invoke-DistributionPhase -ErrorAction Stop
         $copy = Get-Command Invoke-FileDistribution -ErrorAction Stop
         $redistribution = Get-Command Invoke-TargetRedistribution -ErrorAction Stop
+        $postProcessing = Get-Command Invoke-PostProcessingPhase -ErrorAction Stop
+        $consolidation = Get-Command Invoke-FolderConsolidation -ErrorAction Stop
+        $rebalance = Get-Command Invoke-FolderRebalance -ErrorAction Stop
+        $randomize = Get-Command Invoke-DistributionRandomize -ErrorAction Stop
+        $endOfScriptDeletion = Get-Command Invoke-EndOfScriptDeletion -ErrorAction Stop
 
         $distribution.CmdletBinding | Should -Be $true
         $distribution.Parameters.ContainsKey('WhatIf') | Should -Be $true
@@ -301,6 +306,16 @@ Describe 'FileDistributor Module Public API' {
         $copy.Parameters.ContainsKey('WhatIf') | Should -Be $true
         $redistribution.CmdletBinding | Should -Be $true
         $redistribution.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $postProcessing.CmdletBinding | Should -Be $true
+        $postProcessing.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $consolidation.CmdletBinding | Should -Be $true
+        $consolidation.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $rebalance.CmdletBinding | Should -Be $true
+        $rebalance.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $randomize.CmdletBinding | Should -Be $true
+        $randomize.Parameters.ContainsKey('WhatIf') | Should -Be $true
+        $endOfScriptDeletion.CmdletBinding | Should -Be $true
+        $endOfScriptDeletion.Parameters.ContainsKey('WhatIf') | Should -Be $true
     }
 
     It 'Should expose the complete expected function API through module exports' {


### PR DESCRIPTION
### Motivation

- Ensure PowerShell `-WhatIf`/`-Confirm` semantics cover the post-processing and end-of-script deletion phases so destructive operations there are safely gated.

### Description

- Marked post-processing and deletion public functions as advanced functions with `SupportsShouldProcess` by adding `[CmdletBinding(SupportsShouldProcess = $true)]` to `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-FolderConsolidation`, `Invoke-FolderRebalance`, and `Invoke-DistributionRandomize`.
- Added `ShouldProcess` guards around destructive actions in those phases: empty-subfolder deletion in consolidation and per-file end-of-script source deletion are now skipped/logged when `ShouldProcess` denies the action.
- Extended unit coverage in `tests/powershell/unit/FileDistributor.Tests.ps1` to assert `WhatIf`/`WhatIf` exposure for the new post-processing/deletion public functions.
- Bumped versions to reflect the patch: `FileDistributor.ps1` -> `4.8.6` and module `FileDistributor` -> `1.2.3`, and updated `CHANGELOG.md`, `src/powershell/file-management/FileDistributor.CHANGELOG.md`, and `src/powershell/file-management/README.md` accordingly.

### Testing

- Attempted to run the Pester unit suite via `Invoke-Pester tests/powershell/unit/FileDistributor.Tests.ps1`, but `pwsh` is not available in this environment so the tests could not be executed here.
- Ran `git diff --check` (whitespace/format check) and it reported no issues.
- Updated and committed changes including the test assertions so CI with PowerShell available should exercise the new `WhatIf`/`-Confirm` exposure during normal test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbcbb22808325bfb1a99c7d83a805)