### PR TITLE
Harden Remove-SourceDirectory cleanup and error accounting; bump Expand-ZipsAndClean to 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory final delete error accounting**
+  - Final source-directory cleanup now appends to `ErrorList` only if `SourceDir` still exists after both deletion attempts complete.
+  - Exceptions raised during the final retry are now logged at debug level and only surfaced as failures when the directory remains present.
+  - Prevents residual `Expected 0, but got 1` failures when transient retry exceptions occur but the source directory is successfully removed.
+  - Script version bumped to **2.1.5** (patch; correctness fix, no new features).
+
+- **[Expand-ZipsAndClean] Remove-SourceDirectory nested `-CleanNonZips` CI flake**
+  - Changed per-item non-zip cleanup failures to best-effort debug diagnostics instead of `ErrorList` entries.
+  - `ErrorList` now reflects only final source-directory deletion failure (the true operation result).
+  - Prevents intermittent `Expected 0, but got 1` failures in the nested cleanup Pester case when intermediate removals are noisy but final deletion succeeds.
+  - Script version bumped to **2.1.4** (patch; correctness fix, no new features).
+
+- **[Expand-ZipsAndClean] Remove-SourceDirectory transient Remove-Item errors no longer produce false failures**
+  - Guarded cleanup error reporting so `ErrorList` is only appended when the target path still exists after a caught `Remove-Item` failure.
+  - Applied the same guard to the final source-directory deletion retry path.
+  - Prevents false-positive cleanup failures in CI/Linux cases where `Remove-Item` throws but the path is already deleted.
+  - Script version bumped to **2.1.3** (patch; correctness fix, no new features).
+
+- **[Expand-ZipsAndClean] Remove-SourceDirectory nested cleanup error under `-CleanNonZips`**
+  - Hardened non-zip cleanup so directory entries are removed with `Remove-Item -Recurse -Force` while files continue to use file-only removal.
+  - Added a deterministic secondary sort key (`FullName` descending) during deepest-first cleanup to avoid same-depth ordering variance.
+  - Fixes the nested cleanup case where `Remove-SourceDirectory` could emit `Failed to remove ... directory not empty` even though `-CleanNonZips` was enabled.
+  - Script version bumped to **2.1.2** (patch; bug fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory non-zip filter and deletion ordering** (issue #970)
   - Simplified the non-zip filter from `(-not $_.PSIsContainer -and $_.Extension -ne '.zip') -or $_.PSIsContainer` to `$_.PSIsContainer -or $_.Extension -ne '.zip'`, dropping the dead `.zip`-exclusion branch (all zips have already been moved by `Move-ZipFilesToParent` before this function runs).
   - Warning message now differentiates between "only empty subdirectories remain" and "non-zip files present" so the caller understands why deletion was blocked.

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,33 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.1
+    Version  : 2.1.5
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.5  Fixed Remove-SourceDirectory final error accounting: record a delete
+           failure only if SourceDir still exists after all delete attempts. This
+           avoids transient retry exceptions being counted as failures when the
+           directory is ultimately removed.
+
+    2.1.4  Fixed Remove-SourceDirectory CI flake for nested -CleanNonZips cleanup:
+           per-item non-zip removal failures are now treated as best-effort debug
+           diagnostics, and ErrorList is reserved for final source directory deletion
+           failures only (the operation's true success criterion).
+
+    2.1.3  Fixed Remove-SourceDirectory false-positive cleanup errors on Linux/CI:
+           when Remove-Item reports a transient error but the target path is already
+           gone, the function no longer records a failure in ErrorList. Applied to
+           both per-item cleanup and final source directory removal paths.
+
+    2.1.2  Fixed Remove-SourceDirectory cleanup robustness for nested trees when
+           -CleanNonZips is set: directory entries are now removed with -Recurse so
+           parent folders do not fail with "directory not empty" when same-depth
+           ordering is non-deterministic. No functional changes to warning behavior.
+
     2.1.1  Fixed Remove-SourceDirectory: simplified non-zip filter (dropped the dead
            .zip-exclusion branch, since Move-ZipFilesToParent has already relocated all
            zips before this function runs); differentiated warning message between
@@ -652,15 +672,19 @@ function Remove-SourceDirectory {
         }
 
         if ($ShouldCleanNonZips -and $nonZips.Count -gt 0) {
-            $nonZips | Sort-Object -Property {
-                ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count
-            } -Descending | ForEach-Object {
+            $nonZips | Sort-Object -Property `
+                @{ Expression = { ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+                @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 try {
                     if (Test-Path -LiteralPath $_.FullName) {
-                        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        if ($_.PSIsContainer) {
+                            Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop
+                        } else {
+                            Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                        }
                     }
                 } catch {
-                    $ErrorList.Add("Failed to remove: $($_.FullName) -> $($_.Exception.Message)") | Out-Null
+                    Write-LogDebug "Best-effort cleanup skip for '$($_.FullName)': $($_.Exception.Message)"
                 }
             }
         }
@@ -673,12 +697,18 @@ function Remove-SourceDirectory {
         if (Test-Path -LiteralPath $SourceDir) {
             Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction SilentlyContinue
         }
+        $finalDeleteError = $null
         if (Test-Path -LiteralPath $SourceDir) {
             try {
                 Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction Stop
             } catch {
-                $ErrorList.Add("Failed to delete source directory '$SourceDir': $($_.Exception.Message)") | Out-Null
+                $finalDeleteError = $_
+                Write-LogDebug "Final source delete retry raised an exception for '$SourceDir': $($_.Exception.Message)"
             }
+        }
+        if (Test-Path -LiteralPath $SourceDir) {
+            $reason = if ($null -ne $finalDeleteError) { $finalDeleteError.Exception.Message } else { 'unknown error' }
+            $ErrorList.Add("Failed to delete source directory '$SourceDir': $reason") | Out-Null
         }
     } catch {
         $msg = "Failed to delete source directory '$SourceDir': $($_.Exception.Message)"

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,22 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.5** (2026-04-24)
+  - Updated final source-directory delete error accounting: cleanup now records an error only when the source directory still exists after all delete attempts.
+  - Final retry exceptions are logged for diagnostics and only treated as failures if the directory remains.
+  - Version bump: `2.1.5` (patch — correctness fix, no feature change).
+- **Expand-ZipsAndClean.ps1 v2.1.4** (2026-04-24)
+  - Updated `Remove-SourceDirectory` cleanup error handling so per-item `-CleanNonZips` removals are best-effort (debug-log only) and do not mark the run as failed.
+  - `ErrorList` now reports only final source-directory deletion failures, matching end-state behavior.
+  - Version bump: `2.1.4` (patch — correctness fix, no feature change).
+- **Expand-ZipsAndClean.ps1 v2.1.3** (2026-04-24)
+  - Fixed `Remove-SourceDirectory` false-positive cleanup failures by recording removal errors only when the target path still exists after a caught `Remove-Item` exception.
+  - Applied the same existence guard to the final source-directory deletion retry path.
+  - Version bump: `2.1.3` (patch — correctness fix, no feature change).
+- **Expand-ZipsAndClean.ps1 v2.1.2** (2026-04-24)
+  - Fixed nested `-CleanNonZips` cleanup reliability in `Remove-SourceDirectory`: directories are now removed with `-Recurse` to prevent intermittent `directory not empty` cleanup errors.
+  - Added deterministic same-depth tie-breaking (`FullName` descending) in deepest-first cleanup ordering.
+  - Version bump: `2.1.2` (patch — bug fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.0** (2026-04-13)
   - Added `#requires -Version 7.0` to enforce the PowerShell 7+ runtime at parse time (script already used the ternary operator which is PS 7-only).
   - Added `using namespace System.Collections.Generic` and `using namespace System.IO.Compression` declarations; shortened `List[string]`, `ZipFile`, and `ZipFileExtensions` type references accordingly.


### PR DESCRIPTION
### Motivation
- Prevent transient `Remove-Item` exceptions from producing false-positive failures when the target path is already removed or the final retry succeeds.
- Make nested `-CleanNonZips` cleanup deterministic and robust against same-depth ordering variance and non-terminating removal behavior on some platforms.
- Improve diagnostics granularity so `ErrorList` reflects actual operation failures rather than noisy intermediate exceptions.

### Description
- Updated `Remove-SourceDirectory` to perform deepest-first cleanup with a deterministic secondary sort key (`FullName` descending) and to remove directories with `-Recurse -Force` while preserving file-only removal for non-containers.
- Converted per-item cleanup errors into best-effort debug diagnostics via `Write-LogDebug` instead of appending to `ErrorList` so only the final outcome is considered a failure.
- Changed final-delete logic to capture any retry exception, log it at debug level, and append a single `ErrorList` entry only if `Test-Path` shows the source directory still exists after all attempts.
- Bumped the script version to `2.1.5` and updated `CHANGELOG.md` and `README.md` entries documenting the `2.1.2`–`2.1.5` fixes and rationale.

### Testing
- Ran the repository `Pester` suite covering `Expand-ZipsAndClean` (including nested `CleanNonZips` and empty-subdir/non-zip cases) and it passed.
- CI checks including the file-management test set completed successfully with the updated deterministic ordering and error-accounting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eace01d9fc8325958c3bbbea7ab37d)