### PR TITLE
Centralize Write-Progress wrapper and fix byte counter off-by-one

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,38 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.2.3 — 2026-05-17
+
+### Added
+
+- `Write-PhaseProgress` private helper that accepts `Activity`, `Status`, `Current`, `Total`,
+  `QuietMode`, optional `CurrentOperation`, and a `Completed` switch. It centralizes percentage
+  math (`[int]($Current / [math]::Max(1, $Total) * 100)`) and `-Quiet` suppression so neither
+  caller has to hand-roll those two concerns.
+
+### Changed
+
+- `Invoke-ZipExtractions`: replaced two inline `Write-Progress` / `if (-not $QuietMode)` blocks
+  with `Write-PhaseProgress` calls.
+- `Move-ZipFilesToParent`: replaced inline `Write-Progress` / `if (-not $QuietMode)` blocks with
+  `Write-PhaseProgress` calls. The `CurrentOperation` caption now reads
+  `"Moving: X of Y bytes"` (was `"Moved X of Y"`), and the byte total shown for the current file
+  is `$bytes + $zf.Length` rather than `$bytes`. This fixes the off-by-one display where the
+  caption previously showed only the cumulative bytes from already-completed files, omitting the
+  file currently being moved.
+
+### Tests
+
+- Added `Describe 'Write-PhaseProgress'` with eight It blocks covering:
+  - QuietMode suppression (both normal and Completed paths).
+  - Correct `PercentComplete` computation (50 % at midpoint, 100 % at end).
+  - `CurrentOperation` included when supplied, omitted when not.
+  - `Completed` switch invokes `Write-Progress -Completed`.
+  - Zero `Total` guard (no division-by-zero error).
+
+### Versioning
+
+- Bumped `Expand-ZipsAndClean.ps1` version to `2.2.3`.
+
 ## 2.2.2 — 2026-05-12
 
 ### Changed

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -103,13 +103,29 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.2.2
+    Version  : 2.2.3
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.2.3  Centralized Write-Progress wrapper and fixed off-by-one byte counter (issue #975):
+           - Added private Write-PhaseProgress helper accepting Activity, Status,
+             Current, Total, QuietMode, optional CurrentOperation, and Completed switch.
+             Percentage math and -Quiet suppression are now in one place.
+           - Refactored Invoke-ZipExtractions and Move-ZipFilesToParent to call
+             Write-PhaseProgress instead of hand-rolling Write-Progress calls.
+           - Fixed off-by-one byte counter in Move-ZipFilesToParent: the CurrentOperation
+             caption now shows bytes including the current file being processed
+             (using $bytes + $zf.Length in the display), so the progress reflects
+             the running total up to and including the current file.
+           - Used PS 7 null-coalescing (??) in Write-PhaseProgress for the
+             optional CurrentOperation guard.
+           - Added Pester tests for Write-PhaseProgress covering QuietMode suppression,
+             progress invocation with parameters, Completed behavior, and percentage math.
+           Version bump: patch.
+
     2.2.2  De-duplicated stat computations and consolidated assembly load (issue #974):
            - Moved single Add-Type -AssemblyName System.IO.Compression.FileSystem
              call to script start; removed per-invocation calls from Get-ZipFileStats
@@ -386,6 +402,60 @@ Initialize-Logger -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
 Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
 
 #region Helpers
+
+<#
+.SYNOPSIS
+    Centralized Write-Progress wrapper that respects -Quiet mode.
+.DESCRIPTION
+    Consolidates percentage math and -Quiet suppression for all phase progress bars.
+    Callers pass raw Current/Total counts; the helper computes PercentComplete.
+.PARAMETER Activity
+    The progress-bar activity label.
+.PARAMETER Status
+    The status message shown on the progress bar.
+.PARAMETER Current
+    Current item index used to compute the percentage complete.
+.PARAMETER Total
+    Total item count (denominator for percentage).
+.PARAMETER QuietMode
+    When $true, all progress output is suppressed and the function returns immediately.
+.PARAMETER CurrentOperation
+    Optional sub-operation text shown beneath the status line.
+.PARAMETER Completed
+    Switch. When set, closes the named progress bar instead of updating it.
+#>
+function Write-PhaseProgress {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Activity,
+        [Parameter(Mandatory)][string]$Status,
+        [Parameter(Mandatory)][int]$Current,
+        [Parameter(Mandatory)][int]$Total,
+        [Parameter(Mandatory)][bool]$QuietMode,
+        [string]$CurrentOperation,
+        [switch]$Completed
+    )
+
+    if ($QuietMode) { return }
+
+    if ($Completed) {
+        Write-Progress -Activity $Activity -Completed
+        return
+    }
+
+    $pct = [int]($Current / [math]::Max(1, $Total) * 100)
+    $params = @{
+        Activity        = $Activity
+        Status          = $Status
+        PercentComplete = $pct
+    }
+    # Use ?? so that a null CurrentOperation gracefully collapses to '' (falsy),
+    # avoiding a spurious empty -CurrentOperation on the progress bar.
+    if ($CurrentOperation ?? '') {
+        $params['CurrentOperation'] = $CurrentOperation
+    }
+    Write-Progress @params
+}
 
 <#
 .SYNOPSIS
@@ -780,10 +850,8 @@ function Invoke-ZipExtractions {
         foreach ($zip in $zips) {
             $index++
             try {
-                if (-not $QuietMode) {
-                    $pct = [int](($index - 1) / [math]::Max(1, $zipCount) * 100)
-                    Write-Progress -Activity "Extracting archives" -Status $zip.Name -PercentComplete $pct
-                }
+                Write-PhaseProgress -Activity "Extracting archives" -Status $zip.Name `
+                    -Current ($index - 1) -Total $zipCount -QuietMode $QuietMode
 
                 if ($PSCmdlet.ShouldProcess($zip.FullName, "Extract")) {
                     $stats = Get-ZipFileStats -ZipPath $zip.FullName
@@ -812,9 +880,8 @@ function Invoke-ZipExtractions {
             }
         }
 
-        if (-not $QuietMode) {
-            Write-Progress -Activity "Extracting archives" -Completed
-        }
+        Write-PhaseProgress -Activity "Extracting archives" -Status "Done" `
+            -Current $zipCount -Total $zipCount -QuietMode $QuietMode -Completed
     }
 
     return [pscustomobject]@{
@@ -1017,13 +1084,13 @@ function Move-ZipFilesToParent {
 
     foreach ($zf in $zipsToMove) {
         $idx++
-        if (-not $QuietMode) {
-            $pct = [int](($idx) / [math]::Max(1, $total) * 100)
-            Write-Progress -Activity "Moving zip files to parent" `
-                -Status "$idx / $total : $($zf.Name) ($(Format-Bytes $zf.Length))" `
-                -CurrentOperation ("Moved {0} of {1}" -f (Format-Bytes $bytes), (Format-Bytes $totalBytes)) `
-                -PercentComplete $pct
-        }
+        # Include the current file's size in the display so the byte counter reflects
+        # the running total up to and including the file being processed (fixes the
+        # off-by-one where the caption previously showed only bytes from prior files).
+        Write-PhaseProgress -Activity "Moving zip files to parent" `
+            -Status "$idx / $total : $($zf.Name) ($(Format-Bytes $zf.Length))" `
+            -Current $idx -Total $total -QuietMode $QuietMode `
+            -CurrentOperation ("Moving: {0} of {1} bytes" -f (Format-Bytes ($bytes + $zf.Length)), (Format-Bytes $totalBytes))
 
         $target = Join-Path $parent $zf.Name
         $collides = [System.IO.File]::Exists($target)
@@ -1052,7 +1119,8 @@ function Move-ZipFilesToParent {
         $bytes += $zf.Length
     }
 
-    if (-not $QuietMode) { Write-Progress -Activity "Moving zip files to parent" -Completed }
+    Write-PhaseProgress -Activity "Moving zip files to parent" -Status "Done" `
+        -Current $total -Total $total -QuietMode $QuietMode -Completed
 
     [pscustomobject]@{ Count = $moved; Bytes = $bytes; Destination = $parent; Skipped = $skipped; Overwritten = $overwritten; Renamed = $renamed }
 }

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -486,3 +486,106 @@ Describe 'Move-ZipFilesToParent' {
         $parentZips.Count | Should -Be 2
     }
 }
+
+Describe 'Write-PhaseProgress' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+
+        $helpersStart = $scriptText.IndexOf('#region Helpers')
+        $helpersEnd   = $scriptText.IndexOf('#endregion Helpers')
+        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
+            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
+        }
+
+        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
+        $usingLines = ($scriptText -split "`n" |
+            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
+        $helpersWithUsing = $usingLines + "`n" + $helpers
+
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+
+        function Write-LogDebug { param([string]$Message) }
+        . ([ScriptBlock]::Create($helpersWithUsing))
+    }
+
+    It 'suppresses Write-Progress when QuietMode is true' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Test' -Status 'Running' -Current 1 -Total 5 -QuietMode $true
+
+        Should -Invoke Write-Progress -Times 0
+    }
+
+    It 'calls Write-Progress with computed percentage when QuietMode is false' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Extracting' -Status 'file.zip' -Current 2 -Total 4 -QuietMode $false
+
+        Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
+            $Activity -eq 'Extracting' -and
+            $Status -eq 'file.zip' -and
+            $PercentComplete -eq 50
+        }
+    }
+
+    It 'includes CurrentOperation when provided' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Moving' -Status '1 / 3 : a.zip' `
+            -Current 1 -Total 3 -QuietMode $false -CurrentOperation 'Moving: 10 B of 30 B bytes'
+
+        Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
+            $CurrentOperation -eq 'Moving: 10 B of 30 B bytes'
+        }
+    }
+
+    It 'omits CurrentOperation when not provided' {
+        $capturedParams = @{}
+        Mock Write-Progress { $capturedParams['keys'] = $PSBoundParameters.Keys -join ',' }
+
+        Write-PhaseProgress -Activity 'Moving' -Status '1 / 3 : a.zip' `
+            -Current 1 -Total 3 -QuietMode $false
+
+        $capturedParams['keys'] | Should -Not -BeLike '*CurrentOperation*'
+    }
+
+    It 'calls Write-Progress -Completed and suppresses update parameters' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Extracting' -Status 'Done' `
+            -Current 5 -Total 5 -QuietMode $false -Completed
+
+        Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
+            $Activity -eq 'Extracting' -and $Completed -eq $true
+        }
+    }
+
+    It 'suppresses Completed call when QuietMode is true' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Extracting' -Status 'Done' `
+            -Current 5 -Total 5 -QuietMode $true -Completed
+
+        Should -Invoke Write-Progress -Times 0
+    }
+
+    It 'clamps percentage to 100 when Current equals Total' {
+        Mock Write-Progress { }
+
+        Write-PhaseProgress -Activity 'Test' -Status 'All done' -Current 7 -Total 7 -QuietMode $false
+
+        Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
+            $PercentComplete -eq 100
+        }
+    }
+
+    It 'uses Total=1 guard so zero Total does not cause division error' {
+        Mock Write-Progress { }
+
+        { Write-PhaseProgress -Activity 'Test' -Status 'Empty' -Current 0 -Total 0 -QuietMode $false } |
+            Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a centralized `Write-PhaseProgress` helper function to consolidate progress bar logic across the script, and fixes an off-by-one display bug in the byte counter during file moves.

## Key Changes

- **Added `Write-PhaseProgress` helper function** that wraps `Write-Progress` with:
  - Centralized percentage math: `[int]($Current / [math]::Max(1, $Total) * 100)`
  - Unified `-QuietMode` suppression logic
  - Optional `CurrentOperation` parameter using PowerShell 7 null-coalescing (`??`)
  - Support for `Completed` switch to close progress bars
  - Guard against division-by-zero with `[math]::Max(1, $Total)`

- **Refactored `Invoke-ZipExtractions`** to use `Write-PhaseProgress` instead of inline `Write-Progress` calls, eliminating duplicate percentage math and quiet-mode checks.

- **Refactored `Move-ZipFilesToParent`** to use `Write-PhaseProgress` and fixed the off-by-one byte counter:
  - Changed `CurrentOperation` display from `"Moved X of Y"` to `"Moving: X of Y bytes"`
  - Fixed byte total calculation: now shows `$bytes + $zf.Length` (including current file) instead of just `$bytes` (prior files only)
  - This ensures the progress caption reflects the running total up to and including the file being processed

- **Added comprehensive Pester tests** for `Write-PhaseProgress` covering:
  - QuietMode suppression in both normal and Completed paths
  - Correct percentage computation (50% at midpoint, 100% at completion)
  - CurrentOperation parameter inclusion/omission
  - Completed switch behavior
  - Zero Total guard (no division-by-zero error)

- **Version bump** to 2.2.3 (patch) with detailed changelog entry.

## Implementation Details

The `Write-PhaseProgress` function uses PowerShell 7's null-coalescing operator (`??`) to gracefully handle the optional `CurrentOperation` parameter, avoiding spurious empty parameters on the progress bar. The percentage clamping via `[math]::Max(1, $Total)` ensures safe division even when Total is zero.

https://claude.ai/code/session_01XjwXMz54kD9BC96ZPyohRD