### PR TITLE
refactor(expand-zipsandclean): split mode-specific extraction helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Entries older than the current minor release line are condensed to architectural
 
 ## [Unreleased]
 
+### Fixed
+
+- **Expand-ZipsAndClean Pester dispatcher mock coverage** (issue #939)
+  - Updated `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` to explicitly mock `Expand-ZipFlat` in the `PerArchiveSubfolder` dispatcher test so `Should -Invoke Expand-ZipFlat -Times 0` assertions resolve cleanly in CI.
+
 ### Added
 
 - **FileSystem module** bumped to v1.1.0 (issue #937)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ Entries older than the current minor release line are condensed to architectural
   - Added warning/error counter APIs to `PowerShellLoggingFramework` (`Get-LogWarningCount`, `Get-LogErrorCount`, `Reset-LogCounters`) and updated FileDistributor end-of-script/summary paths to source totals from the logging framework.
   - Bumped versions: `FileDistributor.ps1` to `4.8.4` and `PowerShellLoggingFramework` module to `2.0.1`.
 
-- **Expand-ZipsAndClean.ps1** bumped to v2.0.3 (issues #937, #938)
+- **Expand-ZipsAndClean.ps1** bumped to v2.0.4 (issues #937, #938, #939)
+  - v2.0.4: Split `Expand-ZipSmart` extraction internals into mode-specific helpers (`Expand-ZipToSubfolder` and `Expand-ZipFlat`) and kept `Expand-ZipSmart` as a dispatcher-only compatibility wrapper. Added Pester coverage for dispatcher routing and flat-mode extraction safety/collision behavior.
   - v2.0.1: Refactored seven generic helper functions into `FileSystem.psm1`
     for reuse across scripts (no behavioral changes).
   - v2.0.2: Refactored main execution into named phase helpers:

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -93,12 +93,16 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.0.3
+    Version  : 2.0.4
     Author   : Manoj Bhaskaran
     Requires : PowerShell 5.1 or 7+, Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.0.4  Refactored extraction internals by splitting Expand-ZipSmart into
+           mode-specific helpers: Expand-ZipToSubfolder and Expand-ZipFlat.
+           Expand-ZipSmart now acts as a dispatcher only (no behavior changes).
+
     2.0.3  Review follow-up: added comment-based help to extracted phase functions
            (Test-ScriptPreconditions, Initialize-Destination, Invoke-ZipExtractions,
            Remove-SourceDirectory) for clarity and script documentation consistency.
@@ -289,67 +293,84 @@ function Get-ZipFileStats {
 
 <#
 .SYNOPSIS
-    Extracts a zip into DestinationRoot with collision handling.
+    Extracts one ZIP archive into a unique subfolder under the destination root.
 .DESCRIPTION
-    - PerArchiveSubfolder: uses Expand-Archive into a unique subfolder (simpler, robust).
-    - Flat: streams entries with ZipArchive, checking collisions BEFORE writing each file,
-            and preventing Zip Slip by verifying resolved full paths.
+    This helper implements `PerArchiveSubfolder` mode. It uses `Expand-Archive` to extract
+    into a sanitized subfolder name and resolves collisions by creating a unique directory path.
 .PARAMETER ZipPath
     Path to the zip archive.
 .PARAMETER DestinationRoot
     Root folder for extraction.
-.PARAMETER ExtractMode
-    'PerArchiveSubfolder' or 'Flat'.
-.PARAMETER CollisionPolicy
-    'Skip' | 'Overwrite' | 'Rename'
-.PARAMETER SafeNameMaxLen
-    Used only in PerArchiveSubfolder mode to cap folder name derived from the zip.
+.PARAMETER SafeSubfolderName
+    Safe destination subfolder name derived from the zip file name.
 .OUTPUTS
-    Int (number of files written or moved into DestinationRoot/subfolder).
+    Int (number of files extracted into the resolved subfolder).
 #>
-function Expand-ZipSmart {
+function Expand-ZipToSubfolder {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$ZipPath,
         [Parameter(Mandatory)][string]$DestinationRoot,
-        [ValidateSet('PerArchiveSubfolder', 'Flat')][string]$ExtractMode = 'PerArchiveSubfolder',
-        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename',
-        [int]$SafeNameMaxLen = 0
+        [Parameter(Mandatory)][string]$SafeSubfolderName
     )
 
-    if (-not (Test-Path -LiteralPath $DestinationRoot)) {
-        New-DirectoryIfMissing -Path $DestinationRoot -Force | Out-Null
+    try {
+        $target = Join-Path $DestinationRoot $SafeSubfolderName
+        $target = Resolve-UniqueDirectoryPath -Path $target
+        if (-not (Test-Path -LiteralPath $target)) {
+            New-DirectoryIfMissing -Path $target -Force | Out-Null
+        }
+
+        Expand-Archive -LiteralPath $ZipPath -DestinationPath $target -Force
+        return (Get-ChildItem -Path $target -Recurse -File | Measure-Object).Count
+
+    } catch {
+        $msg = $_.Exception.Message
+        if ($msg -imatch 'encrypt|password|protected') {
+            throw "Extraction failed for '$ZipPath' (zip may be encrypted): $msg"
+        }
+        throw
     }
+}
 
-    $destRootFull = Get-FullPath -Path $DestinationRoot
-    $destRootFullWithSep = if ($destRootFull.EndsWith('\')) { $destRootFull } else { $destRootFull + '\' }
+<#
+.SYNOPSIS
+    Streams one ZIP archive directly into the destination root (flat mode).
+.DESCRIPTION
+    Implements `Flat` extraction mode using `ZipArchive` streaming extraction. The function:
+    - Normalizes each entry path and enforces a destination-root prefix check to prevent Zip Slip.
+    - Applies per-file collision policy (`Skip`, `Overwrite`, `Rename`) before writing.
+    - Creates required destination directories on demand.
+.PARAMETER ZipPath
+    Path to the zip archive.
+.PARAMETER DestinationRoot
+    Root folder for extraction.
+.PARAMETER DestinationRootFull
+    Fully-qualified destination root path used for Zip Slip boundary validation.
+.PARAMETER CollisionPolicy
+    File collision behavior: `Skip`, `Overwrite`, or `Rename`.
+.OUTPUTS
+    Int (number of files extracted).
+#>
+function Expand-ZipFlat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$DestinationRoot,
+        [Parameter(Mandatory)][string]$DestinationRootFull,
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
+    )
 
-    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ZipPath)
-    $safeSub = Get-SafeName -Name $baseName -MaxLength $SafeNameMaxLen
+    $destRootFullWithSep = if ($DestinationRootFull.EndsWith('\')) { $DestinationRootFull } else { $DestinationRootFull + '\' }
     $written = 0
 
     try {
-        if ($ExtractMode -eq 'PerArchiveSubfolder') {
-            # Extract to a unique subfolder under DestinationRoot
-            $target = Join-Path $DestinationRoot $safeSub
-            $target = Resolve-UniqueDirectoryPath -Path $target
-            if (-not (Test-Path -LiteralPath $target)) {
-                New-DirectoryIfMissing -Path $target -Force | Out-Null
-            }
-            Expand-Archive -LiteralPath $ZipPath -DestinationPath $target -Force
-            $written = (Get-ChildItem -Path $target -Recurse -File | Measure-Object).Count
-            return $written
-        }
-
-        # Flat mode: stream entries directly (no temp folder)
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
         $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
         try {
             foreach ($entry in $zip.Entries) {
-                # Skip directory markers
                 if ([string]::IsNullOrEmpty($entry.Name)) { continue }
 
-                # Build target path safely; prevent Zip Slip
                 $rel = ($entry.FullName -replace '/', '\').TrimStart('\')
                 $dest = Join-Path $DestinationRoot $rel
                 $destFull = [System.IO.Path]::GetFullPath($dest)
@@ -368,12 +389,11 @@ function Expand-ZipSmart {
                     switch ($CollisionPolicy) {
                         'Skip' { continue }
                         'Rename' { $targetPath = Resolve-UniquePath -Path $targetPath }
-                        'Overwrite' { } # NOTE: overwrite flag below is only enabled when policy is Overwrite
+                        'Overwrite' { }
                     }
                 }
 
                 try {
-                    # Overwrite is true only if policy == Overwrite; otherwise false (Skip handled above; Rename changed path)
                     [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
                     $written++
                 } catch {
@@ -387,6 +407,7 @@ function Expand-ZipSmart {
         } finally {
             $zip.Dispose()
         }
+
         return $written
 
     } catch {
@@ -396,6 +417,50 @@ function Expand-ZipSmart {
         }
         throw
     }
+}
+
+<#
+.SYNOPSIS
+    Dispatches zip extraction to the configured extraction mode helper.
+.DESCRIPTION
+    Public-facing compatibility wrapper that preserves the existing signature and routes
+    extraction to either `Expand-ZipToSubfolder` (`PerArchiveSubfolder`) or `Expand-ZipFlat` (`Flat`).
+.PARAMETER ZipPath
+    Path to the zip archive.
+.PARAMETER DestinationRoot
+    Root folder for extraction.
+.PARAMETER ExtractMode
+    `PerArchiveSubfolder` or `Flat`.
+.PARAMETER CollisionPolicy
+    `Skip` | `Overwrite` | `Rename`.
+.PARAMETER SafeNameMaxLen
+    Maximum safe-name length used to derive per-archive subfolder names.
+.OUTPUTS
+    Int (number of files written by the selected mode helper).
+#>
+function Expand-ZipSmart {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$DestinationRoot,
+        [ValidateSet('PerArchiveSubfolder', 'Flat')][string]$ExtractMode = 'PerArchiveSubfolder',
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename',
+        [int]$SafeNameMaxLen = 0
+    )
+
+    if (-not (Test-Path -LiteralPath $DestinationRoot)) {
+        New-DirectoryIfMissing -Path $DestinationRoot -Force | Out-Null
+    }
+
+    $destRootFull = Get-FullPath -Path $DestinationRoot
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ZipPath)
+    $safeSub = Get-SafeName -Name $baseName -MaxLength $SafeNameMaxLen
+
+    if ($ExtractMode -eq 'PerArchiveSubfolder') {
+        return Expand-ZipToSubfolder -ZipPath $ZipPath -DestinationRoot $DestinationRoot -SafeSubfolderName $safeSub
+    }
+
+    return Expand-ZipFlat -ZipPath $ZipPath -DestinationRoot $DestinationRoot -DestinationRootFull $destRootFull -CollisionPolicy $CollisionPolicy
 }
 
 <#

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.0.4** (2026-04-13)
+  - Refactored extraction internals by splitting `Expand-ZipSmart` into mode-specific helpers: `Expand-ZipToSubfolder` and `Expand-ZipFlat`.
+  - Kept `Expand-ZipSmart` as the compatibility dispatcher with unchanged parameters and mode behavior.
+  - Added Pester coverage for dispatcher routing, `Flat` skip-collision behavior, and Zip Slip traversal rejection.
 - **Expand-ZipsAndClean.ps1 v2.0.3** (2026-04-13)
   - Review follow-up: added comment-based help blocks for extracted phase functions to keep inline script documentation consistent.
 - **Expand-ZipsAndClean.ps1 v2.0.2** (2026-04-13)

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,8 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 test-suite follow-up** (2026-04-13)
+  - Updated the dispatcher routing Pester test to mock `Expand-ZipFlat` explicitly in the `PerArchiveSubfolder` path assertion, fixing CI `Should -Invoke ... -Times 0` mock-resolution failures.
 - **Expand-ZipsAndClean.ps1 v2.0.4** (2026-04-13)
   - Refactored extraction internals by splitting `Expand-ZipSmart` into mode-specific helpers: `Expand-ZipToSubfolder` and `Expand-ZipFlat`.
   - Kept `Expand-ZipSmart` as the compatibility dispatcher with unchanged parameters and mode behavior.

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -31,6 +31,7 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
         Mock Get-FullPath { '/tmp/dest' }
         Mock Get-SafeName { 'safe-name' }
         Mock Expand-ZipToSubfolder { 7 }
+        Mock Expand-ZipFlat { 0 }
 
         $result = Expand-ZipSmart -ZipPath '/tmp/a.zip' -DestinationRoot '/tmp/dest' -ExtractMode PerArchiveSubfolder -SafeNameMaxLen 80
 

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -1,0 +1,115 @@
+Set-StrictMode -Version Latest
+
+Describe 'Expand-ZipsAndClean helper extraction refactor' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+
+        $helpersStart = $scriptText.IndexOf('#region Helpers')
+        $helpersEnd = $scriptText.IndexOf('#endregion Helpers')
+        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
+            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
+        }
+
+        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
+
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+
+        function Write-LogDebug { param([string]$Message) }
+        Invoke-Expression $helpers
+    }
+
+    It 'defines mode-specific helper functions and dispatcher' {
+        Get-Command Expand-ZipToSubfolder -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Expand-ZipFlat -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Expand-ZipSmart -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+
+    It 'dispatches PerArchiveSubfolder mode to Expand-ZipToSubfolder' {
+        Mock Test-Path { $true }
+        Mock Get-FullPath { '/tmp/dest' }
+        Mock Get-SafeName { 'safe-name' }
+        Mock Expand-ZipToSubfolder { 7 }
+
+        $result = Expand-ZipSmart -ZipPath '/tmp/a.zip' -DestinationRoot '/tmp/dest' -ExtractMode PerArchiveSubfolder -SafeNameMaxLen 80
+
+        $result | Should -Be 7
+        Should -Invoke Expand-ZipToSubfolder -Times 1 -Exactly -ParameterFilter {
+            $ZipPath -eq '/tmp/a.zip' -and
+            $DestinationRoot -eq '/tmp/dest' -and
+            $SafeSubfolderName -eq 'safe-name'
+        }
+        Should -Invoke Expand-ZipFlat -Times 0
+    }
+
+    It 'dispatches Flat mode to Expand-ZipFlat with computed destination root' {
+        Mock Test-Path { $true }
+        Mock Get-FullPath { '/tmp/dest-full' }
+        Mock Get-SafeName { 'unused-safe-name' }
+        Mock Expand-ZipFlat { 3 }
+
+        $result = Expand-ZipSmart -ZipPath '/tmp/b.zip' -DestinationRoot '/tmp/dest' -ExtractMode Flat -CollisionPolicy Rename
+
+        $result | Should -Be 3
+        Should -Invoke Expand-ZipFlat -Times 1 -Exactly -ParameterFilter {
+            $ZipPath -eq '/tmp/b.zip' -and
+            $DestinationRoot -eq '/tmp/dest' -and
+            $DestinationRootFull -eq '/tmp/dest-full' -and
+            $CollisionPolicy -eq 'Rename'
+        }
+    }
+
+    It 'applies Flat collision policy Skip by not overwriting existing files' {
+        $root = Join-Path $TestDrive 'flat-skip'
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+        $zipPath = Join-Path $TestDrive 'flat-skip.zip'
+        $existingPath = Join-Path $root 'same.txt'
+        Set-Content -LiteralPath $existingPath -Value 'existing' -NoNewline
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $archive = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+        try {
+            $entry = $archive.CreateEntry('same.txt')
+            $stream = $entry.Open()
+            $writer = New-Object System.IO.StreamWriter($stream)
+            try { $writer.Write('incoming') } finally { $writer.Dispose() }
+        } finally {
+            $archive.Dispose()
+        }
+
+        $written = Expand-ZipFlat -ZipPath $zipPath -DestinationRoot $root -DestinationRootFull ([System.IO.Path]::GetFullPath($root)) -CollisionPolicy Skip
+
+        $written | Should -Be 0
+        (Get-Content -LiteralPath $existingPath -Raw) | Should -Be 'existing'
+    }
+
+    It 'blocks Zip Slip traversal entries in Flat mode' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'flat-zipslip'
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+        $zipPath = Join-Path $TestDrive 'flat-zipslip.zip'
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $archive = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+        try {
+            $good = $archive.CreateEntry('good.txt')
+            $goodStream = $good.Open()
+            $goodWriter = New-Object System.IO.StreamWriter($goodStream)
+            try { $goodWriter.Write('ok') } finally { $goodWriter.Dispose() }
+
+            $evil = $archive.CreateEntry('../evil.txt')
+            $evilStream = $evil.Open()
+            $evilWriter = New-Object System.IO.StreamWriter($evilStream)
+            try { $evilWriter.Write('bad') } finally { $evilWriter.Dispose() }
+        } finally {
+            $archive.Dispose()
+        }
+
+        $written = Expand-ZipFlat -ZipPath $zipPath -DestinationRoot $root -DestinationRootFull ([System.IO.Path]::GetFullPath($root)) -CollisionPolicy Rename
+
+        $written | Should -Be 1
+        Test-Path -LiteralPath (Join-Path $root 'good.txt') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path (Split-Path -Parent $root) 'evil.txt') | Should -BeFalse
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity and improve testability of the `Expand-ZipsAndClean.ps1` extraction logic by isolating mode-specific behavior. 
- Make the streaming `Flat` extraction easier to audit (Zip Slip guard and per-file collision handling) and improve clarity for future maintenance. 
- Preserve existing public behavior and parameters while enabling focused unit tests for each extraction mode.

### Description
- Split `Expand-ZipSmart` internals into two mode-specific helpers: `Expand-ZipToSubfolder` (PerArchiveSubfolder) and `Expand-ZipFlat` (Flat streaming extraction), then reduced `Expand-ZipSmart` to a dispatcher that preserves the original signature. 
- Implemented `Expand-ZipFlat` with explicit Zip Slip boundary validation, per-file `CollisionPolicy` handling (`Skip`/`Overwrite`/`Rename`), and directory creation on demand. 
- Added comment-based help for the new helpers and bumped the script `Version` in the script `.NOTES` to `2.0.4`, updated `src/powershell/file-management/README.md`, and recorded the change in the root `CHANGELOG.md` (issue #939). 
- Added new Pester tests at `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` covering function presence, dispatcher routing, `Flat` mode `Skip` collision behavior, and a Zip Slip traversal rejection case (Windows-gated). 

### Testing
- Added a Pester test suite (`tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1`) but running it requires PowerShell/Pester in the environment. 
- Attempted to run `Invoke-Pester` (`pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1' -Output Detailed"`) but the runner could not execute because `pwsh`/`powershell` is not installed in this environment (automated test run failed). 
- The new tests are present and expected to pass when run in a CI job or developer environment with PowerShell 5.1+/PowerShell 7+ and Pester available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6649874c8325be0fd59e346aa737)