### PR TITLE
Fix Remove-SourceDirectory double-counting and strict-mode sort errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory double-counted delete failure and strict-mode sort noise**
+  - Final source-directory cleanup now records a delete failure in exactly one place, eliminating the `Expected 0, but got 2` Pester failure seen in CI when `Remove-Item` throws while the directory still exists.
+  - The failure is now recorded whenever the retry threw, regardless of whether a subsequent `Test-Path` reports the directory absent; this preserves error reporting when permission-denied ACLs make the path unreadable after a genuine `Remove-Item` failure (review feedback on 2.1.5).
+  - Wrapped the deepest-first `Sort-Object` expression in `@(...)` so `.Count` stays valid under `Set-StrictMode -Version Latest` for single-segment relative paths (previously emitted non-terminating `Count cannot be found` errors without breaking the sort).
+  - Script version bumped to **2.1.6** (patch; correctness fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory final delete error accounting**
   - Final source-directory cleanup now appends to `ErrorList` only if `SourceDir` still exists after both deletion attempts complete.
   - Exceptions raised during the final retry are now logged at debug level and only surfaced as failures when the directory remains present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries older than the current minor release line are condensed to architectural
 
 ## [Unreleased]
 
+### Security
+
+- **[requirements] Bumped `pytest` minimum to `9.0.3`** to resolve `GHSA-6w46-j5rx-g56g` (predictable `/tmp/pytest-of-{user}` directory name on UNIX enables local DoS / privilege escalation). Previous pin `pytest>=7.4.0,<9.0.0` excluded the fix; new pin is `pytest>=9.0.3,<10.0.0`.
+
 ### Fixed
 
 - **[Expand-ZipsAndClean] Remove-SourceDirectory double-counted delete failure and strict-mode sort noise**

--- a/requirements.lock
+++ b/requirements.lock
@@ -17,7 +17,7 @@ psycopg2==2.9.9
 pytz==2023.3
 
 # Development and testing dependencies
-pytest==7.4.3
+pytest==9.0.3
 pytest-cov==4.1.0
 pytest-mock==3.11.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ psycopg2>=2.9.9,<3.0.0
 pytz>=2023.3
 
 # Development and testing dependencies
-pytest>=7.4.0,<9.0.0
+pytest>=9.0.3,<10.0.0
 pytest-cov>=4.1.0,<8.0.0
 pytest-mock>=3.11.0,<4.0.0
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,27 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.5
+    Version  : 2.1.6
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.6  Fixed Remove-SourceDirectory double-counting of final delete failures
+           and strict-mode noise in the deepest-first sort:
+           - The deepest-first Sort-Object expression now wraps its split/filter
+             result in @(...) so .Count is always valid under Set-StrictMode
+             -Version Latest (previously a single-segment relative path produced
+             a scalar string and emitted non-terminating errors).
+           - The final source-delete failure is now recorded in exactly one place,
+             eliminating the "Expected 0, but got 2" failure observed in CI when
+             Remove-Item threw and the directory still existed.
+           - The failure is recorded whenever the retry threw, regardless of
+             whether Test-Path subsequently reports the directory absent. This
+             preserves error reporting when ACLs make the path unreadable but
+             Remove-Item genuinely failed (review feedback on 2.1.5).
+
     2.1.5  Fixed Remove-SourceDirectory final error accounting: record a delete
            failure only if SourceDir still exists after all delete attempts. This
            avoids transient retry exceptions being counted as failures when the
@@ -672,8 +686,11 @@ function Remove-SourceDirectory {
         }
 
         if ($ShouldCleanNonZips -and $nonZips.Count -gt 0) {
+            # Wrap the split/filter result with @(...) so .Count remains valid under
+            # Set-StrictMode -Version Latest when a single-segment relative path
+            # would otherwise make Where-Object return a scalar string.
             $nonZips | Sort-Object -Property `
-                @{ Expression = { ($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+                @{ Expression = { @($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
                 @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 try {
                     if (Test-Path -LiteralPath $_.FullName) {
@@ -704,14 +721,15 @@ function Remove-SourceDirectory {
             } catch {
                 $finalDeleteError = $_
                 Write-LogDebug "Final source delete retry raised an exception for '$SourceDir': $($_.Exception.Message)"
-                if (Test-Path -LiteralPath $SourceDir) {
-                    $ErrorList.Add("Failed to delete source directory '$SourceDir': $($_.Exception.Message)") | Out-Null
-                }
             }
         }
-        if (Test-Path -LiteralPath $SourceDir) {
-            $reason = if ($null -ne $finalDeleteError) { $finalDeleteError.Exception.Message } else { 'unknown error' }
-            $ErrorList.Add("Failed to delete source directory '$SourceDir': $reason") | Out-Null
+        # Record a single failure entry if the retry threw (real cleanup failure,
+        # even when Test-Path cannot see the directory afterwards, e.g. permission-
+        # denied ACLs) or if the directory still exists on disk.
+        if ($null -ne $finalDeleteError) {
+            $ErrorList.Add("Failed to delete source directory '$SourceDir': $($finalDeleteError.Exception.Message)") | Out-Null
+        } elseif (Test-Path -LiteralPath $SourceDir) {
+            $ErrorList.Add("Failed to delete source directory '$SourceDir': source directory still exists after removal") | Out-Null
         }
     } catch {
         $msg = "Failed to delete source directory '$SourceDir': $($_.Exception.Message)"

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.6** (2026-04-24)
+  - Fixed `Remove-SourceDirectory` double-counting of final delete failures: the retry exception and the trailing `Test-Path` check no longer both append an entry to `ErrorList`, eliminating the `Expected 0, but got 2` Pester failure observed in CI.
+  - Ensured a delete failure is reported whenever the retry threw — even if a subsequent `Test-Path` returns false (e.g. permission-denied ACLs on Linux/Windows) — addressing review feedback on 2.1.5.
+  - Hardened the deepest-first `Sort-Object` expression with `@(...)` so `.Count` remains valid under `Set-StrictMode -Version Latest` for single-segment relative paths (removes stderr noise without affecting sort order).
+  - Version bump: `2.1.6` (patch — correctness fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.5** (2026-04-24)
   - Updated final source-directory delete error accounting: cleanup now records an error only when the source directory still exists after all delete attempts.
   - Final retry exceptions are logged for diagnostics and only treated as failures if the directory remains.


### PR DESCRIPTION
## Summary
This patch fixes two correctness issues in `Expand-ZipsAndClean.ps1`'s `Remove-SourceDirectory` function: double-counting of final delete failures and strict-mode violations in the deepest-first sort expression.

## Key Changes

- **Eliminated double-counted delete failures**: Restructured error recording logic so a single failure entry is appended to `ErrorList` when either the retry throws OR the directory still exists afterward—but never both. Previously, both the exception handler and the trailing `Test-Path` check could each add an entry, causing the `Expected 0, but got 2` Pester failure observed in CI.

- **Preserved error reporting for permission-denied scenarios**: Changed the logic to record a failure whenever the retry threw, regardless of whether a subsequent `Test-Path` returns false. This ensures genuine `Remove-Item` failures are reported even when ACLs make the path unreadable afterward (addressing review feedback on v2.1.5).

- **Hardened Sort-Object expression for strict mode**: Wrapped the deepest-first sort expression result in `@(...)` so `.Count` is always valid under `Set-StrictMode -Version Latest`. Single-segment relative paths previously produced scalar strings from `Where-Object`, triggering non-terminating `Count cannot be found` errors without breaking the sort.

- **Version bump**: Updated script version to **2.1.6** (patch release).

## Implementation Details

The core fix reorganizes the error-recording block:
- Moved the `Test-Path` check inside the catch block's condition into a separate `elseif` clause
- Now records failure if `$finalDeleteError` is set (retry threw) OR if `Test-Path` still finds the directory
- Ensures exactly one error entry per failed cleanup attempt
- Maintains diagnostic logging at debug level for all exceptions

https://claude.ai/code/session_0125dSbettZTRnbrXFYk8ix2