### PR TITLE
fix(file-management): resolve SourceDir provider path before .NET delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Entries older than the current minor release line are condensed to architectural
 
 ### Fixed
 
+- **[Expand-ZipsAndClean] Remove-SourceDirectory silent short-circuit on PSDrive-qualified `SourceDir`**
+  - `[System.IO.Directory]::Exists` / `::Delete` don't understand PowerShell PSDrives. A caller (or test harness) passing `TestDrive:\source-nested` would make `Directory.Exists` return `$false`, so both delete attempts were skipped and the function returned with `$errors` empty while the directory remained on disk — exactly the `"errors: , but got $true"` Pester failure that followed the 2.1.7 fix.
+  - Now resolves `SourceDir` to its native provider path (`(Resolve-Path -LiteralPath $SourceDir).ProviderPath`) upfront and uses the resolved path for every `[System.IO.Directory]` call, the recursive `Get-ChildItem` scan, and the deepest-first sort regex. The user-facing error messages still reference the caller's original path.
+  - Also enriched the Pester `-Because` diagnostic with `[IO.Directory.Exists]` / `Test-Path` / remaining-items state so future regressions are self-diagnosing.
+  - Script version bumped to **2.1.8** (patch; correctness fix, no new features).
+
 - **[Expand-ZipsAndClean] Remove-SourceDirectory source-dir deletion unreliable on Linux CI**
   - Replaced the two-pass `Remove-Item -Recurse -Force` pattern for the source directory with `[System.IO.Directory]::Delete($path, recursive: $true)`. On GitHub Actions Linux runners the two-pass pattern was leaving the source directory on disk even after the per-item cleanup loop had successfully removed its contents, which manifested as `Test-Path $sourceDir | Should -BeFalse` failing in the nested-cleanup Pester case.
   - The .NET primitive is synchronous, cross-platform, and not subject to PowerShell issue #8211. `Remove-Item` is retained as a single-shot fallback only if the .NET call fails.

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,27 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.7
+    Version  : 2.1.8
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.8  Fixed Remove-SourceDirectory silent short-circuit when SourceDir
+           was passed as a PSDrive-qualified path:
+           - Resolve SourceDir to its native provider path (Resolve-Path |
+             ProviderPath) before any [System.IO.Directory] call. .NET APIs are
+             unaware of PowerShell PSDrives, so a caller (or test harness)
+             passing a path like `TestDrive:\source-nested` would make
+             [Directory]::Exists return $false, causing both delete attempts
+             to be skipped silently and leaving the directory on disk with no
+             error recorded. This matches the CI symptom where $errors was
+             empty yet Test-Path reported the directory still present.
+           - The deepest-first Sort-Object regex and the Get-ChildItem scan
+             also use the resolved path so item FullName values consistently
+             strip the expected prefix.
+
     2.1.7  Fixed Remove-SourceDirectory source-dir deletion reliability on Linux:
            - Replaced the two-pass Remove-Item -Recurse -Force dance with
              [System.IO.Directory]::Delete($path, recursive: $true), which is
@@ -684,9 +698,21 @@ function Remove-SourceDirectory {
         return
     }
 
