### PR TITLE
chore(filedistributor): harden parameter validation attributes and remove dead defensive checks

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG — FileDistributor
 
+## 4.8.8 — 2026-04-12
+
+### Changed
+
+- Hardened FileDistributor parameter contracts with explicit validation attributes (`ValidateRange` / `ValidateSet`) for numeric retry/limit settings and enum-like mode inputs in `FileDistributor.ps1`.
+- Added stricter parameter attributes to module public functions (`Invoke-ParameterValidation`, `Invoke-FileDistribution`) so invalid values fail earlier during binding.
+- Removed now-unreachable defensive branches in `Invoke-ParameterValidation` that duplicated binder-enforced validation (invalid `DeleteMode`, invalid end-of-script condition, fallback reset for non-positive `FilesPerFolderLimit`, and `< -1` normalization for `MaxFilesToCopy`).
+- Applied small style cleanups in validation logic (`-not` consistency and minor spacing/alignment fixes) while preserving behavior.
+- Bumped `FileDistributor` script version to `4.8.8` and module version to `1.2.5`.
+
 ## 4.8.7 — 2026-04-12
 
 ### Fixed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -278,28 +278,38 @@ Limitations:
 param(
     [string]$SourceFolder = $null,
     [string]$TargetFolder = $null,
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$FilesPerFolderLimit = 20000,
+    [ValidateRange(-1, [int]::MaxValue)]
     [int]$MaxFilesToCopy = -1, # -1 = all, 0 = none, N = first N files from enumeration
     [string]$LogFilePath = $null,
     [string]$StateFilePath = $null,
     [string]$RandomNameModulePath = $null,
     [switch]$Restart,
     [switch]$ShowProgress = $false,
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$MaxBackoff = 60, # Cap for exponential backoff used by retry helper
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$UpdateFrequency = 100, # Default: 100 files
+    [ValidateSet("RecycleBin", "Immediate", "EndOfScript")]
     [string]$DeleteMode = "RecycleBin", # Options: "RecycleBin", "Immediate", "EndOfScript"
+    [ValidateSet("NoWarnings", "WarningsOnly")]
     [string]$EndOfScriptDeletionCondition = "NoWarnings", # Options: "NoWarnings", "WarningsOnly"
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$RetryDelay = 10, # Time to wait before retrying file access (seconds)
+    [ValidateRange(0, [int]::MaxValue)]
     [int]$RetryCount = 3, # Number of times to retry file access (0 for unlimited retries)
     [switch]$CleanupDuplicates,
     [switch]$CleanupEmptyFolders,
     [switch]$TruncateLog,
     [string]$TruncateIfLarger,
     [string]$RemoveEntriesBefore,
+    [ValidateRange(0, [int]::MaxValue)]
     [int]$RemoveEntriesOlderThan,
     [switch]$Help,
     [switch]$ConsolidateToMinimum,
     [switch]$RebalanceToAverage,
+    [ValidateRange(0, 100)]
     [int]$RebalanceTolerance = 10,
     [switch]$RandomizeDistribution
 )
@@ -323,7 +333,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.7"
+$script:Version = "4.8.8"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -372,8 +382,6 @@ function Main {
             try { $beforeTimestamp = [datetime]::Parse($RemoveEntriesBefore) }
             catch { throw "Invalid timestamp format. Use 'YYYY-MM-DD HH:MM:SS' or ISO 8601." }
         }
