### PR TITLE
fix(file-management): clean nested non-zips recursively in Remove-SourceDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory nested cleanup error under `-CleanNonZips`**
+  - Hardened non-zip cleanup so directory entries are removed with `Remove-Item -Recurse -Force` while files continue to use file-only removal.
+  - Added a deterministic secondary sort key (`FullName` descending) during deepest-first cleanup to avoid same-depth ordering variance.
+  - Fixes the nested cleanup case where `Remove-SourceDirectory` could emit `Failed to remove ... directory not empty` even though `-CleanNonZips` was enabled.
+  - Script version bumped to **2.1.2** (patch; bug fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory non-zip filter and deletion ordering** (issue #970)
   - Simplified the non-zip filter from `(-not $_.PSIsContainer -and $_.Extension -ne '.zip') -or $_.PSIsContainer` to `$_.PSIsContainer -or $_.Extension -ne '.zip'`, dropping the dead `.zip`-exclusion branch (all zips have already been moved by `Move-ZipFilesToParent` before this function runs).
   - Warning message now differentiates between "only empty subdirectories remain" and "non-zip files present" so the caller understands why deletion was blocked.

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,18 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.1
+    Version  : 2.1.2
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.2  Fixed Remove-SourceDirectory cleanup robustness for nested trees when
+           -CleanNonZips is set: directory entries are now removed with -Recurse so
+           parent folders do not fail with "directory not empty" when same-depth
+           ordering is non-deterministic. No functional changes to warning behavior.
+
     2.1.1  Fixed Remove-SourceDirectory: simplified non-zip filter (dropped the dead
            .zip-exclusion branch, since Move-ZipFilesToParent has already relocated all
            zips before this function runs); differentiated warning message between
@@ -652,12 +657,16 @@ function Remove-SourceDirectory {
         }
 
         if ($ShouldCleanNonZips -and $nonZips.Count -gt 0) {
-            $nonZips | Sort-Object -Property {
-                ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count
-            } -Descending | ForEach-Object {
+            $nonZips | Sort-Object -Property `
+                @{ Expression = { ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+                @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 try {
                     if (Test-Path -LiteralPath $_.FullName) {
-                        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        if ($_.PSIsContainer) {
+                            Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop
+                        } else {
+                            Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        }
                     }
                 } catch {
                     $ErrorList.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.2** (2026-04-24)
+  - Fixed nested `-CleanNonZips` cleanup reliability in `Remove-SourceDirectory`: directories are now removed with `-Recurse` to prevent intermittent `directory not empty` cleanup errors.
+  - Added deterministic same-depth tie-breaking (`FullName` descending) in deepest-first cleanup ordering.
+  - Version bump: `2.1.2` (patch — bug fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.0** (2026-04-13)
   - Added `#requires -Version 7.0` to enforce the PowerShell 7+ runtime at parse time (script already used the ternary operator which is PS 7-only).
   - Added `using namespace System.Collections.Generic` and `using namespace System.IO.Compression` declarations; shortened `List[string]`, `ZipFile`, and `ZipFileExtensions` type references accordingly.


### PR DESCRIPTION
### Motivation
- Fix a failing Pester case where `Remove-SourceDirectory` could leave nested directories and emit "directory not empty" when `-CleanNonZips` was used on nested trees.

### Description
- Update `Remove-SourceDirectory` to remove container entries with `Remove-Item -Recurse -Force` while leaving file removal as file-only to avoid "directory not empty" races and intermittent failures; also add a deterministic secondary sort key (`FullName` descending) to tie-break same-depth items during deepest-first cleanup.
- Bump `Expand-ZipsAndClean.ps1` script version to `2.1.2` and add a matching version-history entry in the script header.
- Update `CHANGELOG.md` and `src/powershell/file-management/README.md` with a `v2.1.2` / Unreleased note describing the fix.

### Testing
- Attempted to run the Pester suite with `pwsh -NoLogo -NoProfile -File tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1`, but `pwsh` is not installed in the environment so tests could not be executed.
- Verified code changes and diffs with `git diff` and commit contents with `git show` after committing `fix(file-management): clean nested non-zips recursively in Remove-SourceDirectory`.
- No automated test runs succeeded in this environment due to the missing PowerShell runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eace01d9fc8325958c3bbbea7ab37d)