+    # Resolve to the native provider path so [System.IO.Directory] calls (which
+    # are unaware of PowerShell PSDrives) see exactly the same path PowerShell
+    # does. Without this, a caller passing e.g. `TestDrive:\source-nested`
+    # would make Directory.Exists return $false (invalid path to .NET) while
+    # Test-Path correctly reported $true, causing the delete logic to short-
+    # circuit silently and leave the directory on disk.
+    $resolvedSource = try {
+        (Resolve-Path -LiteralPath $SourceDir -ErrorAction Stop).ProviderPath
+    } catch {
+        $SourceDir
+    }
+
     try {
         $gcErrors = $null
-        $remaining = Get-ChildItem -LiteralPath $SourceDir -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable gcErrors
+        $remaining = Get-ChildItem -LiteralPath $resolvedSource -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable gcErrors
         foreach ($e in $gcErrors) {
             Write-Warning "Could not read item during source directory scan: $($e.Exception.Message)"
         }
@@ -707,7 +733,7 @@ function Remove-SourceDirectory {
             # Set-StrictMode -Version Latest when a single-segment relative path
             # would otherwise make Where-Object return a scalar string.
             $nonZips | Sort-Object -Property `
-                @{ Expression = { @($_.FullName -replace [regex]::Escape($SourceDir), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+                @{ Expression = { @($_.FullName -replace [regex]::Escape($resolvedSource), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
                 @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 # Capture the pipeline item; inside the catch below, $_ is rebound
                 # to the ErrorRecord and reading $_.FullName would raise a
@@ -742,29 +768,29 @@ function Remove-SourceDirectory {
         # cross-platform, and has no such quirk. Remove-Item is kept as a
         # fallback only if the .NET call fails.
         $finalDeleteError = $null
-        if ([System.IO.Directory]::Exists($SourceDir)) {
+        if ([System.IO.Directory]::Exists($resolvedSource)) {
             try {
-                [System.IO.Directory]::Delete($SourceDir, $true)
+                [System.IO.Directory]::Delete($resolvedSource, $true)
             } catch {
                 $finalDeleteError = $_
-                Write-LogDebug "Directory.Delete raised for '$SourceDir': $($_.Exception.Message)"
+                Write-LogDebug "Directory.Delete raised for '$resolvedSource': $($_.Exception.Message)"
             }
         }
         # Fallback: if .NET failed and the dir still exists, try Remove-Item once.
-        if ([System.IO.Directory]::Exists($SourceDir)) {
+        if ([System.IO.Directory]::Exists($resolvedSource)) {
             try {
-                Remove-Item -LiteralPath $SourceDir -Recurse -Force -ErrorAction Stop
+                Remove-Item -LiteralPath $resolvedSource -Recurse -Force -ErrorAction Stop
                 $finalDeleteError = $null
             } catch {
                 if ($null -eq $finalDeleteError) { $finalDeleteError = $_ }
-                Write-LogDebug "Remove-Item fallback raised for '$SourceDir': $($_.Exception.Message)"
+                Write-LogDebug "Remove-Item fallback raised for '$resolvedSource': $($_.Exception.Message)"
             }
         }
         # Record a single failure entry if the directory still exists, or if the
         # last delete attempt threw (preserves error reporting when permission-
         # denied ACLs might make the directory appear absent while deletion
         # genuinely failed).
-        if ([System.IO.Directory]::Exists($SourceDir)) {
+        if ([System.IO.Directory]::Exists($resolvedSource)) {
             $reason = if ($null -ne $finalDeleteError) { $finalDeleteError.Exception.Message } else { 'source directory still exists after removal' }
             $ErrorList.Add("Failed to delete source directory '$SourceDir': $reason") | Out-Null
         } elseif ($null -ne $finalDeleteError) {

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -45,6 +45,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean.ps1 v2.1.8** (2026-04-24)
+  - Resolved `SourceDir` to its native provider path before any `[System.IO.Directory]` call. `.NET` file APIs don't understand PowerShell PSDrives, so a PSDrive-qualified path (e.g. `TestDrive:\...` from Pester) was making `Directory.Exists` return `$false` and both delete attempts would skip silently, leaving the directory on disk with no error reported.
+  - Enriched Pester test `-Because` diagnostic to include `[IO.Directory]::Exists` / `Test-Path` / remaining-items state for self-diagnosing failures.
+  - Version bump: `2.1.8` (patch — correctness fix, no feature change).
 - **Expand-ZipsAndClean.ps1 v2.1.7** (2026-04-24)
   - Replaced the two-pass `Remove-Item -Recurse -Force` source-directory deletion with `[System.IO.Directory]::Delete($path, recursive: $true)`, with `Remove-Item` retained as a single-shot fallback. Fixes the nested-cleanup Pester case on Linux CI where the source directory remained on disk even after its contents were removed.
   - Captured the per-item cleanup pipeline value as `$item` before the `try`/`catch` to avoid a latent `$_` shadowing hazard under `Set-StrictMode -Version Latest`.

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -179,11 +179,24 @@ Describe 'Remove-SourceDirectory' {
 
         Remove-SourceDirectory -SourceDir $sourceDir -ShouldDeleteSource $true -ShouldCleanNonZips $true -ErrorList $errors
 
-        # End-state: the source directory must be gone. The -Because clause
-        # surfaces the actual $errors content so CI failures are self-diagnosing
-        # instead of requiring another round-trip.
-        Test-Path -LiteralPath $sourceDir | Should -BeFalse -Because ("errors: " + ($errors -join '; '))
-        $errors.Count | Should -Be 0 -Because ("errors: " + ($errors -join '; '))
+        # End-state: the source directory must be gone. Assemble a rich -Because
+        # clause so CI failures are self-diagnosing. Previously we only dumped
+        # $errors, which left us guessing when Test-Path disagreed with
+        # [System.IO.Directory]::Exists (e.g. 0 errors reported but the dir
+        # still visible on disk -- points to the function taking a path that
+        # normalizes differently from the one the test holds).
+        $netExists  = [System.IO.Directory]::Exists($sourceDir)
+        $psExists   = Test-Path -LiteralPath $sourceDir
+        $remaining  = if ($psExists) {
+            try {
+                (Get-ChildItem -LiteralPath $sourceDir -Recurse -Force -ErrorAction Stop |
+                    ForEach-Object FullName) -join ', '
+            } catch { "<enum-failed: $($_.Exception.Message)>" }
+        } else { '<none>' }
+        $diag = "errors=[$($errors -join '; ')]; IO.Directory.Exists=$netExists; Test-Path=$psExists; sourceDir='$sourceDir'; remaining=[$remaining]"
+
+        $psExists     | Should -BeFalse -Because $diag
+        $errors.Count | Should -Be 0    -Because $diag
     }
 
     It 'surfaces Get-ChildItem read errors as warnings rather than silently dropping them' {


### PR DESCRIPTION
[System.IO.Directory]::Exists / ::Delete don't understand PowerShell PSDrives. On CI the nested-cleanup Pester case was failing with `Test-Path=$true` but `$errors` empty -- the function's first `Directory.Exists($SourceDir)` check was returning $false because the caller's path was PSDrive-qualified (e.g. TestDrive:\source-nested), so both delete attempts were silently skipped and the function returned clean while the directory stayed on disk.

Now resolve SourceDir to its native provider path up front:

    $resolvedSource = (Resolve-Path -LiteralPath $SourceDir -EA Stop).ProviderPath

and thread that through every [System.IO.Directory] call, the Get-ChildItem scan, and the deepest-first sort regex. User-facing error messages still carry the caller's original path.

Also enriched the failing test's `-Because` diagnostic to dump [IO.Directory]::Exists, Test-Path, and any remaining items on failure, so if this ever regresses again CI will say *what* went wrong instead of requiring a round-trip to discover it.

Script version bumped to 2.1.8.

https://claude.ai/code/session_0125dSbettZTRnbrXFYk8ix2