### PR TITLE
Enforce PowerShell 7+ runtime and modernize type references

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -1,3 +1,7 @@
+#requires -Version 7.0
+using namespace System.Collections.Generic
+using namespace System.IO.Compression
+
 <#
 .SYNOPSIS
     Unzips all .zip files from a source folder into a destination folder, moves the .zip files
@@ -93,12 +97,21 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.0.4
+    Version  : 2.1.0
     Author   : Manoj Bhaskaran
-    Requires : PowerShell 5.1 or 7+, Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
+    Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
+               Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.0  Enforced PowerShell 7+ as the minimum runtime: added #requires -Version 7.0,
+           added using namespace directives (System.Collections.Generic,
+           System.IO.Compression), updated .NOTES Requires line and Setup/Module
+           section (removed PS 5.1 compatibility note), replaced New-Object
+           List[string] with [List[string]]::new(), and shortened ZipFile /
+           ZipFileExtensions type references to use the declared namespaces.
+           Version bump: minor (supported-runtime contract change, no new features).
+
     2.0.4  Refactored extraction internals by splitting Expand-ZipSmart into
            mode-specific helpers: Expand-ZipToSubfolder and Expand-ZipFlat.
            Expand-ZipSmart now acts as a dispatcher only (no behavior changes).
@@ -153,9 +166,7 @@
            table summary, ms in duration, and expanded docs/FAQ.
     ── Setup / Module check ─────────────────────────────────────────────────────
     Expand-Archive is provided by Microsoft.PowerShell.Archive.
-    • PowerShell 5.1: The module is included with Windows Management Framework 5.1.
-      (Install-Module is generally for PowerShell 7+. On 5.1 you normally already have it.)
-    • PowerShell 7+: If missing, install from PSGallery:
+    If missing on PowerShell 7+, install from PSGallery:
         Install-Module -Name Microsoft.PowerShell.Archive -Scope CurrentUser -Force
       (You may need: Set-PSRepository PSGallery -InstallationPolicy Trusted)
 
@@ -274,7 +285,7 @@ function Get-ZipFileStats {
     }
 
     try {
-        $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+        $zip = [ZipFile]::OpenRead($ZipPath)
         try {
             foreach ($entry in $zip.Entries) {
                 if ($entry.Name) {
@@ -366,7 +377,7 @@ function Expand-ZipFlat {
 
     try {
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-        $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+        $zip = [ZipFile]::OpenRead($ZipPath)
         try {
             foreach ($entry in $zip.Entries) {
                 if ([string]::IsNullOrEmpty($entry.Name)) { continue }
@@ -394,7 +405,7 @@ function Expand-ZipFlat {
                 }
 
                 try {
-                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
+                    [ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
                     $written++
                 } catch {
                     $emsg = $_.Exception.Message
@@ -700,7 +711,7 @@ function Move-ZipFilesToParent {
 #------------------------------- Main -------------------------------#
 
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-$errors = New-Object System.Collections.Generic.List[string]
+$errors = [List[string]]::new()
 
 # State for summary
 $zipCount = 0

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -22,7 +22,7 @@ Scripts for file operations, distribution, copying, and archiving.
 
 ### External Tools
 
-- PowerShell 5.1 or later
+- PowerShell 7+ (required by `Expand-ZipsAndClean.ps1`; other scripts may work on 5.1)
 - Windows API access for file handle operations
 
 ## Common Use Cases
@@ -45,6 +45,12 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.0** (2026-04-13)
+  - Added `#requires -Version 7.0` to enforce the PowerShell 7+ runtime at parse time (script already used the ternary operator which is PS 7-only).
+  - Added `using namespace System.Collections.Generic` and `using namespace System.IO.Compression` declarations; shortened `List[string]`, `ZipFile`, and `ZipFileExtensions` type references accordingly.
+  - Replaced `New-Object System.Collections.Generic.List[string]` with `[List[string]]::new()`.
+  - Updated `.NOTES` `Requires` line and `Setup/Module check` section to remove the PowerShell 5.1 compatibility note.
+  - Version bump: `2.1.0` (minor — supported-runtime contract change).
 - **Expand-ZipsAndClean.ps1 test-suite follow-up** (2026-04-13)
   - Updated the dispatcher routing Pester test to mock `Expand-ZipFlat` explicitly in the `PerArchiveSubfolder` path assertion, fixing CI `Should -Invoke ... -Times 0` mock-resolution failures.
 - **Expand-ZipsAndClean.ps1 v2.0.4** (2026-04-13)

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -14,10 +14,16 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
 
         $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
 
+        # Prepend using-namespace declarations so that short type aliases (e.g. [ZipFile],
+        # [List[string]]) resolve when the helpers block is evaluated via Invoke-Expression.
+        $usingLines = ($scriptText -split "`n" |
+            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
+        $helpersWithUsing = $usingLines + "`n" + $helpers
+
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
 
         function Write-LogDebug { param([string]$Message) }
-        Invoke-Expression $helpers
+        Invoke-Expression $helpersWithUsing
     }
 
     It 'defines mode-specific helper functions and dispatcher' {


### PR DESCRIPTION
## Summary
Updated `Expand-ZipsAndClean.ps1` to explicitly enforce PowerShell 7+ as the minimum runtime and modernized type references using namespace declarations. This formalizes the script's existing dependency on PS 7-only features (ternary operator, null-coalescing operator, `-Parallel` parameter) and improves code readability.

## Key Changes

- **Added `#requires -Version 7.0`** directive to enforce PowerShell 7+ at parse time, preventing execution on incompatible runtimes
- **Added namespace declarations** for `System.Collections.Generic` and `System.IO.Compression` to enable shorter type references
- **Shortened type references** throughout the script:
  - `[System.IO.Compression.ZipFile]` → `[ZipFile]`
  - `[System.IO.Compression.ZipFileExtensions]` → `[ZipFileExtensions]`
  - `New-Object System.Collections.Generic.List[string]` → `[List[string]]::new()`
- **Updated documentation** in `.NOTES` section to reflect PowerShell 7+ requirement and removed PowerShell 5.1 compatibility notes from the Setup/Module check section
- **Updated README.md** to clarify that PowerShell 7+ is required by this script
- **Version bump** to 2.1.0 (minor version — supported-runtime contract change, no new features)

## Implementation Details

The script already relied on PowerShell 7-only syntax (ternary operator `?:`, null-coalescing operator `??`, and `-Parallel` parameter in `ForEach-Object`), making the explicit version requirement a formalization of the existing contract rather than a breaking change. The namespace declarations reduce verbosity and improve maintainability without altering functionality.

https://claude.ai/code/session_01Ldcj6HihRg5sqa4nbXSaA6