### PR TITLE
Fix Clear-LogFile hijacking caller's logger configuration

### DIFF
--- a/src/powershell/modules/Core/Logging/PurgeLogs.psd1
+++ b/src/powershell/modules/Core/Logging/PurgeLogs.psd1
@@ -1,7 +1,7 @@
 @{
     # Module manifest for PurgeLogs
     RootModule        = 'PurgeLogs.psm1'
-    ModuleVersion     = '2.2.2'
+    ModuleVersion     = '2.2.3'
     GUID              = '8e9f2b4d-6c3a-4f7e-9d5b-2a8c4e6f1b3d'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = ''
@@ -15,7 +15,7 @@
         PSData = @{
             Tags         = @('logging','purge','retention','cleanup','maintenance')
             ProjectUri   = ''
-            ReleaseNotes = '2.2.2: Fixed Clear-LogFile timestamp parsing for cross-version PowerShell/.NET TryParseExact overload compatibility.'
+            ReleaseNotes = '2.2.3: Fixed Clear-LogFile no longer hijacks the caller''s logger configuration when a logger is already initialized.'
         }
     }
 }

--- a/src/powershell/modules/Core/Logging/PurgeLogs.psm1
+++ b/src/powershell/modules/Core/Logging/PurgeLogs.psm1
@@ -101,7 +101,9 @@ function Clear-LogFile {
 
     $verboseSet = $PSCmdlet.MyInvocation.BoundParameters['Verbose']
     if (Get-Command -Name Initialize-Logger -ErrorAction SilentlyContinue) {
-        Initialize-Logger -ScriptName "purge_logs.ps1" -Verbose:$verboseSet
+        if (-not $Global:LogConfig -or [string]::IsNullOrEmpty([string]$Global:LogConfig.LogFilePath)) {
+            Initialize-Logger -ScriptName "purge_logs.ps1" -Verbose:$verboseSet
+        }
     }
 
     if ($PSBoundParameters.ContainsKey('RetentionDays') -and $RetentionDays -lt 0) {

--- a/src/powershell/modules/Core/Logging/PurgeLogs/CHANGELOG.md
+++ b/src/powershell/modules/Core/Logging/PurgeLogs/CHANGELOG.md
@@ -6,6 +6,11 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 > This file is module-scoped. For repository-wide changes affecting other scripts, see the root `CHANGELOG.md`.
 
+## [2.2.3] - 2026-04-25
+### Fixed
+- `Clear-LogFile` no longer overwrites the caller's `$Global:LogConfig.LogFilePath` when a logger has already been initialized. Previously the unconditional `Initialize-Logger -ScriptName "purge_logs.ps1"` call (with no `-resolvedLogDir`) reset the global log path to the framework's default `logs` directory, silently redirecting all subsequent `Write-Log*` output away from the host script's chosen log file. This affected `FileDistributor.ps1` runs invoked with `-TruncateLog` (and any other `Clear-LogFile` retention/truncation parameter), where logs after the truncation step landed in `<framework-modules>\logs\purge_logs_powershell_<date>.log` instead of the user-specified `-LogFilePath`.
+- The fallback `Initialize-Logger` call now only fires when no logger is already initialized (`$Global:LogConfig.LogFilePath` is null/empty), preserving the safety net for standalone use of `Clear-LogFile` without disturbing host scripts that have already configured the logger.
+
 ## [2.2.2] - 2026-03-27
 ### Fixed
 - Corrected `Clear-LogFile` timestamp parsing to use explicit `TryParseExact`/`TryParse` overloads compatible across PowerShell/.NET runtime variants.

--- a/src/powershell/modules/Core/Logging/PurgeLogs/Public/Clear-LogFile.ps1
+++ b/src/powershell/modules/Core/Logging/PurgeLogs/Public/Clear-LogFile.ps1
@@ -53,7 +53,9 @@ function Clear-LogFile {
 
     $verboseSet = $PSCmdlet.MyInvocation.BoundParameters['Verbose']
     if (Get-Command -Name Initialize-Logger -ErrorAction SilentlyContinue) {
-        Initialize-Logger -ScriptName "purge_logs.ps1" -Verbose:$verboseSet
+        if (-not $Global:LogConfig -or [string]::IsNullOrEmpty([string]$Global:LogConfig.LogFilePath)) {
+            Initialize-Logger -ScriptName "purge_logs.ps1" -Verbose:$verboseSet
+        }
     }
 
     if ($PSBoundParameters.ContainsKey('RetentionDays') -and $RetentionDays -lt 0) {

--- a/src/powershell/modules/Core/Logging/PurgeLogs/README.md
+++ b/src/powershell/modules/Core/Logging/PurgeLogs/README.md
@@ -4,7 +4,7 @@
 Log file purging and retention management module implementing multiple cleanup strategies per [Logging Specification](../../../../../docs/specifications/logging_specification.md).
 
 ## Version
-Current version: **2.2.2**
+Current version: **2.2.3**
 
 ## Features
 


### PR DESCRIPTION
## Summary
Fixed a bug in `Clear-LogFile` where it unconditionally reinitializes the logger, overwriting the caller's configured log file path. This caused log output to be redirected to the framework's default logs directory instead of the user-specified path when `Clear-LogFile` was invoked by host scripts like `FileDistributor.ps1`.

## Key Changes
- Added a guard condition to only call `Initialize-Logger` when no logger is already initialized (i.e., when `$Global:LogConfig.LogFilePath` is null or empty)
- This preserves the caller's logger configuration while maintaining the safety net for standalone use of `Clear-LogFile`
- Updated module version from 2.2.2 to 2.2.3
- Updated CHANGELOG and README with version information

## Implementation Details
The fix checks `$Global:LogConfig` and its `LogFilePath` property before calling `Initialize-Logger`. The condition:
```powershell
if (-not $Global:LogConfig -or [string]::IsNullOrEmpty([string]$Global:LogConfig.LogFilePath)) {
    Initialize-Logger -ScriptName "purge_logs.ps1" -Verbose:$verboseSet
}
```

This ensures that:
- If a logger is already configured by a host script, `Clear-LogFile` respects that configuration
- If `Clear-LogFile` is used standalone without prior logger initialization, it still initializes the logger as a fallback
- The verbose flag is properly propagated when initialization occurs

## Affected Scenarios
- `FileDistributor.ps1` runs with `-TruncateLog` parameter now correctly log to the user-specified `-LogFilePath` instead of the framework's default logs directory
- Any host script that initializes the logger before calling `Clear-LogFile` with retention/truncation parameters will no longer have its log configuration overwritten

https://claude.ai/code/session_01CNtsG3zbvLWBiPCvx8V7Au