### PR TITLE
fix(deps): pin pytest>=9.0.3 in requirements.lock to resolve GHSA-6w4…

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -17,9 +17,9 @@ psycopg2==2.9.9
 pytz==2023.3
 
 # Development and testing dependencies
-pytest==7.4.3
-pytest-cov==4.1.0
-pytest-mock==3.11.1
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
 
 # Code quality and formatting
 pre-commit==4.3.0


### PR DESCRIPTION
…6-j5rx-g56g

pytest <9.0.3 on UNIX uses predictable /tmp/pytest-of-{user} directories, allowing local DoS or privilege escalation. Commit 2e75593 bumped the range in requirements.txt but did not update requirements.lock, which is what CI's pip-audit scan reads. The scan therefore still flagged pytest==7.4.3 on every push.

Bump the lockfile pins to satisfy the requirements.txt ranges and be mutually compatible:
- pytest==7.4.3 -> 9.0.3  (fixes CVE)
- pytest-cov==4.1.0 -> 7.1.0  (4.x does not support pytest 9)
- pytest-mock==3.11.1 -> 3.15.1  (matches pytest 9 API)

Resolved via `uv pip compile --python-version 3.11` against requirements.txt; all three resolve cleanly with no other transitive conflicts.

https://claude.ai/code/session_01QeJsfyrMtaUk82LFgx26tx