### PR TITLE
Expand-ZipsAndClean: guard cleanup error reporting, fix nested non-zip removal, bump to v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory transient Remove-Item errors no longer produce false failures**
+  - Guarded cleanup error reporting so `ErrorList` is only appended when the target path still exists after a caught `Remove-Item` failure.
+  - Applied the same guard to the final source-directory deletion retry path.
+  - Prevents false-positive cleanup failures in CI/Linux cases where `Remove-Item` throws but the path is already deleted.
+  - Script version bumped to **2.1.3** (patch; correctness fix, no new features).
+
+- **[Expand-ZipsAndClean] Remove-SourceDirectory nested cleanup error under `-CleanNonZips`**
+  - Hardened non-zip cleanup so directory entries are removed with `Remove-Item -Recurse -Force` while files continue to use file-only removal.
+  - Added a deterministic secondary sort key (`FullName` descending) during deepest-first cleanup to avoid same-depth ordering variance.
+  - Fixes the nested cleanup case where `Remove-SourceDirectory` could emit `Failed to remove ... directory not empty` even though `-CleanNonZips` was enabled.
+  - Script version bumped to **2.1.2** (patch; bug fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory non-zip filter and deletion ordering** (issue #970)
   - Simplified the non-zip filter from `(-not $_.PSIsContainer -and $_.Extension -ne '.zip') -or $_.PSIsContainer` to `$_.PSIsContainer -or $_.Extension -ne '.zip'`, dropping the dead `.zip`-exclusion branch (all zips have already been moved by `Move-ZipFilesToParent` before this function runs).
   - Warning message now differentiates between "only empty subdirectories remain" and "non-zip files present" so the caller understands why deletion was blocked.

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,23 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.1
+    Version  : 2.1.3
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.3  Fixed Remove-SourceDirectory false-positive cleanup errors on Linux/CI:
+           when Remove-Item reports a transient error but the target path is already
+           gone, the function no longer records a failure in ErrorList. Applied to
+           both per-item cleanup and final source directory removal paths.
+
+    2.1.2  Fixed Remove-SourceDirectory cleanup robustness for nested trees when
+           -CleanNonZips is set: directory entries are now removed with -Recurse so
+           parent folders do not fail with "directory not empty" when same-depth
+           ordering is non-deterministic. No functional changes to warning behavior.
+
     2.1.1  Fixed Remove-SourceDirectory: simplified non-zip filter (dropped the dead
            .zip-exclusion branch, since Move-ZipFilesToParent has already relocated all
            zips before this function runs); differentiated warning message between
@@ -652,15 +662,21 @@ function Remove-SourceDirectory {
         }
 
         if ($ShouldCleanNonZips -and $nonZips.Count -gt 0) {
-            $nonZips | Sort-Object -Property {
-                ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count
-            } -Descending | ForEach-Object {
+            $nonZips | Sort-Object -Property `
+                @{ Expression = { ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+                @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 try {
                     if (Test-Path -LiteralPath $_.FullName) {
-                        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        if ($_.PSIsContainer) {
+                            Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop
+                        } else {
+                            Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        }
                     }
                 } catch {
-                    $ErrorList.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null
+                    if (Test-Path -LiteralPath $_.FullName) {
+                        $ErrorList.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null
+                    }
                 }
             }
         }
@@ -677,7 +693,9 @@ function Remove-SourceDirectory {
             try {
                 Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction Stop
             } catch {
-                $ErrorList.Add("Failed to delete source directory '$SourceDir': $($_.Exception.Message)") | Out-Null
+                if (Test-Path -LiteralPath $SourceDir) {
+                    $ErrorList.Add("Failed to delete source directory '$SourceDir': $($_.Exception.Message)") | Out-Null
+                }
             }
         }
     } catch {

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,14 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.3** (2026-04-24)
+  - Fixed `Remove-SourceDirectory` false-positive cleanup failures by recording removal errors only when the target path still exists after a caught `Remove-Item` exception.
+  - Applied the same existence guard to the final source-directory deletion retry path.
+  - Version bump: `2.1.3` (patch — correctness fix, no feature change).
+- **Expand-ZipsAndClean.ps1 v2.1.2** (2026-04-24)
+  - Fixed nested `-CleanNonZips` cleanup reliability in `Remove-SourceDirectory`: directories are now removed with `-Recurse` to prevent intermittent `directory not empty` cleanup errors.
+  - Added deterministic same-depth tie-breaking (`FullName` descending) in deepest-first cleanup ordering.
+  - Version bump: `2.1.2` (patch — bug fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.0** (2026-04-13)
   - Added `#requires -Version 7.0` to enforce the PowerShell 7+ runtime at parse time (script already used the ternary operator which is PS 7-only).
   - Added `using namespace System.Collections.Generic` and `using namespace System.IO.Compression` declarations; shortened `List[string]`, `ZipFile`, and `ZipFileExtensions` type references accordingly.


### PR DESCRIPTION
### Motivation

- Prevent transient `Remove-Item` errors from producing false-positive cleanup failures in CI/Linux when the target path was already removed.
- Make non-zip cleanup deterministic and robust for nested directory trees to avoid intermittent "directory not empty" errors.
- Record the fix in the script version and project documentation so callers and CI reflect the corrected behavior.

### Description

- Added existence guards (`Test-Path -LiteralPath`) before appending removal failures to `ErrorList` in both per-item cleanup and the final source-directory deletion retry path so errors are only recorded if the target still exists after a caught `Remove-Item` exception.
- Hardened non-zip cleanup to remove directory entries with `Remove-Item -Recurse -Force` while continuing to remove files with `Remove-Item -Force` to avoid parent-folder failures.
- Introduced a deterministic same-depth tie-breaker by sorting non-zip items with a secondary key of `FullName` descending in addition to deepest-first ordering.
- Bumped the script `.NOTES` `Version` to `2.1.3` and updated `CHANGELOG.md` and `src/powershell/file-management/README.md` with entries for `2.1.2` and `2.1.3` describing the fixes.

### Testing

- Ran the repository Pester suite covering the `file-management` scripts including `Expand-ZipsAndClean.Tests.ps1`, which includes nested-tree and cleanup-related tests, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eace01d9fc8325958c3bbbea7ab37d)