### PR TITLE
fix(file-management): use [Directory]::Delete for source cleanup to f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory source-dir deletion unreliable on Linux CI**
+  - Replaced the two-pass `Remove-Item -Recurse -Force` pattern for the source directory with `[System.IO.Directory]::Delete($path, recursive: $true)`. On GitHub Actions Linux runners the two-pass pattern was leaving the source directory on disk even after the per-item cleanup loop had successfully removed its contents, which manifested as `Test-Path $sourceDir | Should -BeFalse` failing in the nested-cleanup Pester case.
+  - The .NET primitive is synchronous, cross-platform, and not subject to PowerShell issue #8211. `Remove-Item` is retained as a single-shot fallback only if the .NET call fails.
+  - Also captured the pipeline item as `$item` before the per-item cleanup `try`/`catch` so that under `Set-StrictMode -Version Latest`, a diagnostic `Write-LogDebug` inside the catch cannot raise a terminating `PropertyNotFoundException` on the `ErrorRecord`. Pester disables StrictMode inside test scopes, so this was only a latent hazard for external callers — but worth hardening.
+  - Restored the strict `$errors.Count | Should -Be 0` test assertion with a `-Because` clause that surfaces the actual `$errors` content, so CI failures are self-diagnosing.
+  - Script version bumped to **2.1.7** (patch; correctness fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory double-counted delete failure and strict-mode sort noise**
   - Final source-directory cleanup now records a delete failure in exactly one place, eliminating the `Expected 0, but got 2` Pester failure seen in CI when `Remove-Item` throws while the directory still exists.
   - The failure is now recorded whenever the retry threw, regardless of whether a subsequent `Test-Path` reports the directory absent; this preserves error reporting when permission-denied ACLs make the path unreadable after a genuine `Remove-Item` failure (review feedback on 2.1.5).

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,30 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.6
+    Version  : 2.1.7
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.7  Fixed Remove-SourceDirectory source-dir deletion reliability on Linux:
+           - Replaced the two-pass Remove-Item -Recurse -Force dance with
+             [System.IO.Directory]::Delete($path, recursive: $true), which is
+             synchronous, cross-platform, and not subject to PowerShell #8211.
+             Remove-Item is retained as a single-shot fallback only if the .NET
+             call fails. On GitHub Actions Linux runners the two-pass Remove-Item
+             pattern was leaving the source directory on disk even after the
+             per-item cleanup loop had successfully removed its contents, which
+             manifested as `Test-Path $sourceDir | Should -BeFalse` failing in
+             the nested-cleanup Pester case.
+           - Also captures the pipeline item as $item before the per-item cleanup
+             try-block so that under Set-StrictMode -Version Latest, a diagnostic
+             Write-LogDebug inside the catch cannot raise a terminating
+             PropertyNotFoundException on the ErrorRecord. This was a latent
+             hazard for callers running under StrictMode even though Pester
+             itself disables StrictMode inside test scopes.
+
     2.1.6  Fixed Remove-SourceDirectory double-counting of final delete failures
            and strict-mode noise in the deepest-first sort:
            - The deepest-first Sort-Object expression now wraps its split/filter
@@ -692,44 +709,66 @@ function Remove-SourceDirectory {
             $nonZips | Sort-Object -Property `
                 @{ Expression = { @($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
                 @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
+                # Capture the pipeline item; inside the catch below, $_ is rebound
+                # to the ErrorRecord and reading $_.FullName would raise a
+                # terminating PropertyNotFoundException under Set-StrictMode -Latest,
+                # which would bubble past this catch into the outer handler and
+                # prevent the final source-directory deletion from running.
+                $item = $_
                 try {
-                    if (Test-Path -LiteralPath $_.FullName) {
-                        if ($_.PSIsContainer) {
-                            Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop
+                    if (Test-Path -LiteralPath $item.FullName) {
+                        if ($item.PSIsContainer) {
+                            Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction Stop
                         } else {
-                            Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop
+                            Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
                         }
                     }
                 } catch {
-                    Write-LogDebug "Best-effort cleanup skip for '$($_.FullName)': $($_.Exception.Message)"
+                    Write-LogDebug "Best-effort cleanup skip for '$($item.FullName)': $($_.Exception.Message)"
                 }
             }
         }
 
         # Delete the source directory itself (no ShouldProcess check needed since $ShouldDeleteSource is explicit).
-        # Use SilentlyContinue for the recursive pass because on Linux Remove-Item
-        # -Recurse can emit non-terminating errors while still removing most content
-        # (PowerShell #8211).  A follow-up Remove-Item with -Recurse handles the
-        # leftover empty shell; only that final attempt uses -ErrorAction Stop.
-        if (Test-Path -LiteralPath $SourceDir) {
-            Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction SilentlyContinue
-        }
+        #
+        # Use [System.IO.Directory]::Delete($path, recursive: true) instead of
+        # Remove-Item -Recurse -Force. On Linux, PowerShell's Remove-Item has a
+        # long-standing rough edge with recursive deletion (PowerShell #8211):
+        # it can emit non-terminating errors while still removing most content,
+        # and on some CI filesystems (GitHub Actions runners in particular) it
+        # leaves the root directory behind, producing a persistent
+        # "source directory still exists after removal" failure in
+        # the nested-cleanup Pester case. The .NET primitive is synchronous,
+        # cross-platform, and has no such quirk. Remove-Item is kept as a
+        # fallback only if the .NET call fails.
         $finalDeleteError = $null
-        if (Test-Path -LiteralPath $SourceDir) {
+        if ([System.IO.Directory]::Exists($SourceDir)) {
             try {
-                Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction Stop
+                [System.IO.Directory]::Delete($SourceDir, $true)
             } catch {
                 $finalDeleteError = $_
-                Write-LogDebug "Final source delete retry raised an exception for '$SourceDir': $($_.Exception.Message)"
+                Write-LogDebug "Directory.Delete raised for '$SourceDir': $($_.Exception.Message)"
             }
         }
-        # Record a single failure entry if the retry threw (real cleanup failure,
-        # even when Test-Path cannot see the directory afterwards, e.g. permission-
-        # denied ACLs) or if the directory still exists on disk.
-        if ($null -ne $finalDeleteError) {
+        # Fallback: if .NET failed and the dir still exists, try Remove-Item once.
+        if ([System.IO.Directory]::Exists($SourceDir)) {
+            try {
+                Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction Stop
+                $finalDeleteError = $null
+            } catch {
+                if ($null -eq $finalDeleteError) { $finalDeleteError = $_ }
+                Write-LogDebug "Remove-Item fallback raised for '$SourceDir': $($_.Exception.Message)"
+            }
+        }
+        # Record a single failure entry if the directory still exists, or if the
+        # last delete attempt threw (preserves error reporting when permission-
+        # denied ACLs might make the directory appear absent while deletion
+        # genuinely failed).
+        if ([System.IO.Directory]::Exists($SourceDir)) {
+            $reason = if ($null -ne $finalDeleteError) { $finalDeleteError.Exception.Message } else { 'source directory still exists after removal' }
+            $ErrorList.Add("Failed to delete source directory '$SourceDir': $reason") | Out-Null
+        } elseif ($null -ne $finalDeleteError) {
             $ErrorList.Add("Failed to delete source directory '$SourceDir': $($finalDeleteError.Exception.Message)") | Out-Null
-        } elseif (Test-Path -LiteralPath $SourceDir) {
-            $ErrorList.Add("Failed to delete source directory '$SourceDir': source directory still exists after removal") | Out-Null
         }
     } catch {
         $msg = "Failed to delete source directory '$SourceDir': $($_.Exception.Message)"

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.7** (2026-04-24)
+  - Replaced the two-pass `Remove-Item -Recurse -Force` source-directory deletion with `[System.IO.Directory]::Delete($path, recursive: $true)`, with `Remove-Item` retained as a single-shot fallback. Fixes the nested-cleanup Pester case on Linux CI where the source directory remained on disk even after its contents were removed.
+  - Captured the per-item cleanup pipeline value as `$item` before the `try`/`catch` to avoid a latent `$_` shadowing hazard under `Set-StrictMode -Version Latest`.
+  - Restored the strict `$errors.Count | Should -Be 0` assertion with a `-Because` clause that surfaces the actual error content on failure.
+  - Version bump: `2.1.7` (patch — correctness fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.6** (2026-04-24)
   - Fixed `Remove-SourceDirectory` double-counting of final delete failures: the retry exception and the trailing `Test-Path` check no longer both append an entry to `ErrorList`, eliminating the `Expected 0, but got 2` Pester failure observed in CI.
   - Ensured a delete failure is reported whenever the retry threw — even if a subsequent `Test-Path` returns false (e.g. permission-denied ACLs on Linux/Windows) — addressing review feedback on 2.1.5.

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -179,21 +179,11 @@ Describe 'Remove-SourceDirectory' {
 
         Remove-SourceDirectory -SourceDir $sourceDir -ShouldDeleteSource $true -ShouldCleanNonZips $true -ErrorList $errors
 
-        # End-state is the real contract: the source directory must be gone.
-        Test-Path -LiteralPath $sourceDir | Should -BeFalse
-
-        # Remove-Item -Recurse -Force on Linux PowerShell can emit transient
-        # non-terminating errors during recursive cleanup while still deleting
-        # the content (PowerShell issue #8211). The function retries and logs
-        # those as debug output, but CI has intermittently surfaced one such
-        # leftover entry in $ErrorList. Rather than asserting an exact count,
-        # guard against errors that would indicate a *meaningful* regression
-        # (items not removed / permission issues) — transient recursive-remove
-        # noise on a dir that is ultimately gone is acceptable.
-        $meaningfulErrors = @($errors | Where-Object {
-            $_ -match 'non-zip files remain|only empty subdirectories remain|Access.*denied|permission denied|directory not empty'
-        })
-        $meaningfulErrors | Should -BeNullOrEmpty -Because ("expected no meaningful cleanup errors, got: " + ($errors -join '; '))
+        # End-state: the source directory must be gone. The -Because clause
+        # surfaces the actual $errors content so CI failures are self-diagnosing
+        # instead of requiring another round-trip.
+        Test-Path -LiteralPath $sourceDir | Should -BeFalse -Because ("errors: " + ($errors -join '; '))
+        $errors.Count | Should -Be 0 -Because ("errors: " + ($errors -join '; '))
     }
 
     It 'surfaces Get-ChildItem read errors as warnings rather than silently dropping them' {


### PR DESCRIPTION
…ix Linux CI

The prior two-pass Remove-Item -Recurse -Force pattern for the source directory in Remove-SourceDirectory was leaving the directory on disk on GitHub Actions Linux runners even after the per-item cleanup loop had successfully removed its contents. This manifested as `Test-Path $sourceDir | Should -BeFalse` failing the nested-cleanup test in CI despite passing locally.

Switched to [System.IO.Directory]::Delete($path, recursive: $true) as the primary delete call -- it's synchronous, cross-platform, and not subject to PowerShell issue #8211. Kept Remove-Item as a single-shot fallback for the case where the .NET call fails.

Also captured the pipeline item as $item before the per-item cleanup try/catch. Pester disables StrictMode inside test scopes, so the $_ shadowing inside the catch ($_ rebinds to ErrorRecord) isn't what was failing CI -- but it IS a latent hazard for external callers running under Set-StrictMode -Version Latest, so worth hardening.

Restored the strict `$errors.Count | Should -Be 0` assertion with a `-Because` clause that surfaces the actual $errors content, so if this regresses again CI will tell us what went wrong in one round-trip instead of requiring a back-and-forth to discover the message.

Script version bumped to 2.1.7.

https://claude.ai/code/session_0125dSbettZTRnbrXFYk8ix2