### PR TITLE
refactor(Move-ZipFilesToParent): eliminate parent-scope reads

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -837,15 +837,15 @@ function Move-ZipFilesToParent {
         throw "Parent directory not found: $parent"
     }
 
-    # Writability probe using an empty directory (skip if WhatIf)
+    # Writability probe using a temporary file (skip if WhatIf)
     if (-not $WhatIfPreference) {
-        $probe = Join-Path $parent ("._write_test_{0}" -f ([guid]::NewGuid().ToString('N')))
+        $probe = Join-Path $parent ("_write_test_{0}.tmp" -f ([guid]::NewGuid().ToString('N')))
         try {
-            New-DirectoryIfMissing -Path $probe -Force | Out-Null
-            Remove-Item -LiteralPath $probe -Recurse -Force
+            New-Item -ItemType File -Path $probe -Force | Out-Null
+            Remove-Item -LiteralPath $probe -Force
         } catch {
-            # Clean up probe directory even on failure
-            try { Remove-Item -LiteralPath $probe -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+            # Clean up probe file even on failure
+            try { Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue } catch { }
             throw "Parent directory is not writable: $parent"
         }
     }

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -100,13 +100,20 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.1.8
+    Version  : 2.1.9
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.1.9  Refactored Move-ZipFilesToParent to eliminate parent-scope reads:
+           - Added [bool]$QuietMode parameter to avoid reading $Quiet from parent scope
+           - Added drive-root edge case check with clear error message
+           - Made writability probe leak-free by cleaning up temp directory on failure
+           - Added comprehensive Pester tests for standalone function exercise
+           - Updated function help documentation for new parameter
+
     2.1.8  Fixed Remove-SourceDirectory silent short-circuit when SourceDir
            was passed as a PSDrive-qualified path:
            - Resolve SourceDir to its native provider path (Resolve-Path |
@@ -733,8 +740,8 @@ function Remove-SourceDirectory {
             # Set-StrictMode -Version Latest when a single-segment relative path
             # would otherwise make Where-Object return a scalar string.
             $nonZips | Sort-Object -Property `
-                @{ Expression = { @($_.FullName -replace [regex]::Escape($resolvedSource), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
-                @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
+            @{ Expression = { @($_.FullName -replace [regex]::Escape($resolvedSource), '' -split '[\\/]' | Where-Object { $_ -ne '' }).Count }; Descending = $true }, `
+            @{ Expression = { $_.FullName }; Descending = $true } | ForEach-Object {
                 # Capture the pipeline item; inside the catch below, $_ is rebound
                 # to the ErrorRecord and reading $_.FullName would raise a
                 # terminating PropertyNotFoundException under Set-StrictMode -Latest,
@@ -806,12 +813,24 @@ function Remove-SourceDirectory {
 <#
 .SYNOPSIS
     Moves .zip files from SourceDir to its parent folder with per-file progress.
+
+.PARAMETER SourceDir
+    The source directory containing .zip files to move.
+
+.PARAMETER QuietMode
+    Suppresses progress bar output when $true.
 #>
 function Move-ZipFilesToParent {
     [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$SourceDir)
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][bool]$QuietMode
+    )
 
     $parentItem = Get-Item -LiteralPath $SourceDir
+    if (-not $parentItem.Parent) {
+        throw "Cannot move zip files: source directory '$SourceDir' is at drive root (no parent directory exists)"
+    }
     $parent = $parentItem.Parent.FullName
 
     if (-not (Test-Path -LiteralPath $parent)) {
@@ -825,6 +844,8 @@ function Move-ZipFilesToParent {
             New-DirectoryIfMissing -Path $probe -Force | Out-Null
             Remove-Item -LiteralPath $probe -Recurse -Force
         } catch {
+            # Clean up probe directory even on failure
+            try { Remove-Item -LiteralPath $probe -Recurse -Force -ErrorAction SilentlyContinue } catch { }
             throw "Parent directory is not writable: $parent"
         }
     }
@@ -839,7 +860,7 @@ function Move-ZipFilesToParent {
 
     foreach ($zf in $zipsToMove) {
         $idx++
-        if (-not $Quiet) {
+        if (-not $QuietMode) {
             $pct = [int](($idx) / [math]::Max(1, $total) * 100)
             Write-Progress -Activity "Moving zip files to parent" `
                 -Status "$idx / $total : $($zf.Name) ($(Format-Bytes $zf.Length))" `
@@ -856,7 +877,7 @@ function Move-ZipFilesToParent {
         $bytes += $zf.Length
     }
 
-    if (-not $Quiet) { Write-Progress -Activity "Moving zip files to parent" -Completed }
+    if (-not $QuietMode) { Write-Progress -Activity "Moving zip files to parent" -Completed }
 
     [pscustomobject]@{ Count = $moved; Bytes = $bytes; Destination = $parent }
 }
@@ -897,7 +918,7 @@ try {
 
     try {
         if ($PSCmdlet.ShouldProcess($SourceDirectory, "Move .zip files to parent")) {
-            $moveSummary = Move-ZipFilesToParent -SourceDir $SourceDirectory
+            $moveSummary = Move-ZipFilesToParent -SourceDir $SourceDirectory -QuietMode $Quiet.IsPresent
         }
     } catch {
         $msg = "Moving .zip files to parent failed: $($_.Exception.Message)"

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -266,6 +266,11 @@ Describe 'Move-ZipFilesToParent' {
     }
 
     It 'throws clear error for drive root source directory' {
+        # Mock Get-Item to simulate a drive root (no parent directory)
+        Mock Get-Item {
+            [pscustomobject]@{ Parent = $null; FullName = 'C:\' }
+        }
+
         { Move-ZipFilesToParent -SourceDir 'C:\' -QuietMode $true } | Should -Throw "*drive root*"
     }
 

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -190,16 +190,16 @@ Describe 'Remove-SourceDirectory' {
         # assertion on [System.IO.Directory]::Exists -- the same API the
         # function uses to decide whether deletion succeeded -- and surface
         # the other signals in the diagnostic for visibility.
-        $netDirExists  = [System.IO.Directory]::Exists($sourceDir)
+        $netDirExists = [System.IO.Directory]::Exists($sourceDir)
         $netFileExists = [System.IO.File]::Exists($sourceDir)
-        $psExists      = Test-Path -LiteralPath $sourceDir
-        $psType        = if ($psExists) {
+        $psExists = Test-Path -LiteralPath $sourceDir
+        $psType = if ($psExists) {
             "container=$(Test-Path -LiteralPath $sourceDir -PathType Container);leaf=$(Test-Path -LiteralPath $sourceDir -PathType Leaf)"
         } else { '<n/a>' }
-        $remaining     = if ($psExists) {
+        $remaining = if ($psExists) {
             try {
                 (Get-ChildItem -LiteralPath $sourceDir -Recurse -Force -ErrorAction Stop |
-                    ForEach-Object FullName) -join ', '
+                ForEach-Object FullName) -join ', '
             } catch { "<enum-failed: $($_.Exception.Message)>" }
         } else { '<none>' }
         $diag = "errors=[$($errors -join '; ')]; IO.Directory.Exists=$netDirExists; IO.File.Exists=$netFileExists; Test-Path=$psExists ($psType); sourceDir='$sourceDir'; remaining=[$remaining]"
@@ -221,5 +221,63 @@ Describe 'Remove-SourceDirectory' {
         Should -Not -Throw
 
         Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter { $Message -like '*scan*' }
+    }
+}
+
+Describe 'Move-ZipFilesToParent' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+
+        $helpersStart = $scriptText.IndexOf('#region Helpers')
+        $helpersEnd = $scriptText.IndexOf('#endregion Helpers')
+        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
+            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
+        }
+
+        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
+        $usingLines = ($scriptText -split "`n" |
+            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
+        $helpersWithUsing = $usingLines + "`n" + $helpers
+
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+
+        function Write-LogDebug { param([string]$Message) }
+        Invoke-Expression $helpersWithUsing
+    }
+
+    It 'moves zip files from source to parent directory' {
+        $parentDir = Join-Path $TestDrive 'parent'
+        $sourceDir = Join-Path $parentDir 'source'
+        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
+
+        $zipPath = Join-Path $sourceDir 'test.zip'
+        Set-Content -LiteralPath $zipPath -Value 'dummy zip content' -NoNewline
+
+        $result = Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true
+
+        $result.Count | Should -Be 1
+        $result.Bytes | Should -BeGreaterThan 0
+        $result.Destination | Should -Be $parentDir
+
+        Test-Path -LiteralPath $zipPath | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $parentDir 'test.zip') | Should -BeTrue
+    }
+
+    It 'throws clear error for drive root source directory' {
+        { Move-ZipFilesToParent -SourceDir 'C:\' -QuietMode $true } | Should -Throw "*drive root*"
+    }
+
+    It 'handles non-existent parent gracefully' {
+        $sourceDir = Join-Path $TestDrive 'orphan'
+        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
+
+        # Mock Get-Item to return an item with no parent
+        Mock Get-Item {
+            [pscustomobject]@{ Parent = $null; FullName = $sourceDir }
+        }
+
+        { Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true } | Should -Throw "*drive root*"
     }
 }


### PR DESCRIPTION
- Add QuietMode parameter to avoid reading \ from parent scope
- Add drive-root edge case check with clear error message
- Make writability probe leak-free by cleaning up temp directory on failure
- Add comprehensive Pester tests for standalone function exercise
- Update function help documentation for new parameter
- Increment version to 2.1.9 and add changelog entry

Closes #971