### PR TITLE
refactor(filedistributor): replace run state hashtable with typed class

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG — FileDistributor
 
+## 4.9.0 — 2026-04-12
+
+### Changed
+
+- Replaced the ad-hoc `$runState` hashtable with a typed `FileDistributorRunState` class (`Private/FileDistributorRunState.ps1`) and updated orchestration startup in `FileDistributor.ps1` to construct `[FileDistributorRunState]::new()`.
+- Updated all module orchestration/public phase functions that accept `-RunState` (`Invoke-ParameterValidation`, `Invoke-RestoreCheckpoint`, `Invoke-DistributionPhase`, `Invoke-PostProcessingPhase`, `Invoke-EndOfScriptDeletion`, `Invoke-PostRunCleanup`, `New-CheckpointPayload`) to declare `[FileDistributorRunState]`.
+- Added typed state serialization helpers: `FileDistributorRunState.ToSerializableHashtable()`, `FileDistributorRunState.FromHashtable([hashtable])`, and `Convert-RunStateToSerializableHashtable`.
+- Updated checkpoint payload creation to use typed state serialization instead of direct hashtable field assembly.
+
+### Compatibility
+
+- Preserved restart/checkpoint backward compatibility with legacy hashtable-shaped state files; typed restore uses case-insensitive key mapping via `FromHashtable` and still enforces saved `SourceFolder` / `DeleteMode` invariants.
+
+### Tests
+
+- Added `FileDistributorRunState.Tests.ps1` covering default construction, property mutation, JSON round-trip serialization, and legacy checkpoint-load compatibility.
+- Bumped `FileDistributor` script version to `4.9.0` and module version to `1.3.0`.
+
 ## 4.8.8 — 2026-04-12
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -333,7 +333,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.8.8"
+$script:Version = "4.9.0"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -396,15 +396,7 @@ function Main {
     $script:Warnings = [Math]::Max($script:Warnings, (Get-LogWarningCount))
     $script:Errors = [Math]::Max($script:Errors, (Get-LogErrorCount))
 
-    $runState = @{
-        totalSourceFilesAll     = 0
-        totalSourceFiles        = 0
-        totalTargetFilesBefore  = 0
-        subfolders              = @()
-        sourceFiles             = @()
-        skippedFilesByExtension = @{}
-        totalSkippedFiles       = 0
-    }
+    $runState = [FileDistributorRunState]::new()
     $fileLockRef = [ref]$null
 
     try {

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.2.5'
+    ModuleVersion     = '1.3.0'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
@@ -2,22 +2,25 @@
 
 $ModuleRoot = $PSScriptRoot
 
-$privateFunctions = @(Get-ChildItem -Path "$ModuleRoot\Private\*.ps1" -ErrorAction SilentlyContinue)
+$runStateClassPath = Join-Path -Path $ModuleRoot -ChildPath 'Private\FileDistributorRunState.ps1'
+if (Test-Path -LiteralPath $runStateClassPath) {
+    . $runStateClassPath
+}
+
+$privateFunctions = @(Get-ChildItem -Path "$ModuleRoot\Private\*.ps1" -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne 'FileDistributorRunState.ps1' } | Sort-Object Name)
 foreach ($import in $privateFunctions) {
     try {
         . $import.FullName
-    }
-    catch {
+    } catch {
         Write-Error "Failed to import private function $($import.FullName): $_"
     }
 }
 
-$publicFunctions = @(Get-ChildItem -Path "$ModuleRoot\Public\*.ps1" -ErrorAction SilentlyContinue)
+$publicFunctions = @(Get-ChildItem -Path "$ModuleRoot\Public\*.ps1" -ErrorAction SilentlyContinue | Sort-Object Name)
 foreach ($import in $publicFunctions) {
     try {
         . $import.FullName
-    }
-    catch {
+    } catch {
         Write-Error "Failed to import public function $($import.FullName): $_"
     }
 }

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/FileDistributorRunState.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/FileDistributorRunState.ps1
@@ -1,0 +1,77 @@
+class FileDistributorRunState {
+    [int]$TotalSourceFilesAll = 0
+    [int]$TotalSourceFiles = 0
+    [int]$TotalTargetFilesBefore = 0
+    [object[]]$Subfolders = @()
+    [object[]]$SourceFiles = @()
+    [hashtable]$SkippedFilesByExtension = @{}
+    [int]$TotalSkippedFiles = 0
+    [string]$SessionId
+    [int]$MaxFilesToCopy = -1
+    [int]$FilesPerFolderLimit = 0
+    [object]$FilesToDelete
+    [object]$GlobalFileCounter
+    [int]$LastCheckpoint = 0
+    [hashtable]$State = @{}
+    [string]$SourceFolder
+
+    FileDistributorRunState() {
+    }
+
+    [hashtable] ToSerializableHashtable() {
+        return @{
+            totalSourceFiles        = $this.TotalSourceFiles
+            totalSourceFilesAll     = $this.TotalSourceFilesAll
+            totalTargetFilesBefore  = $this.TotalTargetFilesBefore
+            MaxFilesToCopy          = $this.MaxFilesToCopy
+            SourceFolder            = $this.SourceFolder
+            totalSkippedFiles       = $this.TotalSkippedFiles
+            skippedFilesByExtension = @{} + $this.SkippedFilesByExtension
+        }
+    }
+
+    static [FileDistributorRunState] FromHashtable([hashtable]$State) {
+        $runState = [FileDistributorRunState]::new()
+
+        if ($null -eq $State) {
+            return $runState
+        }
+
+        if ($State.ContainsKey('totalSourceFiles')) {
+            $runState.TotalSourceFiles = [int]$State['totalSourceFiles']
+        }
+        if ($State.ContainsKey('totalSourceFilesAll')) {
+            $runState.TotalSourceFilesAll = [int]$State['totalSourceFilesAll']
+        }
+        if ($State.ContainsKey('totalTargetFilesBefore')) {
+            $runState.TotalTargetFilesBefore = [int]$State['totalTargetFilesBefore']
+        }
+        if ($State.ContainsKey('MaxFilesToCopy')) {
+            $runState.MaxFilesToCopy = [int]$State['MaxFilesToCopy']
+        }
+        if ($State.ContainsKey('SourceFolder')) {
+            $runState.SourceFolder = [string]$State['SourceFolder']
+        }
+        if ($State.ContainsKey('SessionId')) {
+            $runState.SessionId = [string]$State['SessionId']
+        }
+        if ($State.ContainsKey('Checkpoint')) {
+            $runState.LastCheckpoint = [int]$State['Checkpoint']
+        }
+        if ($State.ContainsKey('totalSkippedFiles')) {
+            $runState.TotalSkippedFiles = [int]$State['totalSkippedFiles']
+        }
+        if ($State.ContainsKey('skippedFilesByExtension')) {
+            $dict = $State['skippedFilesByExtension']
+            if ($dict -is [System.Collections.IDictionary]) {
+                $copy = @{}
+                foreach ($key in $dict.Keys) {
+                    $copy[[string]$key] = [int]$dict[$key]
+                }
+                $runState.SkippedFilesByExtension = $copy
+            }
+        }
+
+        return $runState
+    }
+}

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/Serialization.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/Serialization.ps1
@@ -1,4 +1,13 @@
 # Function to extract paths from items
+function Convert-RunStateToSerializableHashtable {
+    param(
+        [Parameter(Mandatory = $true)][FileDistributorRunState]$RunState
+    )
+
+    return $RunState.ToSerializableHashtable()
+}
+
+# Function to extract paths from items
 function ConvertItemsToPaths {
     param ([array]$Items)
 
@@ -28,20 +37,16 @@ function ConvertItemsToPaths {
                 if (-not [string]::IsNullOrWhiteSpace($fullPath)) {
                     Write-LogDebug "DEBUG: ConvertItemsToPaths - Item $index converting '$($i.Name)' to '$fullPath'"
                     $out += $fullPath
-                }
-                else {
+                } else {
                     Write-LogDebug "DEBUG: ConvertItemsToPaths - Item $index has whitespace-only FullName for '$($i.Name)'"
                 }
-            }
-            else {
+            } else {
                 Write-LogDebug "DEBUG: ConvertItemsToPaths - Item $index has no FullName property for '$($i.Name)'"
             }
-        }
-        elseif (-not [string]::IsNullOrWhiteSpace([string]$i)) {
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$i)) {
             Write-LogDebug "DEBUG: ConvertItemsToPaths - Item $index is string '$i'"
             $out += [string]$i
-        }
-        else {
+        } else {
             Write-LogDebug "DEBUG: ConvertItemsToPaths - Item $index skipped (empty/whitespace)"
         }
     }