-        if ($RemoveEntriesOlderThan -lt 0) { throw "Invalid value for RemoveEntriesOlderThan. Must be a non-negative integer." }
-
         $purgeParams = @{ LogFilePath = $LogFilePath }
         if ($beforeTimestamp) { $purgeParams.BeforeTimestamp = $beforeTimestamp }
         if ($RemoveEntriesOlderThan) { $purgeParams.RetentionDays = $RemoveEntriesOlderThan }

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **FileDistributor.ps1 v4.8.8** (module v1.2.5) (2026-04-12)
+  - Hardened parameter contracts using `ValidateRange`/`ValidateSet` attributes for core limit/retry/delete-mode inputs in the script and module public functions.
+  - Removed redundant dead defensive checks in `Invoke-ParameterValidation` that are now enforced by parameter binding.
+  - Applied small style cleanups in validation code (`-not` consistency and formatting).
 - **FileDistributor.ps1 v4.8.7** (module v1.2.4) (2026-04-12)
   - Fixed `Invoke-EndOfScriptDeletion` queue handling so denied `ShouldProcess` (`-WhatIf` or declined `-Confirm`) does not consume pending deletion entries.
   - The function now peeks first and dequeues only when deletion is approved/attempted, preserving queue state for a later confirmed run.

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.4'
+    ModuleVersion     = '1.2.5'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-FileDistribution.ps1
@@ -5,17 +5,17 @@ function Invoke-FileDistribution {
     param (
         [object[]]$Files,
         [object[]]$Subfolders,
-        [Parameter(Mandatory = $true)][string]$TargetRoot,
-        [int]$Limit,
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$TargetRoot,
+        [ValidateRange(1, [int]::MaxValue)][int]$Limit,
         [switch]$ShowProgress,
-        [int]$UpdateFrequency,
-        [string]$DeleteMode,
+        [ValidateRange(1, [int]::MaxValue)][int]$UpdateFrequency,
+        [ValidateSet("RecycleBin", "Immediate", "EndOfScript")][string]$DeleteMode,
         $FilesToDelete,  # FileQueue object (PSCustomObject) - reference type, no [ref] needed
         [ref]$GlobalFileCounter,
-        [int]$TotalFiles,
-        [int]$RetryDelay = 10,
-        [int]$RetryCount = 3,
-        [int]$MaxBackoff = 60,
+        [ValidateRange(0, [int]::MaxValue)][int]$TotalFiles,
+        [ValidateRange(1, [int]::MaxValue)][int]$RetryDelay = 10,
+        [ValidateRange(0, [int]::MaxValue)][int]$RetryCount = 3,
+        [ValidateRange(1, [int]::MaxValue)][int]$MaxBackoff = 60,
         [ref]$WarningCount,
         [ref]$ErrorCount
     )

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-ParameterValidation.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-ParameterValidation.ps1
@@ -2,16 +2,16 @@
 
 function Invoke-ParameterValidation {
     param(
-        [hashtable]$RunState,
+        [Parameter(Mandatory = $true)][hashtable]$RunState,
         [string]$SourceFolder,
-        [Parameter(Mandatory = $true)][string]$TargetFolder,
-        [int]$FilesPerFolderLimit,
-        [int]$MaxFilesToCopy,
-        [Parameter(Mandatory = $true)][string]$DeleteMode,
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$TargetFolder,
+        [ValidateRange(1, [int]::MaxValue)][int]$FilesPerFolderLimit,
+        [ValidateRange(-1, [int]::MaxValue)][int]$MaxFilesToCopy,
+        [Parameter(Mandatory = $true)][ValidateSet("RecycleBin", "Immediate", "EndOfScript")][string]$DeleteMode,
         [switch]$ConsolidateToMinimum,
         [switch]$RebalanceToAverage,
         [switch]$RandomizeDistribution,
-        [Parameter(Mandatory = $true)][string]$EndOfScriptDeletionCondition,
+        [Parameter(Mandatory = $true)][ValidateSet("NoWarnings", "WarningsOnly")][string]$EndOfScriptDeletionCondition,
         [Parameter(Mandatory = $true)][ref]$WarningCount,
         [Parameter(Mandatory = $true)][ref]$ErrorCount
     )
@@ -27,36 +27,18 @@ function Invoke-ParameterValidation {
         $RunState.MaxFilesToCopy = $MaxFilesToCopy
     }
 
-    if ([string]::IsNullOrWhiteSpace($TargetFolder)) {
-        Write-LogError "TargetFolder not specified. Provide -TargetFolder with a valid path."
-        $ErrorCount.Value++
-        throw "Missing required parameter: -TargetFolder"
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($SourceFolder) -and !(Test-Path -Path $SourceFolder)) {
+    if (-not [string]::IsNullOrWhiteSpace($SourceFolder) -and -not (Test-Path -Path $SourceFolder)) {
         Write-LogError "Source folder '$SourceFolder' does not exist."
         $ErrorCount.Value++
         throw "Source folder not found."
     }
 
-    if (!($FilesPerFolderLimit -gt 0)) {
-        Write-LogWarning "Incorrect value for FilesPerFolderLimit. Resetting to default: 20000."
-        $WarningCount.Value++
-        $RunState.FilesPerFolderLimit = 20000
-    } else {
-        $RunState.FilesPerFolderLimit = $FilesPerFolderLimit
-    }
+    $RunState.FilesPerFolderLimit = $FilesPerFolderLimit
 
-    if (!(Test-Path -Path $TargetFolder)) {
+    if (-not (Test-Path -Path $TargetFolder)) {
         Write-LogWarning "Target folder '$TargetFolder' does not exist. Creating it."
         $WarningCount.Value++
         New-Item -ItemType Directory -Path $TargetFolder -Force | Out-Null
-    }
-
-    if (-not ("RecycleBin", "Immediate", "EndOfScript" -contains $DeleteMode)) {
-        Write-LogError "Invalid value for DeleteMode: $DeleteMode. Valid options are 'RecycleBin', 'Immediate', 'EndOfScript'."
-        $ErrorCount.Value++
-        throw "Invalid DeleteMode."
     }
 
     $exclusiveOptions = @($ConsolidateToMinimum, $RebalanceToAverage, $RandomizeDistribution)
@@ -67,19 +49,7 @@ function Invoke-ParameterValidation {
         throw "Mutually exclusive options: only one of -ConsolidateToMinimum, -RebalanceToAverage, or -RandomizeDistribution can be specified"
     }
 
-    if (-not ("NoWarnings", "WarningsOnly" -contains $EndOfScriptDeletionCondition)) {
-        Write-LogError "Invalid value for EndOfScriptDeletionCondition: $EndOfScriptDeletionCondition. Valid options are 'NoWarnings', 'WarningsOnly'."
-        $ErrorCount.Value++
-        throw "Invalid EndOfScriptDeletionCondition."
-    }
-
-    if ($RunState.MaxFilesToCopy -lt -1) {
-        Write-LogWarning "Invalid MaxFilesToCopy '$($RunState.MaxFilesToCopy)'. Using -1 (no limit)."
-        $WarningCount.Value++
-        $RunState.MaxFilesToCopy = -1
-    }
-
-    $RunState.FilesToDelete    = New-FileQueue -Name "FilesToDelete" -SessionId $RunState.SessionId -MaxSize -1
+    $RunState.FilesToDelete = New-FileQueue -Name "FilesToDelete" -SessionId $RunState.SessionId -MaxSize -1
     $RunState.GlobalFileCounter = New-Ref 0
     Write-LogInfo "Parameter validation completed"
 }


### PR DESCRIPTION
### Motivation

- Ensure FileDistributor fails fast on invalid inputs by moving numeric and enum validation to parameter binding instead of runtime defensive checks. 
- Remove duplicated/unreachable defensive code in the parameter validation helper now made redundant by binder-enforced attributes. 
- Keep behavior unchanged for callers while making validation clearer, safer, and easier to maintain; update component versions/docs accordingly.

### Description

- Added parameter validation attributes (`ValidateRange`, `ValidateSet`, `ValidateNotNullOrEmpty`) to the `FileDistributor.ps1` script parameter block for limits, retry/backoff settings, delete-mode enums, tolerance, and other numeric inputs.
- Hardened module public APIs by adding binder-level attributes to `Invoke-ParameterValidation` (mandatory `RunState`, `TargetFolder`, validated numeric and enum params) and `Invoke-FileDistribution` (validated `TargetRoot`, `Limit`, `UpdateFrequency`, `DeleteMode`, `Retry*`, `TotalFiles`).
- Removed redundant defensive branches in `Invoke-ParameterValidation` that duplicated binder checks: missing `TargetFolder` guard, explicit `DeleteMode` membership checks, fallback reset for non-positive `FilesPerFolderLimit`, and normalization for `MaxFilesToCopy < -1`.
- Bumped FileDistributor script version to `4.8.8` and module `ModuleVersion` to `1.2.5`, and updated `FileDistributor.CHANGELOG.md` and the file-management `README.md` to document the changes.

### Testing

- Attempted to run the PowerShell/Pester validation tests, but the environment lacks `pwsh`/`powershell`, so Pester runs could not be executed.
- Performed static verification by inspecting changed parameter blocks, call sites, and module exports to confirm attributes cover the previously-defensive checks and that the changes are self-consistent (no behavioral regressions expected at runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc33ec8b083258faf8da77350c22c)