### PR TITLE
Replace Invoke-Expression with ScriptBlock.Create for safer code execution

### DIFF
--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
 
         function Write-LogDebug { param([string]$Message) }
-        Invoke-Expression $helpersWithUsing
+        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'defines mode-specific helper functions and dispatcher' {
@@ -173,7 +173,7 @@ Describe 'Remove-SourceDirectory' {
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
 
         function Write-LogDebug { param([string]$Message) }
-        Invoke-Expression $helpersWithUsing
+        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'blocks DeleteSource and preserves zip files remaining after a Skip-policy move' {
@@ -292,7 +292,7 @@ Describe 'Move-ZipFilesToParent' {
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
 
         function Write-LogDebug { param([string]$Message) }
-        Invoke-Expression $helpersWithUsing
+        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'moves zip files from source to parent directory' {


### PR DESCRIPTION
## Summary
This PR improves code safety in the PowerShell test suite by replacing `Invoke-Expression` with a safer alternative using `ScriptBlock::Create()` for dynamic code execution.

## Key Changes
- Replaced three instances of `Invoke-Expression $helpersWithUsing` with `. ([ScriptBlock]::Create($helpersWithUsing))` across test files:
  - `Expand-ZipsAndClean.Tests.ps1` (2 occurrences)
  - `Remove-SourceDirectory` test block
  - `Move-ZipFilesToParent` test block

## Implementation Details
The change uses PowerShell's `ScriptBlock::Create()` method combined with the dot-sourcing operator (`.`) instead of `Invoke-Expression`. This approach:
- Provides better security by avoiding the risks associated with `Invoke-Expression`
- Maintains the same functionality of executing the helper code in the current scope
- Follows PowerShell best practices for dynamic code execution in test scenarios

https://claude.ai/code/session_017mCt5nWa4XpXJAZXqjYJ6W