@@ -78,12 +83,10 @@ function ConvertPathsToItems {
             if ($item -and $item.FullName -and -not [string]::IsNullOrWhiteSpace($item.FullName)) {
                 Write-LogDebug "DEBUG: ConvertPathsToItems - Item $index successfully converted to $($item.GetType().Name)"
                 $out += $item
-            }
-            else {
+            } else {
                 Write-LogDebug "DEBUG: ConvertPathsToItems - Item $index has invalid FullName after Get-Item"
             }
-        }
-        catch {
+        } catch {
             Write-LogWarning "DEBUG: ConvertPathsToItems - Item $index failed to convert '$path' - $($_.Exception.Message)"
         }
     }

--- a/src/powershell/modules/FileManagement/FileDistributor/Private/State.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Private/State.ps1
@@ -2,6 +2,7 @@ function ConvertTo-Hashtable {
     param([Parameter(Mandatory = $true)]$Object)
 
     if ($null -eq $Object) { return $null }
+    if ($Object -is [FileDistributorRunState]) { return $Object.ToSerializableHashtable() }
     if ($Object -is [hashtable]) { return $Object }
     if ($Object -is [System.Collections.IDictionary]) { return @{} + $Object }
 

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionPhase.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-DistributionPhase.ps1
@@ -3,7 +3,7 @@
 function Invoke-DistributionPhase {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,
         [string]$SourceFolder,
         [Parameter(Mandatory = $true)][string]$TargetFolder,
@@ -28,7 +28,7 @@ function Invoke-DistributionPhase {
     if ($RunState.LastCheckpoint -lt 2) {
         if ([string]::IsNullOrWhiteSpace($SourceFolder)) {
             Write-LogInfo "Enumerating target files..."
-            $RunState.sourceFiles = @(); $RunState.totalSourceFiles = 0; $RunState.totalSourceFilesAll = 0
+            $RunState.SourceFiles = @(); $RunState.TotalSourceFiles = 0; $RunState.TotalSourceFilesAll = 0
         } else {
             Write-LogInfo "Enumerating source and target files..."
             $allSourceFiles = Get-ChildItem -Path $SourceFolder -Recurse -File
@@ -38,46 +38,46 @@ function Invoke-DistributionPhase {
                 $ext = $file.Extension.ToLower()
                 if ($ext -in $allowedExtensions) { $sourceFilesAll += $file }
                 else {
-                    if (-not $RunState.skippedFilesByExtension.ContainsKey($ext)) { $RunState.skippedFilesByExtension[$ext] = 0 }
-                    $RunState.skippedFilesByExtension[$ext]++
-                    $RunState.totalSkippedFiles++
+                    if (-not $RunState.SkippedFilesByExtension.ContainsKey($ext)) { $RunState.SkippedFilesByExtension[$ext] = 0 }
+                    $RunState.SkippedFilesByExtension[$ext]++
+                    $RunState.TotalSkippedFiles++
                 }
             }
-            $RunState.totalSourceFilesAll = $sourceFilesAll.Count
-            if ($RunState.MaxFilesToCopy -eq 0) { $RunState.sourceFiles = @() }
-            elseif ($RunState.MaxFilesToCopy -gt 0) { $RunState.sourceFiles = $sourceFilesAll | Select-Object -First $RunState.MaxFilesToCopy }
-            else { $RunState.sourceFiles = $sourceFilesAll }
-            $RunState.totalSourceFiles = $RunState.sourceFiles.Count
+            $RunState.TotalSourceFilesAll = $sourceFilesAll.Count
+            if ($RunState.MaxFilesToCopy -eq 0) { $RunState.SourceFiles = @() }
+            elseif ($RunState.MaxFilesToCopy -gt 0) { $RunState.SourceFiles = $sourceFilesAll | Select-Object -First $RunState.MaxFilesToCopy }
+            else { $RunState.SourceFiles = $sourceFilesAll }
+            $RunState.TotalSourceFiles = $RunState.SourceFiles.Count
         }
 
-        $RunState.totalTargetFilesBefore = (Get-ChildItem -Path $TargetFolder -Recurse -File | Measure-Object).Count
-        $RunState.totalTargetFilesBefore = if ($null -eq $RunState.totalTargetFilesBefore) { 0 } else { $RunState.totalTargetFilesBefore }
-        $totalFiles = $RunState.totalSourceFiles + $RunState.totalTargetFilesBefore
+        $RunState.TotalTargetFilesBefore = (Get-ChildItem -Path $TargetFolder -Recurse -File | Measure-Object).Count
+        $RunState.TotalTargetFilesBefore = if ($null -eq $RunState.TotalTargetFilesBefore) { 0 } else { $RunState.TotalTargetFilesBefore }
+        $totalFiles = $RunState.TotalSourceFiles + $RunState.TotalTargetFilesBefore
 
-        $RunState.subfolders = @(Get-ChildItem -LiteralPath $TargetFolder -Force | Where-Object { $_.PSIsContainer })
-        if ($totalFiles / $RunState.FilesPerFolderLimit -gt $RunState.subfolders.Count) {
-            $additionalFolders = [math]::Ceiling($totalFiles / $RunState.FilesPerFolderLimit) - $RunState.subfolders.Count
-            $RunState.subfolders += New-DistributionSubfolders -TargetPath $TargetFolder -NumberOfFolders $additionalFolders -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency
+        $RunState.Subfolders = @(Get-ChildItem -LiteralPath $TargetFolder -Force | Where-Object { $_.PSIsContainer })
+        if ($totalFiles / $RunState.FilesPerFolderLimit -gt $RunState.Subfolders.Count) {
+            $additionalFolders = [math]::Ceiling($totalFiles / $RunState.FilesPerFolderLimit) - $RunState.Subfolders.Count
+            $RunState.Subfolders += New-DistributionSubfolders -TargetPath $TargetFolder -NumberOfFolders $additionalFolders -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency
         }
 
-        Save-DistributionState -Checkpoint 2 -AdditionalVariables (New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.subfolders -SourceFiles $RunState.sourceFiles -IncludeSourceFiles) -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $WarningCount.Value -ErrorsSoFar $ErrorCount.Value -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
+        Save-DistributionState -Checkpoint 2 -AdditionalVariables (New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.Subfolders -SourceFiles $RunState.SourceFiles -IncludeSourceFiles) -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $WarningCount.Value -ErrorsSoFar $ErrorCount.Value -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
     }
 
     if ($RunState.LastCheckpoint -lt 3) {
-        $cp3 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.subfolders -SourceFiles $RunState.sourceFiles -IncludeSourceFiles -IncludeFilesToDelete
+        $cp3 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.Subfolders -SourceFiles $RunState.SourceFiles -IncludeSourceFiles -IncludeFilesToDelete
         Save-DistributionState -Checkpoint 3 -AdditionalVariables $cp3 -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $WarningCount.Value -ErrorsSoFar $ErrorCount.Value -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
     }
 
     if ($RunState.LastCheckpoint -lt 4) {
-        if ($RunState.totalSourceFiles -gt 0 -and $RunState.sourceFiles.Count -gt 0) {
-            Invoke-FileDistribution -Files $RunState.sourceFiles -Subfolders $RunState.subfolders -TargetRoot $TargetFolder -Limit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -TotalFiles $RunState.totalSourceFiles -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount $WarningCount -ErrorCount $ErrorCount
+        if ($RunState.TotalSourceFiles -gt 0 -and $RunState.SourceFiles.Count -gt 0) {
+            Invoke-FileDistribution -Files $RunState.SourceFiles -Subfolders $RunState.Subfolders -TargetRoot $TargetFolder -Limit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -TotalFiles $RunState.TotalSourceFiles -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount $WarningCount -ErrorCount $ErrorCount
         }
-        $cp4 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.subfolders -SourceFiles $RunState.sourceFiles -IncludeSourceFiles -IncludeFilesToDelete
+        $cp4 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -Subfolders $RunState.Subfolders -SourceFiles $RunState.SourceFiles -IncludeSourceFiles -IncludeFilesToDelete
         Save-DistributionState -Checkpoint 4 -AdditionalVariables $cp4 -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $WarningCount.Value -ErrorsSoFar $ErrorCount.Value -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
     }
 
     if ($RunState.LastCheckpoint -lt 5) {
-        Invoke-TargetRedistribution -TargetFolder $TargetFolder -Subfolders $RunState.subfolders -FilesPerFolderLimit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount $WarningCount -ErrorCount $ErrorCount
+        Invoke-TargetRedistribution -TargetFolder $TargetFolder -Subfolders $RunState.Subfolders -FilesPerFolderLimit $RunState.FilesPerFolderLimit -ShowProgress:$ShowProgress -UpdateFrequency:$UpdateFrequency -DeleteMode $DeleteMode -FilesToDelete $RunState.FilesToDelete -GlobalFileCounter $RunState.GlobalFileCounter -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff -WarningCount $WarningCount -ErrorCount $ErrorCount
         $cp5 = New-CheckpointPayload -RunState $RunState -DeleteMode $DeleteMode -SourceFolder $SourceFolder -MaxFilesToCopy $RunState.MaxFilesToCopy -IncludeFilesToDelete
         Save-DistributionState -Checkpoint 5 -AdditionalVariables $cp5 -FileLock $FileLockRef -SessionId $RunState.SessionId -WarningsSoFar $WarningCount.Value -ErrorsSoFar $ErrorCount.Value -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
     }

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-EndOfScriptDeletion.ps1
@@ -3,7 +3,7 @@
 function Invoke-EndOfScriptDeletion {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [int]$PriorWarnings,
         [int]$PriorErrors,
         [Parameter(Mandatory = $true)][string]$DeleteMode,
@@ -19,7 +19,7 @@ function Invoke-EndOfScriptDeletion {
     $frameworkWarnings = if (Get-Command -Name Get-LogWarningCount -ErrorAction SilentlyContinue) { Get-LogWarningCount } else { $WarningCount.Value }
     $frameworkErrors = if (Get-Command -Name Get-LogErrorCount -ErrorAction SilentlyContinue) { Get-LogErrorCount } else { $ErrorCount.Value }
     $effectiveWarnings = [Math]::Max($frameworkWarnings, $PriorWarnings)
-    $effectiveErrors   = [Math]::Max($frameworkErrors,   $PriorErrors)
+    $effectiveErrors = [Math]::Max($frameworkErrors, $PriorErrors)
 
     if (-not (Test-EndOfScriptCondition -Condition $EndOfScriptDeletionCondition -Warnings $effectiveWarnings -Errors $effectiveErrors)) {
         Write-LogInfo "End-of-script deletion skipped due to warnings or errors."

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-ParameterValidation.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-ParameterValidation.ps1
@@ -2,7 +2,7 @@
 
 function Invoke-ParameterValidation {
     param(
-        [Parameter(Mandatory = $true)][hashtable]$RunState,
+        [Parameter(Mandatory = $true)][FileDistributorRunState]$RunState,
         [string]$SourceFolder,
         [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$TargetFolder,
         [ValidateRange(1, [int]::MaxValue)][int]$FilesPerFolderLimit,
@@ -22,9 +22,11 @@ function Invoke-ParameterValidation {
 
     if ([string]::IsNullOrWhiteSpace($SourceFolder)) {
         $RunState.MaxFilesToCopy = 0
+        $RunState.SourceFolder = $null
         Write-LogInfo "SourceFolder not specified. Running in rebalance-only mode (no files will be copied)."
     } else {
         $RunState.MaxFilesToCopy = $MaxFilesToCopy
+        $RunState.SourceFolder = $SourceFolder
     }
 
     if (-not [string]::IsNullOrWhiteSpace($SourceFolder) -and -not (Test-Path -Path $SourceFolder)) {

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostProcessingPhase.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostProcessingPhase.ps1
@@ -3,7 +3,7 @@
 function Invoke-PostProcessingPhase {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,
         [switch]$ConsolidateToMinimum,
         [switch]$RebalanceToAverage,

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostRunCleanup.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-PostRunCleanup.ps1
@@ -2,7 +2,7 @@
 
 function Invoke-PostRunCleanup {
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,
         [Parameter(Mandatory = $true)][string]$TargetFolder,
         [Parameter(Mandatory = $true)][string]$StateFilePath,
@@ -17,7 +17,7 @@ function Invoke-PostRunCleanup {
     $totalTargetFilesAfter = Get-ChildItem -Path $TargetFolder -Recurse -File | Measure-Object | Select-Object -ExpandProperty Count
     $totalTargetFilesAfter = if ($null -eq $totalTargetFilesAfter) { 0 } else { $totalTargetFilesAfter }
 
-    if ([string]::IsNullOrWhiteSpace($RunState['SourceFolder'])) {
+    if ([string]::IsNullOrWhiteSpace($RunState.SourceFolder)) {
         Write-LogInfo "===== File Rebalancing Summary ====="
         Write-LogInfo "Original number of files in the target folder hierarchy: $($RunState.totalTargetFilesBefore)"
         Write-LogInfo "Final number of files in the target folder hierarchy: $totalTargetFilesAfter"

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-RestoreCheckpoint.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/Invoke-RestoreCheckpoint.ps1
@@ -2,7 +2,7 @@
 
 function Invoke-RestoreCheckpoint {
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [Parameter(Mandatory = $true)][ref]$FileLockRef,
         [Parameter(Mandatory = $true)][ref]$PriorWarnings,
         [Parameter(Mandatory = $true)][ref]$PriorErrors,
@@ -24,7 +24,15 @@ function Invoke-RestoreCheckpoint {
 
         $state = Restore-DistributionState -FileLock $FileLockRef -StateFilePath $StateFilePath -RetryDelay $RetryDelay -RetryCount $RetryCount -MaxBackoff $MaxBackoff
         $RunState.State = $state
-        $RunState.LastCheckpoint = $state.Checkpoint
+        $restoredRunState = [FileDistributorRunState]::FromHashtable($state)
+        $RunState.LastCheckpoint = $restoredRunState.LastCheckpoint
+        $RunState.TotalSourceFiles = $restoredRunState.TotalSourceFiles
+        $RunState.TotalSourceFilesAll = $restoredRunState.TotalSourceFilesAll
+        $RunState.TotalTargetFilesBefore = $restoredRunState.TotalTargetFilesBefore
+        $RunState.TotalSkippedFiles = $restoredRunState.TotalSkippedFiles
+        if ($restoredRunState.SkippedFilesByExtension) {
+            $RunState.SkippedFilesByExtension = @{} + $restoredRunState.SkippedFilesByExtension
+        }
 
         if ($RunState.LastCheckpoint -gt 0) {
             if ($state.PSObject.Properties.Name -contains 'SessionId' -and $state.SessionId) {
@@ -50,6 +58,7 @@ function Invoke-RestoreCheckpoint {
                     throw "SourceFolder mismatch: Restarted script must use the saved SourceFolder ('$savedSourceFolder'). Aborting."
                 }
             }
+            $RunState.SourceFolder = [string]$savedSourceFolder
         } else {
             throw "State file does not contain SourceFolder. Unable to enforce."
         }
@@ -64,9 +73,6 @@ function Invoke-RestoreCheckpoint {
         }
 
         if ($RunState.LastCheckpoint -in 2..7 -and $null -ne $state) {
-            if ($state.ContainsKey('totalSourceFiles'))     { $RunState.totalSourceFiles     = [int]$state['totalSourceFiles'] }
-            if ($state.ContainsKey('totalTargetFilesBefore')) { $RunState.totalTargetFilesBefore = [int]$state['totalTargetFilesBefore'] }
-            if ($state.ContainsKey('totalSourceFilesAll'))  { $RunState.totalSourceFilesAll  = [int]$state['totalSourceFilesAll'] }
             if ($state.ContainsKey('MaxFilesToCopy')) {
                 $savedMax = [int]$state['MaxFilesToCopy']
                 if ($RunState.MaxFilesToCopy -ne $savedMax) {
@@ -74,8 +80,8 @@ function Invoke-RestoreCheckpoint {
                 }
                 $RunState.MaxFilesToCopy = $savedMax
             }
-            if ($state.ContainsKey('subfolders')) { $RunState.subfolders = ConvertPathsToItems($state['subfolders']) }
-            if ($RunState.LastCheckpoint -in 2, 3 -and $state.ContainsKey('sourceFiles')) { $RunState.sourceFiles = ConvertPathsToItems($state['sourceFiles']) }
+            if ($state.ContainsKey('subfolders')) { $RunState.Subfolders = ConvertPathsToItems($state['subfolders']) }
+            if ($RunState.LastCheckpoint -in 2, 3 -and $state.ContainsKey('sourceFiles')) { $RunState.SourceFiles = ConvertPathsToItems($state['sourceFiles']) }
         }
 
         if ($DeleteMode -eq "EndOfScript" -and $RunState.LastCheckpoint -in 3, 4, 5, 6, 7 -and $state.ContainsKey("FilesToDelete")) {

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/New-CheckpointPayload.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/New-CheckpointPayload.ps1
@@ -2,7 +2,7 @@
 
 function New-CheckpointPayload {
     param(
-        [hashtable]$RunState,
+        [FileDistributorRunState]$RunState,
         [Parameter(Mandatory = $true)][string]$DeleteMode,
         [string]$SourceFolder,
         [int]$MaxFilesToCopy,
@@ -12,14 +12,10 @@ function New-CheckpointPayload {
         [switch]$IncludeFilesToDelete
     )
 
-    $payload = @{
-        totalSourceFiles       = $RunState.totalSourceFiles
-        totalSourceFilesAll    = $RunState.totalSourceFilesAll
-        totalTargetFilesBefore = $RunState.totalTargetFilesBefore
-        deleteMode             = $DeleteMode
-        SourceFolder           = $SourceFolder
-        MaxFilesToCopy         = $MaxFilesToCopy
-    }
+    $payload = Convert-RunStateToSerializableHashtable -RunState $RunState
+    $payload.deleteMode = $DeleteMode
+    $payload.SourceFolder = $SourceFolder
+    $payload.MaxFilesToCopy = $MaxFilesToCopy
 
     if ($null -ne $Subfolders) {
         $payload.subfolders = ConvertItemsToPaths($Subfolders)

--- a/tests/powershell/modules/FileManagement/FileDistributor/FileDistributorRunState.Tests.ps1
+++ b/tests/powershell/modules/FileManagement/FileDistributor/FileDistributorRunState.Tests.ps1
@@ -1,6 +1,8 @@
 BeforeAll {
-    $script:ModulePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psd1'
+    $script:ClassPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'Private' 'FileDistributorRunState.ps1'
+    $script:ModulePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psd1'
 
+    . $script:ClassPath
     Import-Module -Name $script:ModulePath -Force | Out-Null
 }
 
@@ -8,13 +10,13 @@ Describe 'FileDistributorRunState typed state contract' {
     It 'constructs with expected default values' {
         $state = [FileDistributorRunState]::new()
 
-        $state | Should -BeOfType 'FileDistributorRunState'
+        $state.GetType().Name | Should -Be 'FileDistributorRunState'
         $state.TotalSourceFilesAll | Should -Be 0
         $state.TotalSourceFiles | Should -Be 0
         $state.TotalTargetFilesBefore | Should -Be 0
         $state.TotalSkippedFiles | Should -Be 0
-        $state.Subfolders | Should -BeEmpty
-        $state.SourceFiles | Should -BeEmpty
+        $state.Subfolders.Count | Should -Be 0
+        $state.SourceFiles.Count | Should -Be 0
         $state.SkippedFilesByExtension.Count | Should -Be 0
     }
 
@@ -78,15 +80,15 @@ Describe 'FileDistributorRunState typed state contract' {
 
     It 'loads legacy checkpoint hashtable shape using case-insensitive keys' {
         $legacy = @{
-            totalsourcefiles = 12
-            TOTALSOURCEFILESALL = 20
-            totaltargetfilesbefore = 8
-            maxfilestocopy = 12
-            sourcefolder = 'C:\legacy'
-            totalskippedfiles = 2
+            totalsourcefiles        = 12
+            TOTALSOURCEFILESALL     = 20
+            totaltargetfilesbefore  = 8
+            maxfilestocopy          = 12
+            sourcefolder            = 'C:\legacy'
+            totalskippedfiles       = 2
             skippedfilesbyextension = @{ '.tmp' = 2 }
-            checkpoint = 3
-            sessionid = 'legacy-session-id'
+            checkpoint              = 3
+            sessionid               = 'legacy-session-id'
         }
 
         $state = [FileDistributorRunState]::FromHashtable($legacy)

--- a/tests/powershell/modules/FileManagement/FileDistributor/FileDistributorRunState.Tests.ps1
+++ b/tests/powershell/modules/FileManagement/FileDistributor/FileDistributorRunState.Tests.ps1
@@ -1,0 +1,104 @@
+BeforeAll {
+    $script:ModulePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psd1'
+
+    Import-Module -Name $script:ModulePath -Force | Out-Null
+}
+
+Describe 'FileDistributorRunState typed state contract' {
+    It 'constructs with expected default values' {
+        $state = [FileDistributorRunState]::new()
+
+        $state | Should -BeOfType 'FileDistributorRunState'
+        $state.TotalSourceFilesAll | Should -Be 0
+        $state.TotalSourceFiles | Should -Be 0
+        $state.TotalTargetFilesBefore | Should -Be 0
+        $state.TotalSkippedFiles | Should -Be 0
+        $state.Subfolders | Should -BeEmpty
+        $state.SourceFiles | Should -BeEmpty
+        $state.SkippedFilesByExtension.Count | Should -Be 0
+    }
+
+    It 'supports property mutation with typed fields' {
+        $state = [FileDistributorRunState]::new()
+
+        $state.TotalSourceFilesAll = 25
+        $state.TotalSourceFiles = 10
+        $state.TotalTargetFilesBefore = 5
+        $state.TotalSkippedFiles = 3
+        $state.MaxFilesToCopy = 10
+        $state.SourceFolder = 'C:\source'
+        $state.SkippedFilesByExtension['.tmp'] = 3
+
+        $state.TotalSourceFilesAll | Should -Be 25
+        $state.TotalSourceFiles | Should -Be 10
+        $state.TotalTargetFilesBefore | Should -Be 5
+        $state.TotalSkippedFiles | Should -Be 3
+        $state.MaxFilesToCopy | Should -Be 10
+        $state.SourceFolder | Should -Be 'C:\source'
+        $state.SkippedFilesByExtension['.tmp'] | Should -Be 3
+    }
+
+    It 'round-trips through JSON using ToSerializableHashtable and FromHashtable' {
+        $state = [FileDistributorRunState]::new()
+        $state.TotalSourceFilesAll = 120
+        $state.TotalSourceFiles = 50
+        $state.TotalTargetFilesBefore = 70
+        $state.TotalSkippedFiles = 11
+        $state.MaxFilesToCopy = 50
+        $state.SourceFolder = 'C:\input'
+        $state.SkippedFilesByExtension['.gif'] = 11
+
+        $payload = $state.ToSerializableHashtable()
+        $json = $payload | ConvertTo-Json -Depth 10
+        $deserialized = ConvertFrom-Json -InputObject $json
+
+        $roundTripTable = @{}
+        foreach ($prop in $deserialized.PSObject.Properties) {
+            if ($prop.Value -is [System.Management.Automation.PSCustomObject]) {
+                $inner = @{}
+                foreach ($innerProp in $prop.Value.PSObject.Properties) {
+                    $inner[$innerProp.Name] = $innerProp.Value
+                }
+                $roundTripTable[$prop.Name] = $inner
+            } else {
+                $roundTripTable[$prop.Name] = $prop.Value
+            }
+        }
+
+        $roundTrip = [FileDistributorRunState]::FromHashtable($roundTripTable)
+
+        $roundTrip.TotalSourceFilesAll | Should -Be 120
+        $roundTrip.TotalSourceFiles | Should -Be 50
+        $roundTrip.TotalTargetFilesBefore | Should -Be 70
+        $roundTrip.TotalSkippedFiles | Should -Be 11
+        $roundTrip.MaxFilesToCopy | Should -Be 50
+        $roundTrip.SourceFolder | Should -Be 'C:\input'
+        $roundTrip.SkippedFilesByExtension['.gif'] | Should -Be 11
+    }
+
+    It 'loads legacy checkpoint hashtable shape using case-insensitive keys' {
+        $legacy = @{
+            totalsourcefiles = 12
+            TOTALSOURCEFILESALL = 20
+            totaltargetfilesbefore = 8
+            maxfilestocopy = 12
+            sourcefolder = 'C:\legacy'
+            totalskippedfiles = 2
+            skippedfilesbyextension = @{ '.tmp' = 2 }
+            checkpoint = 3
+            sessionid = 'legacy-session-id'
+        }
+
+        $state = [FileDistributorRunState]::FromHashtable($legacy)
+
+        $state.TotalSourceFiles | Should -Be 12
+        $state.TotalSourceFilesAll | Should -Be 20
+        $state.TotalTargetFilesBefore | Should -Be 8
+        $state.MaxFilesToCopy | Should -Be 12
+        $state.SourceFolder | Should -Be 'C:\legacy'
+        $state.TotalSkippedFiles | Should -Be 2
+        $state.SkippedFilesByExtension['.tmp'] | Should -Be 2
+        $state.LastCheckpoint | Should -Be 3
+        $state.SessionId | Should -Be 'legacy-session-id'
+    }
+}


### PR DESCRIPTION
Introduce FileDistributorRunState with typed properties and serialization helpers.

Update Invoke-* orchestration signatures to accept FileDistributorRunState and preserve legacy checkpoint compatibility.

Add run state tests for defaults, mutation, JSON round-trip, and legacy load support.

Closes #935