### PR TITLE
Fix FileDistributorRunState type visibility in entry script

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG — FileDistributor
 
+## 4.9.2 — 2026-04-22
+
+### Fixed
+
+- Fixed `InvalidOperation: Unable to find type [FileDistributorRunState]` when running `FileDistributor.ps1` (regression introduced in 4.9.0). `Import-Module` does not export PowerShell class types to the caller's scope, so the entry script could not construct `[FileDistributorRunState]::new()` directly. The script now obtains its run state from a module-scope factory function.
+
+### Added
+
+- Added public module function `New-FileDistributorRunState` (`Public/New-FileDistributorRunState.ps1`) that returns a fresh `[FileDistributorRunState]` instance. The function runs in module scope where the class type is visible and is exported via `FileDistributor.psd1`.
+
+### Changed
+
+- Replaced `[FileDistributorRunState]::new()` at `FileDistributor.ps1` startup with `New-FileDistributorRunState`. No behavior change; the returned object is identical.
+
+### Versioning
+
+- Bumped `FileDistributor.ps1` script version to `4.9.2`.
+- Bumped `FileDistributor` module version to `1.3.2`.
+
 ## 4.9.1 — 2026-04-12
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -14,6 +14,11 @@
 
 - Replaced `[FileDistributorRunState]::new()` at `FileDistributor.ps1` startup with `New-FileDistributorRunState`. No behavior change; the returned object is identical.
 
+### Tests
+
+- Added `New-FileDistributorRunState` to the expected-exports list in `FileDistributor.Tests.ps1` so the public-API contract test matches the new export.
+- Added a behavioral test verifying `New-FileDistributorRunState` returns a `FileDistributorRunState` instance from script scope (the scenario the fix enables).
+
 ### Versioning
 
 - Bumped `FileDistributor.ps1` script version to `4.9.2`.

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -331,7 +331,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.9.1"
+$script:Version = "4.9.2"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -402,7 +402,7 @@ function Main {
     $script:Warnings = [Math]::Max($script:Warnings, (Get-LogWarningCount))
     $script:Errors = [Math]::Max($script:Errors, (Get-LogErrorCount))
 
-    $runState = [FileDistributorRunState]::new()
+    $runState = New-FileDistributorRunState
     $fileLockRef = [ref]$null
 
     try {

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.3.1'
+    ModuleVersion     = '1.3.2'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'
@@ -12,6 +12,7 @@
         'Invoke-ParameterValidation',
         'Invoke-RestoreCheckpoint',
         'New-CheckpointPayload',
+        'New-FileDistributorRunState',
         'Invoke-DistributionPhase',
         'Invoke-PostProcessingPhase',
         'Invoke-EndOfScriptDeletion',

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/New-FileDistributorRunState.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/New-FileDistributorRunState.ps1
@@ -1,0 +1,15 @@
+# New-FileDistributorRunState.ps1 - Factory for FileDistributorRunState (public module function)
+#
+# The FileDistributorRunState class is defined inside this module. PowerShell's
+# Import-Module does not export class types to the caller's scope, so entry
+# scripts that use `Import-Module` cannot invoke [FileDistributorRunState]::new()
+# directly. This factory runs in module scope where the type is visible and
+# returns a fresh instance to the caller.
+
+function New-FileDistributorRunState {
+    [CmdletBinding()]
+    [OutputType([FileDistributorRunState])]
+    param()
+
+    return [FileDistributorRunState]::new()
+}

--- a/src/powershell/modules/FileManagement/FileDistributor/Public/New-FileDistributorRunState.ps1
+++ b/src/powershell/modules/FileManagement/FileDistributor/Public/New-FileDistributorRunState.ps1
@@ -8,7 +8,7 @@
 
 function New-FileDistributorRunState {
     [CmdletBinding()]
-    [OutputType([FileDistributorRunState])]
+    [OutputType('FileDistributorRunState')]
     param()
 
     return [FileDistributorRunState]::new()

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -325,12 +325,19 @@ Describe 'FileDistributor Module Public API' {
         $functionContent | Should -Match 'Get-NextQueueItem\s+-Queue\s+\$RunState\.FilesToDelete\s+-Peek'
     }
 
+    It 'New-FileDistributorRunState should return a FileDistributorRunState instance callable from script scope' {
+        $runState = New-FileDistributorRunState
+        $runState | Should -Not -BeNullOrEmpty
+        $runState.GetType().Name | Should -Be 'FileDistributorRunState'
+    }
+
     It 'Should expose the complete expected function API through module exports' {
         $expectedExports = @(
             'Initialize-FileDistributorPaths',
             'Invoke-ParameterValidation',
             'Invoke-RestoreCheckpoint',
             'New-CheckpointPayload',
+            'New-FileDistributorRunState',
             'Invoke-DistributionPhase',
             'Invoke-PostProcessingPhase',
             'Invoke-EndOfScriptDeletion',


### PR DESCRIPTION
## Summary
Fixed a regression in FileDistributor 4.9.0 where the entry script could not instantiate `FileDistributorRunState` due to PowerShell's `Import-Module` not exporting class types to the caller's scope. The fix introduces a module-scoped factory function that creates instances in the proper scope.

## Key Changes
- **Added** `New-FileDistributorRunState` public module function that acts as a factory for creating `FileDistributorRunState` instances in module scope where the class type is visible
- **Updated** `FileDistributor.ps1` to use `New-FileDistributorRunState` instead of directly invoking `[FileDistributorRunState]::new()`
- **Exported** the new factory function via `FileDistributor.psd1` module manifest
- **Bumped** script version from 4.9.1 to 4.9.2
- **Bumped** module version from 1.3.1 to 1.3.2

## Implementation Details
The root cause was that PowerShell's `Import-Module` cmdlet does not export class type definitions to the caller's scope, only to the module's scope. By creating a factory function that runs within the module scope, the function can access the `FileDistributorRunState` class and return properly constructed instances to the entry script. This is a non-breaking change that maintains identical behavior while resolving the `InvalidOperation: Unable to find type [FileDistributorRunState]` error.

https://claude.ai/code/session_01QeJsfyrMtaUk82LFgx26tx