### PR TITLE
refactor(expand-zipsandclean): extract named phase functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,12 +54,17 @@ Entries older than the current minor release line are condensed to architectural
   - Added warning/error counter APIs to `PowerShellLoggingFramework` (`Get-LogWarningCount`, `Get-LogErrorCount`, `Reset-LogCounters`) and updated FileDistributor end-of-script/summary paths to source totals from the logging framework.
   - Bumped versions: `FileDistributor.ps1` to `4.8.4` and `PowerShellLoggingFramework` module to `2.0.1`.
 
-- **Expand-ZipsAndClean.ps1** bumped to v2.0.1 (issue #937)
-  - Refactored: seven generic helper functions moved to `FileSystem.psm1` module
-    for reuse across other scripts (no behavioral changes to script)
-  - Removed from script: `Get-FullPath`, `Format-Bytes`, `Resolve-UniquePathCore`,
-    `Resolve-UniquePath`, `Resolve-UniqueDirectoryPath`, `Get-SafeName`,
-    `Test-LongPathsEnabled` (now imported via `FileSystem.psm1`)
+- **Expand-ZipsAndClean.ps1** bumped to v2.0.2 (issues #937, #938)
+  - v2.0.1: Refactored seven generic helper functions into `FileSystem.psm1`
+    for reuse across scripts (no behavioral changes).
+  - v2.0.2: Refactored main execution into named phase helpers:
+    `Test-ScriptPreconditions`, `Initialize-Destination`,
+    `Invoke-ZipExtractions`, `Move-ZipFilesToParent`, and
+    `Remove-SourceDirectory`.
+  - Renamed `Move-Zips-ToParent` to `Move-ZipFilesToParent` to align with
+    PowerShell Verb-Noun naming conventions.
+  - Removed duplicate historical entries (`1.1.1`–`1.2.2`) from the script
+    `.NOTES` version history block.
 
 - **Sync-MacriumBackups.ps1** bumped to v2.7.2
   - v2.7.0: Extracted all eight state management functions into the new `BackupState`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,13 +54,16 @@ Entries older than the current minor release line are condensed to architectural
   - Added warning/error counter APIs to `PowerShellLoggingFramework` (`Get-LogWarningCount`, `Get-LogErrorCount`, `Reset-LogCounters`) and updated FileDistributor end-of-script/summary paths to source totals from the logging framework.
   - Bumped versions: `FileDistributor.ps1` to `4.8.4` and `PowerShellLoggingFramework` module to `2.0.1`.
 
-- **Expand-ZipsAndClean.ps1** bumped to v2.0.2 (issues #937, #938)
+- **Expand-ZipsAndClean.ps1** bumped to v2.0.3 (issues #937, #938)
   - v2.0.1: Refactored seven generic helper functions into `FileSystem.psm1`
     for reuse across scripts (no behavioral changes).
   - v2.0.2: Refactored main execution into named phase helpers:
     `Test-ScriptPreconditions`, `Initialize-Destination`,
     `Invoke-ZipExtractions`, `Move-ZipFilesToParent`, and
     `Remove-SourceDirectory`.
+  - v2.0.3: Review follow-up — added comment-based help blocks to extracted
+    phase functions for readability/documentation consistency; no behavior
+    changes.
   - Renamed `Move-Zips-ToParent` to `Move-ZipFilesToParent` to align with
     PowerShell Verb-Noun naming conventions.
   - Removed duplicate historical entries (`1.1.1`–`1.2.2`) from the script

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -93,12 +93,17 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.0.2
+    Version  : 2.0.3
     Author   : Manoj Bhaskaran
     Requires : PowerShell 5.1 or 7+, Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.0.3  Review follow-up: added comment-based help to extracted phase functions
+           (Test-ScriptPreconditions, Initialize-Destination, Invoke-ZipExtractions,
+           Remove-SourceDirectory) for clarity and script documentation consistency.
+           No behavioral changes.
+
     2.0.2  Refactored orchestration into named phase functions:
            - Test-ScriptPreconditions, Initialize-Destination,
              Invoke-ZipExtractions, Move-ZipFilesToParent, Remove-SourceDirectory
@@ -393,6 +398,10 @@ function Expand-ZipSmart {
     }
 }
 
+<#
+.SYNOPSIS
+    Validates source/destination safety constraints before any file operations.
+#>
 function Test-ScriptPreconditions {
     [CmdletBinding()]
     param(
@@ -426,6 +435,10 @@ function Test-ScriptPreconditions {
     }
 }
 
+<#
+.SYNOPSIS
+    Ensures destination root exists before extraction begins.
+#>
 function Initialize-Destination {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$DestinationDir)
@@ -437,6 +450,10 @@ function Initialize-Destination {
     }
 }
 
+<#
+.SYNOPSIS
+    Extracts all zip files from source to destination and returns summary totals.
+#>
 function Invoke-ZipExtractions {
     [CmdletBinding()]
     param(
@@ -507,6 +524,10 @@ function Invoke-ZipExtractions {
     }
 }
 
+<#
+.SYNOPSIS
+    Optionally cleans non-zip leftovers and removes the source directory.
+#>
 function Remove-SourceDirectory {
     [CmdletBinding()]
     param(

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -93,12 +93,19 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.0.1
+    Version  : 2.0.2
     Author   : Manoj Bhaskaran
     Requires : PowerShell 5.1 or 7+, Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.0.2  Refactored orchestration into named phase functions:
+           - Test-ScriptPreconditions, Initialize-Destination,
+             Invoke-ZipExtractions, Move-ZipFilesToParent, Remove-SourceDirectory
+           Renamed Move-Zips-ToParent -> Move-ZipFilesToParent to follow Verb-Noun.
+           Removed duplicate 1.1.1-1.2.2 entries from version history block.
+           Script behavior unchanged.
+
     2.0.1  Refactored: Moved generic helper functions to FileSystem.psm1 module
            for shared reuse across scripts. Moved functions:
            - Get-FullPath, Format-Bytes, Resolve-UniquePathCore
@@ -135,24 +142,6 @@
            for password-protected zips, unique subfolder naming if exists, parent
            writability check, optional -CleanNonZips, consistent summary printing,
            table summary, ms in duration, and expanded docs/FAQ.
-    1.1.1  Safety/UX: guard against same/overlapping source/destination, optional
-           MaxSafeNameLength, per-file move progress, compression ratio, de-duped
-           suffix logic, directory write probe, docs for novices, PS 5.1 note.
-    1.1.2  Quick wins: path separator normalization for comparisons, verbose notice
-           on truncation, bytes shown in move progress, compression ratio rounded
-           to 1 decimal, `.EXAMPLE` for MaxSafeNameLength + -Verbose, notes on
-           typical MaxSafeNameLength values, FAQ includes 7-Zip example.
-    1.2.0  Flat mode now streams via ZipArchive (no temp folder; pre-check collisions);
-           function-level help & more inline comments; cache minor lookups;
-           progress shows cumulative bytes moved; docs extend security caveats and
-           rationale for 255-char limit; notes clarify ratio meaning.
-    1.2.1  Docs/UX polish: .NOTES calls out Zip Slip protection; parameter doc & NOTES
-           reiterate 255-char rationale; verbose truncation message retained (with
-           original length); clarify ExtractToFile overwrite flag comment; progress shows
-           total bytes target; FAQ explains CompressionRatio; minor comments on caching.
-    1.2.2  Fixes & UX: Move Format-Bytes to Helpers (scope); adaptive summary layout
-           (table for wide consoles, list for narrow) to prevent header wrapping.
-
     ── Setup / Module check ─────────────────────────────────────────────────────
     Expand-Archive is provided by Microsoft.PowerShell.Archive.
     • PowerShell 5.1: The module is included with Windows Management Framework 5.1.
@@ -404,11 +393,169 @@ function Expand-ZipSmart {
     }
 }
 
+function Test-ScriptPreconditions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir
+    )
+
+    $srcFull = Get-FullPath -Path $SourceDir
+    $dstFull = Get-FullPath -Path $DestinationDir
+
+    if ($srcFull -eq $dstFull) {
+        throw "Source and destination cannot be the same: $srcFull"
+    }
+
+    $srcWithSep = if ($srcFull.EndsWith('\')) { $srcFull } else { $srcFull + '\' }
+    $dstWithSep = if ($dstFull.EndsWith('\')) { $dstFull } else { $dstFull + '\' }
+
+    if ($dstWithSep.StartsWith($srcWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Destination cannot be inside the source directory."
+    }
+    if ($srcWithSep.StartsWith($dstWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Source cannot be inside the destination directory."
+    }
+
+    if (-not (Test-Path -LiteralPath $SourceDir)) {
+        throw "Source directory not found: $SourceDir"
+    }
+
+    if (-not (Test-LongPathsEnabled)) {
+        Write-LogDebug "LongPathsEnabled=0; consider enabling to avoid path-length issues."
+    }
+}
+
+function Initialize-Destination {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$DestinationDir)
+
+    if (-not (Test-Path -LiteralPath $DestinationDir)) {
+        if ($PSCmdlet.ShouldProcess($DestinationDir, "Create destination directory")) {
+            New-DirectoryIfMissing -Path $DestinationDir -Force | Out-Null
+        }
+    }
+}
+
+function Invoke-ZipExtractions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir,
+        [Parameter(Mandatory)][string]$Mode,
+        [Parameter(Mandatory)][string]$Policy,
+        [Parameter(Mandatory)][int]$SafeNameMaxLen,
+        [Parameter(Mandatory)][bool]$QuietMode,
+        [Parameter(Mandatory)][System.Collections.Generic.List[string]]$ErrorList
+    )
+
+    $processedZips = 0
+    $totalFilesExtracted = 0
+    $totalUncompressedBytes = [int64]0
+    $totalCompressedZipBytes = [int64]0
+
+    $zips = @(Get-ChildItem -LiteralPath $SourceDir -Filter *.zip -File -ErrorAction Stop)
+    $zipCount = $zips.Count
+
+    Write-LogInfo "Found $zipCount zip file(s) in: $SourceDir"
+    Write-LogInfo "Extracting to: $DestinationDir (Mode: $Mode, Policy: $Policy)"
+
+    if ($zipCount -gt 0) {
+        $index = 0
+        foreach ($zip in $zips) {
+            $index++
+            try {
+                if (-not $QuietMode) {
+                    $pct = [int](($index - 1) / [math]::Max(1, $zipCount) * 100)
+                    Write-Progress -Activity "Extracting archives" -Status $zip.Name -PercentComplete $pct
+                }
+
+                if ($PSCmdlet.ShouldProcess($zip.FullName, "Extract")) {
+                    $stats = Get-ZipFileStats -ZipPath $zip.FullName
+                    $stats.CompressedBytes = [int64]$zip.Length
+
+                    $filesFromZip = Expand-ZipSmart -ZipPath $zip.FullName `
+                        -DestinationRoot $DestinationDir `
+                        -ExtractMode $Mode `
+                        -CollisionPolicy $Policy `
+                        -SafeNameMaxLen $SafeNameMaxLen
+
+                    $totalFilesExtracted += (($filesFromZip -is [int]) ? $filesFromZip : $stats.FileCount)
+                    $totalUncompressedBytes += $stats.UncompressedBytes
+                    $totalCompressedZipBytes += $stats.CompressedBytes
+                    $processedZips++
+                    Write-LogDebug "Extracted '$($zip.Name)': files=$($stats.FileCount), uncompressed=$($stats.UncompressedBytes), compressed=$($stats.CompressedBytes)"
+                }
+            } catch {
+                $msg = $_.Exception.Message
+                $ErrorList.Add("Extraction failed for '$($zip.FullName)': $msg") | Out-Null
+                Write-LogDebug $msg
+            }
+        }
+
+        if (-not $QuietMode) {
+            Write-Progress -Activity "Extracting archives" -Completed
+        }
+    }
+
+    return [pscustomobject]@{
+        ZipCount = $zipCount
+        ProcessedZips = $processedZips
+        FilesExtracted = $totalFilesExtracted
+        UncompressedBytes = $totalUncompressedBytes
+        CompressedBytes = $totalCompressedZipBytes
+    }
+}
+
+function Remove-SourceDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][bool]$ShouldDeleteSource,
+        [Parameter(Mandatory)][bool]$ShouldCleanNonZips,
+        [Parameter(Mandatory)][System.Collections.Generic.List[string]]$ErrorList
+    )
+
+    if (-not $ShouldDeleteSource) {
+        return
+    }
+
+    try {
+        $remaining = Get-ChildItem -LiteralPath $SourceDir -Recurse -Force -ErrorAction SilentlyContinue
+        $nonZips = @($remaining | Where-Object { (-not $_.PSIsContainer -and $_.Extension -ne '.zip') -or $_.PSIsContainer })
+        if ($nonZips.Count -gt 0 -and -not $ShouldCleanNonZips) {
+            $ErrorList.Add("DeleteSource skipped: non-zip items remain. Use -CleanNonZips to remove them.") | Out-Null
+            Write-LogDebug ("Remaining items: `n" + ($nonZips | Select-Object -ExpandProperty FullName | Out-String))
+            return
+        }
+
+        if ($ShouldCleanNonZips -and $nonZips.Count -gt 0) {
+            if ($PSCmdlet.ShouldProcess($SourceDir, "Clean non-zip items before delete")) {
+                $nonZips | ForEach-Object {
+                    try {
+                        Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop
+                    } catch {
+                        $ErrorList.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null
+                    }
+                }
+            }
+        }
+
+        if ($PSCmdlet.ShouldProcess($SourceDir, "Delete source directory")) {
+            Remove-Item -LiteralPath $SourceDir -Recurse -Force
+        }
+    } catch {
+        $msg = "Failed to delete source directory '$SourceDir': $($_.Exception.Message)"
+        Write-LogDebug $msg
+        $ErrorList.Add($msg) | Out-Null
+    }
+}
+
 <#
 .SYNOPSIS
     Moves .zip files from SourceDir to its parent folder with per-file progress.
 #>
-function Move-Zips-ToParent {
+function Move-ZipFilesToParent {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$SourceDir)
 
@@ -478,89 +625,27 @@ $totalCompressedZipBytes = [int64]0
 $moveSummary = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = "" }
 
 try {
-    # Guard: same/overlapping paths (prevent destructive/undefined behaviors)
-    $srcFull = Get-FullPath -Path $SourceDirectory
-    $dstFull = Get-FullPath -Path $DestinationDirectory
+    Test-ScriptPreconditions -SourceDir $SourceDirectory -DestinationDir $DestinationDirectory
+    Initialize-Destination -DestinationDir $DestinationDirectory
 
-    if ($srcFull -eq $dstFull) {
-        throw "Source and destination cannot be the same: $srcFull"
-    }
+    $extractionResult = Invoke-ZipExtractions `
+        -SourceDir $SourceDirectory `
+        -DestinationDir $DestinationDirectory `
+        -Mode $ExtractMode `
+        -Policy $CollisionPolicy `
+        -SafeNameMaxLen $MaxSafeNameLength `
+        -QuietMode $Quiet.IsPresent `
+        -ErrorList $errors
 
-    # Add trailing backslash for containment tests (use normalized paths)
-    $srcWithSep = if ($srcFull.EndsWith('\')) { $srcFull } else { $srcFull + '\' }
-    $dstWithSep = if ($dstFull.EndsWith('\')) { $dstFull } else { $dstFull + '\' }
+    $zipCount = $extractionResult.ZipCount
+    $processedZips = $extractionResult.ProcessedZips
+    $totalFilesExtracted = $extractionResult.FilesExtracted
+    $totalUncompressedBytes = $extractionResult.UncompressedBytes
+    $totalCompressedZipBytes = $extractionResult.CompressedBytes
 
-    if ($dstWithSep.StartsWith($srcWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw "Destination cannot be inside the source directory."
-    }
-    if ($srcWithSep.StartsWith($dstWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw "Source cannot be inside the destination directory."
-    }
-
-    if (-not (Test-Path -LiteralPath $SourceDirectory)) {
-        throw "Source directory not found: $SourceDirectory"
-    }
-
-    # Destination readiness
-    if (-not (Test-Path -LiteralPath $DestinationDirectory)) {
-        if ($PSCmdlet.ShouldProcess($DestinationDirectory, "Create destination directory")) {
-            New-DirectoryIfMissing -Path $DestinationDirectory -Force | Out-Null
-        }
-    }
-
-    if (-not (Test-LongPathsEnabled)) {
-        Write-LogDebug "LongPathsEnabled=0; consider enabling to avoid path-length issues."
-    }
-
-    $zips = @(Get-ChildItem -LiteralPath $SourceDirectory -Filter *.zip -File -ErrorAction Stop)
-    $zipCount = $zips.Count
-
-    Write-LogInfo "Found $zipCount zip file(s) in: $SourceDirectory"
-    Write-LogInfo "Extracting to: $DestinationDirectory (Mode: $ExtractMode, Policy: $CollisionPolicy)"
-
-    if ($zipCount -gt 0) {
-        $index = 0
-        foreach ($zip in $zips) {
-            $index++
-            try {
-                if (-not $Quiet) {
-                    $pct = [int](($index - 1) / [math]::Max(1, $zipCount) * 100)
-                    Write-Progress -Activity "Extracting archives" -Status $zip.Name -PercentComplete $pct
-                }
-
-                if ($PSCmdlet.ShouldProcess($zip.FullName, "Extract")) {
-                    $stats = Get-ZipFileStats -ZipPath $zip.FullName
-                    # Cache compressed bytes from the FileInfo to avoid redundant Get-Item
-                    $stats.CompressedBytes = [int64]$zip.Length
-
-                    $filesFromZip = Expand-ZipSmart -ZipPath $zip.FullName `
-                        -DestinationRoot $DestinationDirectory `
-                        -ExtractMode $ExtractMode `
-                        -CollisionPolicy $CollisionPolicy `
-                        -SafeNameMaxLen $MaxSafeNameLength
-
-                    $totalFilesExtracted += ( ($filesFromZip -is [int]) ? $filesFromZip : $stats.FileCount )
-                    $totalUncompressedBytes += $stats.UncompressedBytes
-                    $totalCompressedZipBytes += $stats.CompressedBytes
-                    $processedZips++
-                    Write-LogDebug "Extracted '$($zip.Name)': files=$($stats.FileCount), uncompressed=$($stats.UncompressedBytes), compressed=$($stats.CompressedBytes)"
-                }
-            } catch {
-                $msg = $_.Exception.Message
-                $errors.Add("Extraction failed for '$($zip.FullName)': $msg") | Out-Null
-                Write-LogDebug $msg
-            }
-        }
-
-        if (-not $Quiet) {
-            Write-Progress -Activity "Extracting archives" -Completed
-        }
-    }
-
-    # Move zips to parent
     try {
         if ($PSCmdlet.ShouldProcess($SourceDirectory, "Move .zip files to parent")) {
-            $moveSummary = Move-Zips-ToParent -SourceDir $SourceDirectory
+            $moveSummary = Move-ZipFilesToParent -SourceDir $SourceDirectory
         }
     } catch {
         $msg = "Moving .zip files to parent failed: $($_.Exception.Message)"
@@ -568,35 +653,11 @@ try {
         $errors.Add($msg) | Out-Null
     }
 
-    # Optionally delete/clean source directory
-    if ($DeleteSource) {
-        try {
-            # If not cleaning non-zips, warn and list if anything other than zip remains
-            # (We include containers in "non-zips" to catch leftover directories.)
-            $remaining = Get-ChildItem -LiteralPath $SourceDirectory -Recurse -Force -ErrorAction SilentlyContinue
-            $nonZips = @($remaining | Where-Object { -not $_.PSIsContainer -and $_.Extension -ne '.zip' -or $_.PSIsContainer })
-            if ($nonZips.Count -gt 0 -and -not $CleanNonZips) {
-                $errors.Add("DeleteSource skipped: non-zip items remain. Use -CleanNonZips to remove them.") | Out-Null
-                Write-LogDebug ("Remaining items: `n" + ($nonZips | Select-Object -ExpandProperty FullName | Out-String))
-            } else {
-                if ($CleanNonZips -and $nonZips.Count -gt 0) {
-                    if ($PSCmdlet.ShouldProcess($SourceDirectory, "Clean non-zip items before delete")) {
-                        # Remove non-zip files and directories
-                        $nonZips | ForEach-Object {
-                            try { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop } catch { $errors.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null }
-                        }
-                    }
-                }
-                if ($PSCmdlet.ShouldProcess($SourceDirectory, "Delete source directory")) {
-                    Remove-Item -LiteralPath $SourceDirectory -Recurse -Force
-                }
-            }
-        } catch {
-            $msg = "Failed to delete source directory '$SourceDirectory': $($_.Exception.Message)"
-            Write-LogDebug $msg
-            $errors.Add($msg) | Out-Null
-        }
-    }
+    Remove-SourceDirectory `
+        -SourceDir $SourceDirectory `
+        -ShouldDeleteSource $DeleteSource.IsPresent `
+        -ShouldCleanNonZips $CleanNonZips.IsPresent `
+        -ErrorList $errors
 
 } catch {
     $errors.Add("Fatal error: $($_.Exception.Message)") | Out-Null

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.0.2** (2026-04-13)
+  - Refactored the top-level execution flow into named phase functions (`Test-ScriptPreconditions`, `Initialize-Destination`, `Invoke-ZipExtractions`, `Move-ZipFilesToParent`, `Remove-SourceDirectory`) so the main orchestration is easier to follow.
+  - Renamed `Move-Zips-ToParent` to `Move-ZipFilesToParent` for PowerShell naming convention compliance.
+  - Removed duplicate historical entries from the script `.NOTES` version history block.
 - **FileDistributor.ps1 v4.8.8** (module v1.2.5) (2026-04-12)
   - Hardened parameter contracts using `ValidateRange`/`ValidateSet` attributes for core limit/retry/delete-mode inputs in the script and module public functions.
   - Removed redundant dead defensive checks in `Invoke-ParameterValidation` that are now enforced by parameter binding.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,8 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.0.3** (2026-04-13)
+  - Review follow-up: added comment-based help blocks for extracted phase functions to keep inline script documentation consistent.
 - **Expand-ZipsAndClean.ps1 v2.0.2** (2026-04-13)
   - Refactored the top-level execution flow into named phase functions (`Test-ScriptPreconditions`, `Initialize-Destination`, `Invoke-ZipExtractions`, `Move-ZipFilesToParent`, `Remove-SourceDirectory`) so the main orchestration is easier to follow.
   - Renamed `Move-Zips-ToParent` to `Move-ZipFilesToParent` for PowerShell naming convention compliance.


### PR DESCRIPTION
### Motivation

- Improve readability and maintainability by moving the monolithic main execution body into clearly named phase functions. 
- Make orchestration easier to test and evolve, and align function naming with PowerShell Verb-Noun conventions.

### Description

- Extracted the main orchestration into named phase functions: `Test-ScriptPreconditions`, `Initialize-Destination`, `Invoke-ZipExtractions`, `Move-ZipFilesToParent`, and `Remove-SourceDirectory` so the top-level `try` block now delegates to these phases. 
- Renamed `Move-Zips-ToParent` → `Move-ZipFilesToParent` and updated call sites to match the new name. 
- Replaced the large inline extraction / move / cleanup logic with a concise orchestration that calls the phase helpers and aggregates returned extraction summary data. 
- Bumped the script `.NOTES` `Version` to `2.0.2`, removed duplicate historical entries in the header, and updated `CHANGELOG.md` and `src/powershell/file-management/README.md` to document the refactor. 
- This is an internal refactor with no intended behavioral change to extraction/move/delete logic; SemVer patch bump applied (`2.0.1` → `2.0.2`). 

### Testing

- Ran `rg -n "Move-Zips-ToParent" src/powershell/file-management/Expand-ZipsAndClean.ps1 CHANGELOG.md src/powershell/file-management/README.md` to confirm code references were updated and remaining mentions are documentation only, and this check succeeded. 
- Attempted to run PowerShell AST validation via `pwsh -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('src/powershell/file-management/Expand-ZipsAndClean.ps1',[ref]$null,[ref]$null); 'Parse OK'"`, but `pwsh` is not available in the execution environment so the parse step could not be performed. 
- No functional unit/integration tests were changed; the refactor preserves existing behavior and documented invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5fffa5988325a444fc8a51391dd1)