### PR TITLE
Extract ZIP archive primitives into Core/Zip module

### DIFF
--- a/docs/architecture/module-dependencies.md
+++ b/docs/architecture/module-dependencies.md
@@ -30,11 +30,13 @@ graph TD
         ADBH[AdbHelpers<br/>v1.0.0]
         ERR[ErrorHandling<br/>v1.0.0]
         FOPS[FileOperations<br/>v1.0.0]
+        FS[FileSystem<br/>v1.1.0]
         PGBAK[PostgresBackup<br/>v2.0.0]
         PROG[ProgressReporter<br/>v1.0.0]
         PURGE[PurgeLogs<br/>v2.0.0]
         RND[RandomName<br/>v2.1.0]
         VID[Videoscreenshot<br/>v3.0.2]
+        ZIP[Zip<br/>v1.0.0]
     end
 
     subgraph "External Dependencies"
@@ -50,6 +52,8 @@ graph TD
     FILE --> ADBH
     FILE --> FOPS
     FILE --> LOG
+    FILE --> FS
+    FILE --> ZIP
     MEDIA --> VID
     MEDIA --> LOG
     SYSTEM --> LOG
@@ -64,6 +68,8 @@ graph TD
     PROG -.Optional.-> LOG
     VID --> RND
     VID --> LOG
+    ZIP -.Optional.-> LOG
+    ZIP --> FS
 
     %% Module to External Dependencies
     PGBAK --> PGCLIENT
@@ -76,7 +82,7 @@ graph TD
     classDef script fill:#50C878,stroke:#2E7D4E,color:#fff
     classDef external fill:#F5A623,stroke:#D68910,color:#fff
 
-    class LOG,ADBH,ERR,FOPS,PGBAK,PROG,PURGE,RND,VID module
+    class LOG,ADBH,ERR,FOPS,FS,PGBAK,PROG,PURGE,RND,VID,ZIP module
     class BACKUP,FILE,MEDIA,SYSTEM,CLOUD,GIT script
     class ADBCLI,PGCLIENT,VLCPLAYER,PYCROP external
 ```
@@ -170,7 +176,30 @@ Invoke-WithRetry -ScriptBlock { Copy-Item $src $dest } -MaxRetries 3
 
 ---
 
-#### 4. ProgressReporter (v1.0.0)
+#### 4. Zip (v1.0.0)
+
+**Purpose**: Reusable ZIP archive primitives extracted from `Expand-ZipsAndClean.ps1`.
+
+**Dependencies**:
+- FileSystem (required — path normalization, safe naming, unique path resolution, directory creation)
+- PowerShellLoggingFramework (optional — no-op stub is used when not loaded)
+
+**Dependents**:
+- `Expand-ZipsAndClean.ps1` (file management scripts)
+
+**Key Features**:
+- `Get-ZipFileStats`: entry count + byte totals without extraction
+- `Expand-ZipToSubfolder`: per-archive subfolder extraction via `Expand-Archive`
+- `Expand-ZipFlat`: flat streaming extraction via `ZipArchive` with collision handling
+- `Expand-ZipSmart`: mode dispatcher routing to the above two helpers
+- `Resolve-ZipEntryDestinationPath` (private): Zip Slip path traversal protection
+- `Test-IsEncryptedZipError` / `Resolve-ExtractionError` (private): unified encryption detection
+
+**Location**: `src/powershell/modules/Core/Zip/`
+
+---
+
+#### 5. ProgressReporter (v1.0.0)
 
 **Purpose**: Standardized progress reporting with logging integration.
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,36 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.3.0 — 2026-05-17
+
+### Changed
+
+- Extracted archive primitives into the new `Core/Zip` module (issue #976):
+  - `Get-ZipFileStats`, `Expand-ZipToSubfolder`, `Expand-ZipFlat`, `Expand-ZipSmart` moved to
+    `src/powershell/modules/Core/Zip/Public/`.
+  - `Test-IsEncryptedZipError`, `Resolve-ExtractionError`, `Resolve-ZipEntryDestinationPath`
+    moved to `src/powershell/modules/Core/Zip/Private/`.
+- Added `Import-Module Core/Zip/Zip.psm1` after the `FileSystem` import.
+- Removed `using namespace System.IO.Compression` from the script (no longer needed in the
+  script body after the zip helpers moved to the module).
+
+### Tests
+
+- Updated `Describe 'Expand-ZipsAndClean helper extraction refactor'` → renamed to
+  `'Core/Zip module — public extraction functions'`.
+- `BeforeAll` now imports `Core/Zip/Zip.psm1` directly instead of extracting the
+  `#region Helpers` block from the script source.
+- Module-internal function mocks (`Expand-ZipToSubfolder`, `Expand-ZipFlat`, `Expand-Archive`)
+  updated to use `-ModuleName Zip`.
+- Tests for private module functions (`Resolve-ZipEntryDestinationPath`,
+  `Test-IsEncryptedZipError`, `Resolve-ExtractionError`) now run inside `InModuleScope Zip`.
+- The three remaining `Describe` blocks (`Remove-SourceDirectory`, `Move-ZipFilesToParent`,
+  `Write-PhaseProgress`) each import `Core/Zip/Zip.psm1` in their `BeforeAll` so
+  `Invoke-ZipExtractions` (which calls the module functions) resolves correctly if exercised.
+
+### Versioning
+
+- Bumped `Expand-ZipsAndClean.ps1` version to `2.3.0` (minor — import contract changes).
+
 ## 2.2.3 — 2026-05-17
 
 ### Added

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -116,9 +116,8 @@ using namespace System.Collections.Generic
              Resolve-ZipEntryDestinationPath to src/powershell/modules/Core/Zip/Private/.
            - Added Import-Module for Core/Zip/Zip.psm1 after the FileSystem import.
            - Removed 'using namespace System.IO.Compression' (no longer needed in script body).
-           - Updated Pester tests to import the Zip module instead of extracting helpers
-             from the script's #region Helpers block; private-function tests now use
-             InModuleScope Zip and module-internal mocks use -ModuleName Zip.
+           - Updated Pester tests to import the Zip module directly; private-function
+             tests use InModuleScope Zip; intra-module dispatcher mocks use InModuleScope.
            Version bump: minor (import contract change — Zip helpers are now module-provided).
 
     2.2.3  Centralized Write-Progress wrapper and fixed off-by-one byte counter (issue #975):

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -1,6 +1,5 @@
 #requires -Version 7.0
 using namespace System.Collections.Generic
-using namespace System.IO.Compression
 
 <#
 .SYNOPSIS
@@ -103,13 +102,25 @@ using namespace System.IO.Compression
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.2.3
+    Version  : 2.3.0
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, and -Parallel),
                Microsoft.PowerShell.Archive (Expand-Archive) for subfolder mode;
                System.IO.Compression (ZipArchive) is used for streaming in Flat mode.
 
     ── Version History ───────────────────────────────────────────────────────────
+    2.3.0  Extracted archive primitives into Core/Zip module (issue #976):
+           - Moved Get-ZipFileStats, Expand-ZipToSubfolder, Expand-ZipFlat, Expand-ZipSmart
+             to src/powershell/modules/Core/Zip/Public/.
+           - Moved Test-IsEncryptedZipError, Resolve-ExtractionError,
+             Resolve-ZipEntryDestinationPath to src/powershell/modules/Core/Zip/Private/.
+           - Added Import-Module for Core/Zip/Zip.psm1 after the FileSystem import.
+           - Removed 'using namespace System.IO.Compression' (no longer needed in script body).
+           - Updated Pester tests to import the Zip module instead of extracting helpers
+             from the script's #region Helpers block; private-function tests now use
+             InModuleScope Zip and module-internal mocks use -ModuleName Zip.
+           Version bump: minor (import contract change — Zip helpers are now module-provided).
+
     2.2.3  Centralized Write-Progress wrapper and fixed off-by-one byte counter (issue #975):
            - Added private Write-PhaseProgress helper accepting Activity, Status,
              Current, Total, QuietMode, optional CurrentOperation, and Completed switch.
@@ -396,6 +407,7 @@ param(
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
 Import-Module "$PSScriptRoot\..\modules\Core\FileSystem\FileSystem.psm1" -Force
+Import-Module "$PSScriptRoot\..\modules\Core\Zip\Zip.psm1" -Force
 
 # Initialize logger (script name will be extracted from the script file name)
 Initialize-Logger -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
@@ -455,315 +467,6 @@ function Write-PhaseProgress {
         $params['CurrentOperation'] = $CurrentOperation
     }
     Write-Progress @params
-}
-
-<#
-.SYNOPSIS
-    Returns quick stats for a zip (file count, uncompressed total, compressed bytes).
-.DESCRIPTION
-    Caches the FileInfo once to avoid redundant Get-Item/Length calls in loops.
-.PARAMETER ZipPath
-    Full path to the .zip file.
-#>
-function Get-ZipFileStats {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$ZipPath)
-
-    # Precompute to avoid repeated Get-Item lookups (minor optimisation)
-    $zipItem = Get-Item -LiteralPath $ZipPath
-    $compressedLen = [int64]$zipItem.Length
-
-    $result = [pscustomobject]@{
-        FileCount         = 0;
-        UncompressedBytes = [int64]0;
-        CompressedBytes   = $compressedLen
-    }
-
-    try {
-        $zip = [ZipFile]::OpenRead($ZipPath)
-        try {
-            foreach ($entry in $zip.Entries) {
-                if ($entry.Name) {
-                    $result.FileCount++
-                    $result.UncompressedBytes += [int64]$entry.Length
-                }
-            }
-        } finally {
-            $zip.Dispose()
-        }
-    } catch {
-        Write-LogDebug "Failed to read zip stats for: $ZipPath. $_"
-    }
-    return $result
-}
-
-<#
-.SYNOPSIS
-    Returns $true when an exception/message indicates archive encryption/password protection.
-#>
-function Test-IsEncryptedZipError {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][AllowNull()][object]$ErrorObject)
-
-    $encryptionPattern = '(?i)encrypt(?:ed|ion)?|password|protected|unsupported compression method'
-
-    if ($ErrorObject -is [System.Management.Automation.ErrorRecord]) {
-        if ($ErrorObject.Exception -and (Test-IsEncryptedZipError -ErrorObject $ErrorObject.Exception)) {
-            return $true
-        }
-        if ([string]$ErrorObject -match $encryptionPattern) { return $true }
-        return $false
-    }
-
-    if ($ErrorObject -is [System.Exception]) {
-        $ex = [System.Exception]$ErrorObject
-        while ($null -ne $ex) {
-            if (($ex.Message ?? '') -match $encryptionPattern) { return $true }
-            $ex = $ex.InnerException
-        }
-        return $false
-    }
-
-    return ([string]$ErrorObject -match $encryptionPattern)
-}
-
-<#
-.SYNOPSIS
-    Throws a normalized encrypted-archive extraction error when applicable.
-#>
-function Resolve-ExtractionError {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$ZipPath,
-        [Parameter(Mandatory)][System.Management.Automation.ErrorRecord]$ErrorRecord
-    )
-
-    if (Test-IsEncryptedZipError -ErrorObject $ErrorRecord) {
-        throw "Extraction failed for '$ZipPath' (zip may be encrypted): $($ErrorRecord.Exception.Message)"
-    }
-    throw $ErrorRecord
-}
-
-<#
-.SYNOPSIS
-    Resolves a ZipArchive entry destination and blocks path traversal (Zip Slip).
-#>
-function Resolve-ZipEntryDestinationPath {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$DestinationRootFull,
-        [Parameter(Mandatory)][string]$EntryFullName
-    )
-
-    if ([string]::IsNullOrWhiteSpace($EntryFullName)) { return $null }
-
-    # Reject rooted/archive-absolute inputs before normalization/trimming.
-    if (
-        $EntryFullName.StartsWith('/') -or
-        $EntryFullName.StartsWith('\') -or
-        $EntryFullName -match '^[A-Za-z]:[\\/]' -or
-        $EntryFullName.StartsWith('//') -or
-        $EntryFullName.StartsWith('\\')
-    ) {
-        return $null
-    }
-
-    # Normalize separators and explicitly reject traversal segments.
-    $directorySeparator = [System.IO.Path]::DirectorySeparatorChar
-    $normalizedEntry = ($EntryFullName -replace '\\', '/')
-    $segments = @($normalizedEntry -split '/+' | Where-Object { $_ -ne '' -and $_ -ne '.' })
-    if ($segments.Count -eq 0) { return $null }
-    if (@($segments | Where-Object { $_ -eq '..' }).Count -gt 0) { return $null }
-
-    $relativePath = ($segments -join [string]$directorySeparator)
-    if ([System.IO.Path]::IsPathRooted($relativePath)) { return $null }
-
-    # Compute canonical paths from fully-qualified roots to compare like-for-like.
-    $rootFull = [System.IO.Path]::GetFullPath($DestinationRootFull)
-    $candidate = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($rootFull, $relativePath))
-    $rootWithSep = if ($rootFull.EndsWith($directorySeparator)) { $rootFull } else { $rootFull + $directorySeparator }
-    $comparison = if ($IsWindows) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
-
-    if ($candidate.StartsWith($rootWithSep, $comparison)) {
-        return $candidate
-    }
-
-    return $null
-}
-
-<#
-.SYNOPSIS
-    Extracts one ZIP archive into a unique subfolder under the destination root.
-.DESCRIPTION
-    This helper implements `PerArchiveSubfolder` mode. It uses `Expand-Archive` to extract
-    into a sanitized subfolder name and resolves collisions by creating a unique directory path.
-.PARAMETER ZipPath
-    Path to the zip archive.
-.PARAMETER DestinationRoot
-    Root folder for extraction.
-.PARAMETER SafeSubfolderName
-    Safe destination subfolder name derived from the zip file name.
-.PARAMETER ExpectedFileCount
-    Pre-computed file count from Get-ZipFileStats. Returned directly to avoid
-    a post-extraction Get-ChildItem walk of the destination folder.
-.OUTPUTS
-    Int ($ExpectedFileCount as supplied by the caller).
-#>
-function Expand-ZipToSubfolder {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$ZipPath,
-        [Parameter(Mandatory)][string]$DestinationRoot,
-        [Parameter(Mandatory)][string]$SafeSubfolderName,
-        [Parameter(Mandatory)][int]$ExpectedFileCount
-    )
-
-    try {
-        $target = Join-Path $DestinationRoot $SafeSubfolderName
-        $target = Resolve-UniqueDirectoryPath -Path $target
-        if (-not (Test-Path -LiteralPath $target)) {
-            New-DirectoryIfMissing -Path $target -Force | Out-Null
-        }
-
-        Expand-Archive -LiteralPath $ZipPath -DestinationPath $target -Force
-        Write-LogDebug "Expand-ZipToSubfolder: '$($ZipPath | Split-Path -Leaf)' -> '$target' ($ExpectedFileCount file(s) per archive manifest)"
-        return $ExpectedFileCount
-
-    } catch { Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_ }
-}
-
-<#
-.SYNOPSIS
-    Streams one ZIP archive directly into the destination root (flat mode).
-.DESCRIPTION
-    Implements `Flat` extraction mode using `ZipArchive` streaming extraction. The function:
-    - Normalizes each entry path and enforces a destination-root prefix check to prevent Zip Slip.
-    - Applies per-file collision policy (`Skip`, `Overwrite`, `Rename`) before writing.
-    - Creates required destination directories on demand.
-.PARAMETER ZipPath
-    Path to the zip archive.
-.PARAMETER DestinationRoot
-    Root folder for extraction.
-.PARAMETER DestinationRootFull
-    Fully-qualified destination root path used for Zip Slip boundary validation.
-.PARAMETER CollisionPolicy
-    File collision behavior: `Skip`, `Overwrite`, or `Rename`.
-.OUTPUTS
-    Int (number of files extracted).
-#>
-function Expand-ZipFlat {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$ZipPath,
-        [Parameter(Mandatory)][string]$DestinationRoot,
-        [Parameter(Mandatory)][string]$DestinationRootFull,
-        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
-    )
-
-    $written = 0
-
-    try {
-        $zip = [ZipFile]::OpenRead($ZipPath)
-        try {
-            foreach ($entry in $zip.Entries) {
-                if ([string]::IsNullOrEmpty($entry.Name)) { continue }
-                if ($entry.FullName.Contains('..') -or $entry.FullName -match '(^|[\\/])\.\.([\\/]|$)') {
-                    Write-LogDebug "Skipped traversal-segment entry: $($entry.FullName)"
-                    continue
-                }
-
-                $destFull = Resolve-ZipEntryDestinationPath -DestinationRootFull $DestinationRootFull -EntryFullName $entry.FullName
-                if ($null -eq $destFull) {
-                    Write-LogDebug "Skipped path traversal: $($entry.FullName)"
-                    continue
-                }
-
-                $destDir = Split-Path -Path $destFull -Parent
-                if (-not (Test-Path -LiteralPath $destDir)) {
-                    New-DirectoryIfMissing -Path $destDir -Force | Out-Null
-                }
-
-                $targetPath = $destFull
-                if ([System.IO.File]::Exists($targetPath)) {
-                    switch ($CollisionPolicy) {
-                        'Skip' { continue }
-                        'Rename' { $targetPath = Resolve-UniquePath -Path $targetPath }
-                        'Overwrite' { }
-                    }
-                }
-
-                try {
-                    [ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
-                    $written++
-                } catch {
-                    # Defensive fallback: if a race or path normalization mismatch causes
-                    # a late "already exists" exception under Skip policy, honor Skip.
-                    if ($CollisionPolicy -eq 'Skip' -and $_.Exception.Message -imatch 'already exists') { continue }
-                    Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_
-                }
-            }
-        } finally {
-            $zip.Dispose()
-        }
-
-        return $written
-
-    } catch { Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_ }
-}
-
-<#
-.SYNOPSIS
-    Dispatches zip extraction to the configured extraction mode helper.
-.DESCRIPTION
-    Public-facing compatibility wrapper that preserves the existing signature and routes
-    extraction to either `Expand-ZipToSubfolder` (`PerArchiveSubfolder`) or `Expand-ZipFlat` (`Flat`).
-.PARAMETER ZipPath
-    Path to the zip archive.
-.PARAMETER DestinationRoot
-    Root folder for extraction.
-.PARAMETER ExtractMode
-    `PerArchiveSubfolder` or `Flat`.
-.PARAMETER CollisionPolicy
-    `Skip` | `Overwrite` | `Rename`.
-.PARAMETER SafeNameMaxLen
-    Maximum safe-name length used to derive per-archive subfolder names.
-.PARAMETER ExpectedFileCount
-    Pre-computed file count from Get-ZipFileStats, threaded to Expand-ZipToSubfolder
-    for PerArchiveSubfolder mode so it can be returned without a post-extraction
-    directory walk.
-.OUTPUTS
-    Int (number of files written by the selected mode helper).
-#>
-function Expand-ZipSmart {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$ZipPath,
-        [Parameter(Mandatory)][string]$DestinationRoot,
-        [ValidateSet('PerArchiveSubfolder', 'Flat')][string]$ExtractMode = 'PerArchiveSubfolder',
-        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename',
-        [int]$SafeNameMaxLen = 0,
-        [int]$ExpectedFileCount = 0
-    )
-
-    if (-not (Test-Path -LiteralPath $DestinationRoot)) {
-        New-DirectoryIfMissing -Path $DestinationRoot -Force | Out-Null
-    }
-
-    $destRootFull = Get-FullPath -Path $DestinationRoot
-    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ZipPath)
-    $safeSub = Get-SafeName -Name $baseName -MaxLength $SafeNameMaxLen
-
-    if ($ExtractMode -eq 'PerArchiveSubfolder') {
-        # Callers that pre-compute stats pass ExpectedFileCount > 0 to avoid a
-        # second zip open; fall back to Get-ZipFileStats so the return value is
-        # correct when ExpectedFileCount is omitted (default 0).
-        if ($ExpectedFileCount -le 0) {
-            $ExpectedFileCount = (Get-ZipFileStats -ZipPath $ZipPath).FileCount
-        }
-        return Expand-ZipToSubfolder -ZipPath $ZipPath -DestinationRoot $DestinationRoot -SafeSubfolderName $safeSub -ExpectedFileCount $ExpectedFileCount
-    }
-
-    return Expand-ZipFlat -ZipPath $ZipPath -DestinationRoot $DestinationRoot -DestinationRootFull $destRootFull -CollisionPolicy $CollisionPolicy
 }
 
 <#

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -18,6 +18,8 @@ Scripts for file operations, distribution, copying, and archiving.
 ### PowerShell Modules
 
 - **PowerShellLoggingFramework** (`src/powershell/modules/Core/Logging/`) - Structured logging
+- **FileSystem** (`src/powershell/modules/Core/FileSystem/`) - Path normalization, safe naming, unique path resolution
+- **Zip** (`src/powershell/modules/Core/Zip/`) - ZIP archive primitives used by `Expand-ZipsAndClean.ps1`
 - **AdbHelpers** (`src/powershell/modules/Android/AdbHelpers/`) - Shared ADB/device helpers used by `Copy-AndroidFiles.ps1`
 
 ### External Tools
@@ -44,6 +46,14 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 - These versions are intentionally independent and may advance separately under SemVer.
 
 ## Recent Updates
+
+- **Expand-ZipsAndClean.ps1 v2.3.0** (2026-05-17)
+  - Extracted archive primitives (`Get-ZipFileStats`, `Expand-ZipToSubfolder`, `Expand-ZipFlat`,
+    `Expand-ZipSmart`) and their private helpers (`Test-IsEncryptedZipError`,
+    `Resolve-ExtractionError`, `Resolve-ZipEntryDestinationPath`) into the new
+    `Core/Zip` module (`src/powershell/modules/Core/Zip/`), following the same layout as
+    `Core/FileSystem`. The script now imports the Zip module instead of carrying the helpers inline.
+  - Version bump: `2.3.0` (minor — import contract change, no behavior change).
 
 - **Expand-ZipsAndClean.ps1 v2.2.1** (2026-04-25)
   - Hardened Flat-mode Zip Slip handling by introducing a dedicated `Resolve-ZipEntryDestinationPath` helper that normalizes entry separators, rejects rooted entry paths, and validates destination containment with OS-appropriate path comparison semantics.

--- a/src/powershell/modules/Core/Zip/CHANGELOG.md
+++ b/src/powershell/modules/Core/Zip/CHANGELOG.md
@@ -1,0 +1,40 @@
+# CHANGELOG — Core/Zip
+
+All notable changes to this module are documented here.
+
+## [1.0.0] — 2026-05-17
+
+### Added
+
+- Initial release. Archive primitives extracted from `Expand-ZipsAndClean.ps1` (issue #976).
+
+- **Public functions** (`Public/`):
+  - `Get-ZipFileStats` — collects file count, uncompressed total, and compressed bytes from a zip
+    without extracting it, using a single `ZipFile.OpenRead` pass.
+  - `Expand-ZipToSubfolder` — extracts one archive into a safe, unique subfolder (PerArchiveSubfolder
+    mode) via `Expand-Archive`; returns `ExpectedFileCount` directly to avoid a post-extraction
+    `Get-ChildItem` walk.
+  - `Expand-ZipFlat` — streams entries directly into the destination root (Flat mode) via
+    `ZipArchive`; applies per-file collision policy (Skip / Overwrite / Rename) and enforces
+    Zip Slip protection on every entry.
+  - `Expand-ZipSmart` — mode dispatcher: derives a safe subfolder name and fully-qualified
+    destination root, then routes to `Expand-ZipToSubfolder` or `Expand-ZipFlat`.
+
+- **Private helpers** (`Private/`):
+  - `Test-IsEncryptedZipError` — walks the full exception chain looking for encryption / password
+    keywords; accepts an `ErrorRecord`, an `Exception`, or a plain string.
+  - `Resolve-ExtractionError` — normalizes extraction errors, surfacing a clear user-facing message
+    when encryption is detected.
+  - `Resolve-ZipEntryDestinationPath` — validates archive entry paths and blocks path traversal
+    (Zip Slip): rejects rooted paths, `..` segments, and entries whose resolved path escapes the
+    destination root.
+
+- Module loader (`Zip.psm1`) and manifest (`Zip.psd1`) following the `Core/FileSystem` conventions:
+  dot-sources `Private/` before `Public/`, exports only public function names.
+
+- `using namespace System.IO.Compression` in the loader and in each `.ps1` file that references
+  `ZipFile` or `ZipFileExtensions`, reducing fully-qualified type clutter.
+
+- No-op `Write-LogDebug` fallback in the module loader: defined only when the logging framework
+  has not already been imported, so the module works standalone in tests without requiring the
+  logging framework as a hard dependency.

--- a/src/powershell/modules/Core/Zip/Private/Invoke-ZipEntryWrite.ps1
+++ b/src/powershell/modules/Core/Zip/Private/Invoke-ZipEntryWrite.ps1
@@ -1,0 +1,61 @@
+using namespace System.IO.Compression
+
+<#
+.SYNOPSIS
+    Writes a single ZIP entry to disk, applying collision policy and Zip Slip protection.
+.DESCRIPTION
+    Validates and writes one ZipArchiveEntry to the destination root.
+    Returns $true if the entry was written, $false if it was skipped.
+.PARAMETER Entry
+    The ZipArchiveEntry to extract.
+.PARAMETER DestinationRootFull
+    Fully-qualified destination root path used for Zip Slip boundary validation.
+.PARAMETER CollisionPolicy
+    File collision behavior: Skip, Overwrite, or Rename (default Rename).
+.OUTPUTS
+    Boolean ($true = written, $false = skipped).
+#>
+function Invoke-ZipEntryWrite {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.IO.Compression.ZipArchiveEntry]$Entry,
+        [Parameter(Mandatory)][string]$DestinationRootFull,
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
+    )
+
+    if ([string]::IsNullOrEmpty($Entry.Name)) { return $false }
+    if ($Entry.FullName -match '(^|[\\/])\.\.([\\/]|$)') {
+        Write-LogDebug "Skipped traversal-segment entry: $($Entry.FullName)"
+        return $false
+    }
+
+    $destFull = Resolve-ZipEntryDestinationPath -DestinationRootFull $DestinationRootFull -EntryFullName $Entry.FullName
+    if ($null -eq $destFull) {
+        Write-LogDebug "Skipped path traversal: $($Entry.FullName)"
+        return $false
+    }
+
+    $destDir = Split-Path -Path $destFull -Parent
+    if (-not (Test-Path -LiteralPath $destDir)) {
+        New-DirectoryIfMissing -Path $destDir -Force | Out-Null
+    }
+
+    $targetPath = $destFull
+    if ([System.IO.File]::Exists($targetPath)) {
+        switch ($CollisionPolicy) {
+            'Skip'      { return $false }
+            'Rename'    { $targetPath = Resolve-UniquePath -Path $targetPath }
+            'Overwrite' { }
+        }
+    }
+
+    try {
+        [ZipFileExtensions]::ExtractToFile($Entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
+        return $true
+    } catch {
+        # Defensive fallback: if a race or path normalization mismatch causes
+        # a late "already exists" exception under Skip policy, honor Skip.
+        if ($CollisionPolicy -eq 'Skip' -and $_.Exception.Message -imatch 'already exists') { return $false }
+        throw $_
+    }
+}

--- a/src/powershell/modules/Core/Zip/Private/Resolve-ExtractionError.ps1
+++ b/src/powershell/modules/Core/Zip/Private/Resolve-ExtractionError.ps1
@@ -1,0 +1,23 @@
+<#
+.SYNOPSIS
+    Throws a normalized extraction error, surfacing a clear encrypted-archive message when applicable.
+.DESCRIPTION
+    Passes the ErrorRecord through Test-IsEncryptedZipError. If encryption is detected, throws a
+    user-friendly message that includes the zip path; otherwise re-throws the original ErrorRecord.
+.PARAMETER ZipPath
+    Path to the zip archive that triggered the error.
+.PARAMETER ErrorRecord
+    The caught ErrorRecord from the extraction attempt.
+#>
+function Resolve-ExtractionError {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][System.Management.Automation.ErrorRecord]$ErrorRecord
+    )
+
+    if (Test-IsEncryptedZipError -ErrorObject $ErrorRecord) {
+        throw "Extraction failed for '$ZipPath' (zip may be encrypted): $($ErrorRecord.Exception.Message)"
+    }
+    throw $ErrorRecord
+}

--- a/src/powershell/modules/Core/Zip/Private/Resolve-ZipEntryDestinationPath.ps1
+++ b/src/powershell/modules/Core/Zip/Private/Resolve-ZipEntryDestinationPath.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Resolves a ZipArchive entry to a destination path and blocks path traversal (Zip Slip).
+.DESCRIPTION
+    Validates every archive entry before extraction:
+    - Rejects null/whitespace names.
+    - Rejects rooted/archive-absolute inputs (Unix /, Windows \, drive letters, UNC prefixes).
+    - Normalizes separators and rejects any '..' traversal segment.
+    - Computes the canonical destination path and confirms it is strictly inside DestinationRootFull.
+    Returns $null for any entry that fails validation; returns the full destination path otherwise.
+.PARAMETER DestinationRootFull
+    Fully-qualified destination root path (used as the containment boundary).
+.PARAMETER EntryFullName
+    The archive entry's FullName property (relative path inside the archive).
+.OUTPUTS
+    [string] Absolute destination path, or $null if the entry is unsafe.
+#>
+function Resolve-ZipEntryDestinationPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$DestinationRootFull,
+        [Parameter(Mandatory)][string]$EntryFullName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($EntryFullName)) { return $null }
+
+    # Reject rooted/archive-absolute inputs before normalization/trimming.
+    if (
+        $EntryFullName.StartsWith('/') -or
+        $EntryFullName.StartsWith('\') -or
+        $EntryFullName -match '^[A-Za-z]:[\\/]' -or
+        $EntryFullName.StartsWith('//') -or
+        $EntryFullName.StartsWith('\\')
+    ) {
+        return $null
+    }
+
+    # Normalize separators and explicitly reject traversal segments.
+    $directorySeparator = [System.IO.Path]::DirectorySeparatorChar
+    $normalizedEntry = ($EntryFullName -replace '\\', '/')
+    $segments = @($normalizedEntry -split '/+' | Where-Object { $_ -ne '' -and $_ -ne '.' })
+    if ($segments.Count -eq 0) { return $null }
+    if (@($segments | Where-Object { $_ -eq '..' }).Count -gt 0) { return $null }
+
+    $relativePath = ($segments -join [string]$directorySeparator)
+    if ([System.IO.Path]::IsPathRooted($relativePath)) { return $null }
+
+    # Compute canonical paths from fully-qualified roots to compare like-for-like.
+    $rootFull = [System.IO.Path]::GetFullPath($DestinationRootFull)
+    $candidate = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($rootFull, $relativePath))
+    $rootWithSep = if ($rootFull.EndsWith($directorySeparator)) { $rootFull } else { $rootFull + $directorySeparator }
+    $comparison = if ($IsWindows) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+
+    if ($candidate.StartsWith($rootWithSep, $comparison)) {
+        return $candidate
+    }
+
+    return $null
+}

--- a/src/powershell/modules/Core/Zip/Private/Test-IsEncryptedZipError.ps1
+++ b/src/powershell/modules/Core/Zip/Private/Test-IsEncryptedZipError.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+    Returns $true when an exception or message indicates archive encryption / password protection.
+.DESCRIPTION
+    Walks the full exception chain (InnerException) looking for keywords that signal an encrypted
+    or password-protected archive. Accepts an ErrorRecord, an Exception, or a plain string.
+.PARAMETER ErrorObject
+    The error to inspect: an ErrorRecord, an Exception, or any object whose string representation
+    is checked against the encryption pattern.
+#>
+function Test-IsEncryptedZipError {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowNull()][object]$ErrorObject)
+
+    $encryptionPattern = '(?i)encrypt(?:ed|ion)?|password|protected|unsupported compression method'
+
+    if ($ErrorObject -is [System.Management.Automation.ErrorRecord]) {
+        if ($ErrorObject.Exception -and (Test-IsEncryptedZipError -ErrorObject $ErrorObject.Exception)) {
+            return $true
+        }
+        if ([string]$ErrorObject -match $encryptionPattern) { return $true }
+        return $false
+    }
+
+    if ($ErrorObject -is [System.Exception]) {
+        $ex = [System.Exception]$ErrorObject
+        while ($null -ne $ex) {
+            if (($ex.Message ?? '') -match $encryptionPattern) { return $true }
+            $ex = $ex.InnerException
+        }
+        return $false
+    }
+
+    return ([string]$ErrorObject -match $encryptionPattern)
+}

--- a/src/powershell/modules/Core/Zip/Public/Expand-ZipFlat.ps1
+++ b/src/powershell/modules/Core/Zip/Public/Expand-ZipFlat.ps1
@@ -1,0 +1,81 @@
+using namespace System.IO.Compression
+
+<#
+.SYNOPSIS
+    Streams one ZIP archive directly into the destination root (flat mode).
+.DESCRIPTION
+    Implements Flat extraction mode using ZipArchive streaming extraction:
+    - Normalizes each entry path and enforces a destination-root prefix check (Zip Slip protection).
+    - Applies per-file collision policy (Skip, Overwrite, Rename) before writing each entry.
+    - Creates required destination subdirectories on demand.
+    - Skips directory entries (entries whose Name is empty).
+.PARAMETER ZipPath
+    Path to the zip archive.
+.PARAMETER DestinationRoot
+    Root folder for extraction.
+.PARAMETER DestinationRootFull
+    Fully-qualified destination root path used for Zip Slip boundary validation.
+.PARAMETER CollisionPolicy
+    File collision behavior: Skip, Overwrite, or Rename (default Rename).
+.OUTPUTS
+    Int (number of files successfully extracted).
+#>
+function Expand-ZipFlat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$DestinationRoot,
+        [Parameter(Mandatory)][string]$DestinationRootFull,
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
+    )
+
+    $written = 0
+
+    try {
+        $zip = [ZipFile]::OpenRead($ZipPath)
+        try {
+            foreach ($entry in $zip.Entries) {
+                if ([string]::IsNullOrEmpty($entry.Name)) { continue }
+                if ($entry.FullName.Contains('..') -or $entry.FullName -match '(^|[\\/])\.\.([\\/]|$)') {
+                    Write-LogDebug "Skipped traversal-segment entry: $($entry.FullName)"
+                    continue
+                }
+
+                $destFull = Resolve-ZipEntryDestinationPath -DestinationRootFull $DestinationRootFull -EntryFullName $entry.FullName
+                if ($null -eq $destFull) {
+                    Write-LogDebug "Skipped path traversal: $($entry.FullName)"
+                    continue
+                }
+
+                $destDir = Split-Path -Path $destFull -Parent
+                if (-not (Test-Path -LiteralPath $destDir)) {
+                    New-DirectoryIfMissing -Path $destDir -Force | Out-Null
+                }
+
+                $targetPath = $destFull
+                if ([System.IO.File]::Exists($targetPath)) {
+                    switch ($CollisionPolicy) {
+                        'Skip'      { continue }
+                        'Rename'    { $targetPath = Resolve-UniquePath -Path $targetPath }
+                        'Overwrite' { }
+                    }
+                }
+
+                try {
+                    [ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
+                    $written++
+                } catch {
+                    # Defensive fallback: if a race or path normalization mismatch causes
+                    # a late "already exists" exception under Skip policy, honor Skip.
+                    if ($CollisionPolicy -eq 'Skip' -and $_.Exception.Message -imatch 'already exists') { continue }
+                    Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_
+                }
+            }
+        } finally {
+            $zip.Dispose()
+        }
+
+        return $written
+
+    } catch { Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_ }
+}

--- a/src/powershell/modules/Core/Zip/Public/Expand-ZipFlat.ps1
+++ b/src/powershell/modules/Core/Zip/Public/Expand-ZipFlat.ps1
@@ -35,40 +35,8 @@ function Expand-ZipFlat {
         $zip = [ZipFile]::OpenRead($ZipPath)
         try {
             foreach ($entry in $zip.Entries) {
-                if ([string]::IsNullOrEmpty($entry.Name)) { continue }
-                if ($entry.FullName.Contains('..') -or $entry.FullName -match '(^|[\\/])\.\.([\\/]|$)') {
-                    Write-LogDebug "Skipped traversal-segment entry: $($entry.FullName)"
-                    continue
-                }
-
-                $destFull = Resolve-ZipEntryDestinationPath -DestinationRootFull $DestinationRootFull -EntryFullName $entry.FullName
-                if ($null -eq $destFull) {
-                    Write-LogDebug "Skipped path traversal: $($entry.FullName)"
-                    continue
-                }
-
-                $destDir = Split-Path -Path $destFull -Parent
-                if (-not (Test-Path -LiteralPath $destDir)) {
-                    New-DirectoryIfMissing -Path $destDir -Force | Out-Null
-                }
-
-                $targetPath = $destFull
-                if ([System.IO.File]::Exists($targetPath)) {
-                    switch ($CollisionPolicy) {
-                        'Skip'      { continue }
-                        'Rename'    { $targetPath = Resolve-UniquePath -Path $targetPath }
-                        'Overwrite' { }
-                    }
-                }
-
-                try {
-                    [ZipFileExtensions]::ExtractToFile($entry, $targetPath, ($CollisionPolicy -eq 'Overwrite'))
+                if (Invoke-ZipEntryWrite -Entry $entry -DestinationRootFull $DestinationRootFull -CollisionPolicy $CollisionPolicy) {
                     $written++
-                } catch {
-                    # Defensive fallback: if a race or path normalization mismatch causes
-                    # a late "already exists" exception under Skip policy, honor Skip.
-                    if ($CollisionPolicy -eq 'Skip' -and $_.Exception.Message -imatch 'already exists') { continue }
-                    Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_
                 }
             }
         } finally {

--- a/src/powershell/modules/Core/Zip/Public/Expand-ZipSmart.ps1
+++ b/src/powershell/modules/Core/Zip/Public/Expand-ZipSmart.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Dispatches zip extraction to the configured extraction mode helper.
+.DESCRIPTION
+    Routes extraction to either Expand-ZipToSubfolder (PerArchiveSubfolder mode) or
+    Expand-ZipFlat (Flat mode). Computes a safe subfolder name and the fully-qualified
+    destination root before delegating to the selected helper.
+.PARAMETER ZipPath
+    Path to the zip archive.
+.PARAMETER DestinationRoot
+    Root folder for extraction.
+.PARAMETER ExtractMode
+    PerArchiveSubfolder (default) or Flat.
+.PARAMETER CollisionPolicy
+    Skip | Overwrite | Rename (default Rename). Applied in Flat mode per-file.
+.PARAMETER SafeNameMaxLen
+    Maximum safe-name length for per-archive subfolder names (0 = no limit).
+.PARAMETER ExpectedFileCount
+    Pre-computed file count from Get-ZipFileStats. Pass when available to avoid
+    a second archive open in PerArchiveSubfolder mode (default 0 = compute internally).
+.OUTPUTS
+    Int (number of files written by the selected mode helper).
+#>
+function Expand-ZipSmart {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$DestinationRoot,
+        [ValidateSet('PerArchiveSubfolder', 'Flat')][string]$ExtractMode = 'PerArchiveSubfolder',
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename',
+        [int]$SafeNameMaxLen = 0,
+        [int]$ExpectedFileCount = 0
+    )
+
+    if (-not (Test-Path -LiteralPath $DestinationRoot)) {
+        New-DirectoryIfMissing -Path $DestinationRoot -Force | Out-Null
+    }
+
+    $destRootFull = Get-FullPath -Path $DestinationRoot
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ZipPath)
+    $safeSub = Get-SafeName -Name $baseName -MaxLength $SafeNameMaxLen
+
+    if ($ExtractMode -eq 'PerArchiveSubfolder') {
+        # Callers that pre-compute stats pass ExpectedFileCount > 0 to avoid a
+        # second zip open; fall back to Get-ZipFileStats when omitted (default 0).
+        if ($ExpectedFileCount -le 0) {
+            $ExpectedFileCount = (Get-ZipFileStats -ZipPath $ZipPath).FileCount
+        }
+        return Expand-ZipToSubfolder -ZipPath $ZipPath -DestinationRoot $DestinationRoot -SafeSubfolderName $safeSub -ExpectedFileCount $ExpectedFileCount
+    }
+
+    return Expand-ZipFlat -ZipPath $ZipPath -DestinationRoot $DestinationRoot -DestinationRootFull $destRootFull -CollisionPolicy $CollisionPolicy
+}

--- a/src/powershell/modules/Core/Zip/Public/Expand-ZipToSubfolder.ps1
+++ b/src/powershell/modules/Core/Zip/Public/Expand-ZipToSubfolder.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Extracts one ZIP archive into a safe, unique subfolder under the destination root.
+.DESCRIPTION
+    Implements PerArchiveSubfolder extraction mode using Expand-Archive.
+    The target subfolder is derived from SafeSubfolderName; if a folder with that name
+    already exists, Resolve-UniqueDirectoryPath generates a timestamped alternative.
+    Returns ExpectedFileCount directly so callers avoid a redundant post-extraction walk.
+.PARAMETER ZipPath
+    Path to the zip archive.
+.PARAMETER DestinationRoot
+    Root folder under which the subfolder is created.
+.PARAMETER SafeSubfolderName
+    Safe destination subfolder name derived from the zip file name.
+.PARAMETER ExpectedFileCount
+    Pre-computed file count from Get-ZipFileStats. Returned without re-opening the archive.
+.OUTPUTS
+    Int ($ExpectedFileCount as supplied by the caller).
+#>
+function Expand-ZipToSubfolder {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ZipPath,
+        [Parameter(Mandatory)][string]$DestinationRoot,
+        [Parameter(Mandatory)][string]$SafeSubfolderName,
+        [Parameter(Mandatory)][int]$ExpectedFileCount
+    )
+
+    try {
+        $target = Join-Path $DestinationRoot $SafeSubfolderName
+        $target = Resolve-UniqueDirectoryPath -Path $target
+        if (-not (Test-Path -LiteralPath $target)) {
+            New-DirectoryIfMissing -Path $target -Force | Out-Null
+        }
+
+        Expand-Archive -LiteralPath $ZipPath -DestinationPath $target -Force
+        Write-LogDebug "Expand-ZipToSubfolder: '$($ZipPath | Split-Path -Leaf)' -> '$target' ($ExpectedFileCount file(s) per archive manifest)"
+        return $ExpectedFileCount
+
+    } catch { Resolve-ExtractionError -ZipPath $ZipPath -ErrorRecord $_ }
+}

--- a/src/powershell/modules/Core/Zip/Public/Get-ZipFileStats.ps1
+++ b/src/powershell/modules/Core/Zip/Public/Get-ZipFileStats.ps1
@@ -1,0 +1,44 @@
+using namespace System.IO.Compression
+
+<#
+.SYNOPSIS
+    Returns quick stats for a ZIP file: file count, total uncompressed bytes, and compressed bytes.
+.DESCRIPTION
+    Opens the archive once with ZipFile.OpenRead and accumulates entry counts and sizes.
+    The compressed byte count is taken from the FileInfo.Length to avoid re-reading the archive.
+    Directory entries (entries whose Name is empty) are excluded from the count.
+.PARAMETER ZipPath
+    Full path to the .zip file.
+.OUTPUTS
+    [pscustomobject] with FileCount [int], UncompressedBytes [int64], and CompressedBytes [int64].
+#>
+function Get-ZipFileStats {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ZipPath)
+
+    $zipItem = Get-Item -LiteralPath $ZipPath
+    $compressedLen = [int64]$zipItem.Length
+
+    $result = [pscustomobject]@{
+        FileCount         = 0
+        UncompressedBytes = [int64]0
+        CompressedBytes   = $compressedLen
+    }
+
+    try {
+        $zip = [ZipFile]::OpenRead($ZipPath)
+        try {
+            foreach ($entry in $zip.Entries) {
+                if ($entry.Name) {
+                    $result.FileCount++
+                    $result.UncompressedBytes += [int64]$entry.Length
+                }
+            }
+        } finally {
+            $zip.Dispose()
+        }
+    } catch {
+        Write-LogDebug "Failed to read zip stats for: $ZipPath. $_"
+    }
+    return $result
+}

--- a/src/powershell/modules/Core/Zip/README.md
+++ b/src/powershell/modules/Core/Zip/README.md
@@ -1,0 +1,122 @@
+# Core/Zip Module
+
+Reusable PowerShell module providing ZIP archive primitives: stats collection, two extraction
+modes (per-archive subfolder and flat streaming), collision handling, and Zip Slip protection.
+
+## Requirements
+
+- PowerShell 7.0+
+- `System.IO.Compression.FileSystem` assembly (loaded automatically by the module loader)
+- `Core/FileSystem` module — provides `Get-FullPath`, `Get-SafeName`, `New-DirectoryIfMissing`,
+  `Resolve-UniquePath`, and `Resolve-UniqueDirectoryPath` used by the public functions
+- `Write-LogDebug` from `Core/Logging/PowerShellLoggingFramework` — a no-op stub is defined
+  automatically when the logging framework is not loaded
+
+## Module Layout
+
+```
+Core/Zip/
+├── Zip.psm1                              # Module loader (dot-sources Private then Public)
+├── Zip.psd1                              # Module manifest (v1.0.0)
+├── Public/
+│   ├── Get-ZipFileStats.ps1              # Entry count + byte totals without extraction
+│   ├── Expand-ZipToSubfolder.ps1         # PerArchiveSubfolder extraction mode
+│   ├── Expand-ZipFlat.ps1                # Flat streaming extraction mode
+│   └── Expand-ZipSmart.ps1               # Mode dispatcher
+└── Private/
+    ├── Test-IsEncryptedZipError.ps1      # Exception-chain encryption detector
+    ├── Resolve-ExtractionError.ps1       # Normalizes extraction errors
+    └── Resolve-ZipEntryDestinationPath.ps1  # Zip Slip path validator
+```
+
+## Public API
+
+### `Get-ZipFileStats`
+
+Returns file count, total uncompressed bytes, and compressed bytes for a ZIP without extracting it.
+
+```powershell
+$stats = Get-ZipFileStats -ZipPath 'C:\archives\data.zip'
+$stats.FileCount          # number of file entries in the archive
+$stats.UncompressedBytes  # sum of uncompressed entry sizes
+$stats.CompressedBytes    # size of the zip file on disk
+```
+
+### `Expand-ZipToSubfolder`
+
+Extracts one ZIP into a safe, unique subfolder under the destination root (PerArchiveSubfolder mode).
+Uses `Expand-Archive` internally. Returns `ExpectedFileCount` directly — no post-extraction
+directory walk is needed.
+
+```powershell
+$count = Expand-ZipToSubfolder -ZipPath 'C:\archives\data.zip' `
+    -DestinationRoot 'C:\output' `
+    -SafeSubfolderName 'data' `
+    -ExpectedFileCount 5
+```
+
+### `Expand-ZipFlat`
+
+Streams every entry from a ZIP directly into the destination root (Flat mode) using `ZipArchive`.
+Applies per-file collision policy before writing and enforces Zip Slip protection on every entry.
+
+```powershell
+$written = Expand-ZipFlat -ZipPath 'C:\archives\data.zip' `
+    -DestinationRoot 'C:\output' `
+    -DestinationRootFull 'C:\output' `
+    -CollisionPolicy Rename
+```
+
+**CollisionPolicy values**: `Skip` | `Overwrite` | `Rename` (default)
+
+### `Expand-ZipSmart`
+
+Mode dispatcher: derives a safe subfolder name and the fully-qualified destination root, then
+routes to `Expand-ZipToSubfolder` or `Expand-ZipFlat` based on `-ExtractMode`.
+
+```powershell
+$count = Expand-ZipSmart -ZipPath 'C:\archives\data.zip' `
+    -DestinationRoot 'C:\output' `
+    -ExtractMode PerArchiveSubfolder `
+    -CollisionPolicy Rename `
+    -SafeNameMaxLen 200 `
+    -ExpectedFileCount 5
+```
+
+**ExtractMode values**: `PerArchiveSubfolder` (default) | `Flat`
+
+## Private Helpers
+
+| Function | Purpose |
+|---|---|
+| `Test-IsEncryptedZipError` | Walks the full exception chain detecting encrypted-archive keywords |
+| `Resolve-ExtractionError` | Re-throws with a friendly message when encryption is detected |
+| `Resolve-ZipEntryDestinationPath` | Validates entry paths and blocks path traversal (Zip Slip) |
+
+## Security: Zip Slip Protection
+
+Flat mode validates every archive entry through `Resolve-ZipEntryDestinationPath` before writing:
+
+1. **Rooted-path rejection** — entries starting with `/`, `\`, a drive letter, or UNC prefix are blocked.
+2. **Traversal rejection** — any segment equal to `..` causes the entry to be skipped.
+3. **Destination containment** — the fully-qualified candidate path must start with the destination
+   root (using OS-appropriate case comparison: case-insensitive on Windows, case-sensitive elsewhere).
+
+Suspicious entries are skipped and logged at `Write-LogDebug` level; extraction continues for
+remaining entries.
+
+## Typical Usage
+
+```powershell
+Import-Module "$PSScriptRoot\..\modules\Core\FileSystem\FileSystem.psm1" -Force
+Import-Module "$PSScriptRoot\..\modules\Core\Zip\Zip.psm1" -Force
+
+# Collect stats without extracting
+$stats = Get-ZipFileStats -ZipPath 'C:\archives\data.zip'
+
+# Extract each archive into its own subfolder
+$count = Expand-ZipSmart -ZipPath 'C:\archives\data.zip' `
+    -DestinationRoot 'C:\output' `
+    -ExtractMode PerArchiveSubfolder `
+    -ExpectedFileCount $stats.FileCount
+```

--- a/src/powershell/modules/Core/Zip/Zip.psd1
+++ b/src/powershell/modules/Core/Zip/Zip.psd1
@@ -1,0 +1,55 @@
+@{
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'Zip.psm1'
+
+    # Version number of this module.
+    ModuleVersion     = '1.0.0'
+
+    # ID used to uniquely identify this module
+    GUID              = 'a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6'
+
+    # Author of this module
+    Author            = 'Manoj Bhaskaran'
+
+    # Company or vendor of this module
+    CompanyName       = 'My-Scripts'
+
+    # Copyright statement for this module
+    Copyright         = '(c) 2025 My-Scripts. Licensed under Apache License 2.0.'
+
+    # Description of the functionality provided by this module
+    Description       = 'ZIP archive primitives: stats collection, per-archive subfolder extraction, flat streaming extraction with collision handling, and Zip Slip path-traversal protection.'
+
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '7.0'
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules   = @()
+
+    # Functions to export from this module
+    FunctionsToExport = @(
+        'Get-ZipFileStats',
+        'Expand-ZipToSubfolder',
+        'Expand-ZipFlat',
+        'Expand-ZipSmart'
+    )
+
+    # Cmdlets to export from this module
+    CmdletsToExport   = @()
+
+    # Variables to export from this module
+    VariablesToExport = @()
+
+    # Aliases to export from this module
+    AliasesToExport   = @()
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess
+    PrivateData       = @{
+        PSData = @{
+            Tags         = @('Zip', 'Archive', 'Compression', 'Extraction', 'ZipSlip', 'FileManagement')
+            LicenseUri   = 'http://www.apache.org/licenses/LICENSE-2.0'
+            ProjectUri   = 'https://github.com/manoj-bhaskaran/My-Scripts'
+            ReleaseNotes = '1.0.0: Initial release. Archive primitives extracted from Expand-ZipsAndClean.ps1 (issue #976). Public: Get-ZipFileStats, Expand-ZipToSubfolder, Expand-ZipFlat, Expand-ZipSmart. Private: Test-IsEncryptedZipError, Resolve-ExtractionError, Resolve-ZipEntryDestinationPath.'
+        }
+    }
+}

--- a/src/powershell/modules/Core/Zip/Zip.psm1
+++ b/src/powershell/modules/Core/Zip/Zip.psm1
@@ -1,0 +1,30 @@
+#requires -Version 7.0
+using namespace System.IO.Compression
+
+# Load the ZIP assembly before dot-sourcing functions that reference ZipFile types.
+Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+
+# Provide a no-op Write-LogDebug when the logging framework is not loaded so the module
+# works standalone in tests and other contexts where logging is not initialised.
+if (-not (Get-Command -Name Write-LogDebug -ErrorAction SilentlyContinue)) {
+    function Write-LogDebug { param([string]$Message) }
+}
+
+$privateDir = Join-Path $PSScriptRoot 'Private'
+if (Test-Path -LiteralPath $privateDir) {
+    Get-ChildItem -Path $privateDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+}
+
+$publicDir = Join-Path $PSScriptRoot 'Public'
+if (Test-Path -LiteralPath $publicDir) {
+    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+}
+
+$publicFunctions = if (Test-Path -LiteralPath $publicDir) {
+    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | Select-Object -ExpandProperty BaseName
+}
+else {
+    @()
+}
+
+Export-ModuleMember -Function $publicFunctions

--- a/src/powershell/modules/README.md
+++ b/src/powershell/modules/README.md
@@ -24,6 +24,23 @@ Fundamental modules used across multiple scripts:
   - Multiple purge strategies
   - Integration with PowerShellLoggingFramework
 
+#### FileSystem (`Core/FileSystem/`)
+
+- **FileSystem** - Path normalization, safe naming, unique path resolution, and directory helpers
+  - `Get-FullPath`, `Get-SafeName`, `New-DirectoryIfMissing`
+  - `Resolve-UniquePath`, `Resolve-UniqueDirectoryPath`
+  - `Test-FileAccessible`, `Test-FileLocked`, `Test-LongPathsEnabled`, `Test-PathValid`
+  - `Format-Bytes`
+
+#### Zip (`Core/Zip/`)
+
+- **Zip** - ZIP archive primitives with Zip Slip protection and collision handling
+  - `Get-ZipFileStats` — entry count and byte totals without extraction
+  - `Expand-ZipToSubfolder` — per-archive subfolder extraction (PerArchiveSubfolder mode)
+  - `Expand-ZipFlat` — flat streaming extraction via `ZipArchive` (Flat mode)
+  - `Expand-ZipSmart` — mode dispatcher
+  - Private: `Resolve-ZipEntryDestinationPath`, `Test-IsEncryptedZipError`, `Resolve-ExtractionError`
+
 ### Database Modules (`Database/`)
 
 Database-related functionality:

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -1,72 +1,48 @@
 Set-StrictMode -Version Latest
 
-Describe 'Expand-ZipsAndClean helper extraction refactor' {
+Describe 'Core/Zip module — public extraction functions' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-
-        # Prepend using-namespace declarations so that short type aliases (e.g. [ZipFile],
-        # [List[string]]) resolve when the helpers block is evaluated via Invoke-Expression.
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-
-        # Assembly must be loaded before helpers are dot-sourced; Add-Type now lives
-        # at script start (outside #region Helpers) so the test loads it explicitly.
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-
-        function Write-LogDebug { param([string]$Message) }
-        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
-    It 'defines mode-specific helper functions and dispatcher' {
-        Get-Command Expand-ZipToSubfolder -ErrorAction Stop | Should -Not -BeNullOrEmpty
-        Get-Command Expand-ZipFlat -ErrorAction Stop | Should -Not -BeNullOrEmpty
-        Get-Command Expand-ZipSmart -ErrorAction Stop | Should -Not -BeNullOrEmpty
-        Get-Command Resolve-ZipEntryDestinationPath -ErrorAction Stop | Should -Not -BeNullOrEmpty
-        Get-Command Test-IsEncryptedZipError -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    It 'exports public extraction functions from the Zip module' {
+        Get-Command Get-ZipFileStats      -Module Zip -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Expand-ZipToSubfolder -Module Zip -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Expand-ZipFlat        -Module Zip -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Expand-ZipSmart       -Module Zip -ErrorAction Stop | Should -Not -BeNullOrEmpty
     }
 
     It 'dispatches PerArchiveSubfolder mode to Expand-ZipToSubfolder' {
         Mock New-DirectoryIfMissing { }
         Mock Get-FullPath { '/tmp/dest' }
         Mock Get-SafeName { 'safe-name' }
-        Mock Expand-ZipToSubfolder { 7 }
-        Mock Expand-ZipFlat { 0 }
+        Mock Expand-ZipToSubfolder { 7 } -ModuleName Zip
+        Mock Expand-ZipFlat { 0 } -ModuleName Zip
 
         $result = Expand-ZipSmart -ZipPath '/tmp/a.zip' -DestinationRoot '/tmp/dest' -ExtractMode PerArchiveSubfolder -SafeNameMaxLen 80 -ExpectedFileCount 7
 
         $result | Should -Be 7
-        Should -Invoke Expand-ZipToSubfolder -Times 1 -Exactly -ParameterFilter {
+        Should -Invoke Expand-ZipToSubfolder -Times 1 -Exactly -ModuleName Zip -ParameterFilter {
             $ZipPath -eq '/tmp/a.zip' -and
             $DestinationRoot -eq '/tmp/dest' -and
             $SafeSubfolderName -eq 'safe-name' -and
             $ExpectedFileCount -eq 7
         }
-        Should -Invoke Expand-ZipFlat -Times 0
+        Should -Invoke Expand-ZipFlat -Times 0 -ModuleName Zip
     }
 
     It 'dispatches Flat mode to Expand-ZipFlat with computed destination root' {
         Mock New-DirectoryIfMissing { }
         Mock Get-FullPath { '/tmp/dest-full' }
         Mock Get-SafeName { 'unused-safe-name' }
-        Mock Expand-ZipFlat { 3 }
+        Mock Expand-ZipFlat { 3 } -ModuleName Zip
 
         $result = Expand-ZipSmart -ZipPath '/tmp/b.zip' -DestinationRoot '/tmp/dest' -ExtractMode Flat -CollisionPolicy Rename
 
         $result | Should -Be 3
-        Should -Invoke Expand-ZipFlat -Times 1 -Exactly -ParameterFilter {
+        Should -Invoke Expand-ZipFlat -Times 1 -Exactly -ModuleName Zip -ParameterFilter {
             $ZipPath -eq '/tmp/b.zip' -and
             $DestinationRoot -eq '/tmp/dest' -and
             $DestinationRootFull -eq '/tmp/dest-full' -and
@@ -135,26 +111,30 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
     }
 
     It 'rejects rooted entry names while allowing valid relative names' {
-        $root = [System.IO.Path]::GetFullPath((Join-Path $TestDrive 'zipslip-rooted'))
-        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        InModuleScope Zip {
+            $root = [System.IO.Path]::GetFullPath((Join-Path $TestDrive 'zipslip-rooted'))
+            New-Item -ItemType Directory -Path $root -Force | Out-Null
 
-        $valid = Resolve-ZipEntryDestinationPath -DestinationRootFull $root -EntryFullName 'nested/file.txt'
-        $rooted = Resolve-ZipEntryDestinationPath -DestinationRootFull $root -EntryFullName '/etc/passwd'
+            $valid  = Resolve-ZipEntryDestinationPath -DestinationRootFull $root -EntryFullName 'nested/file.txt'
+            $rooted = Resolve-ZipEntryDestinationPath -DestinationRootFull $root -EntryFullName '/etc/passwd'
 
-        $valid | Should -Not -BeNullOrEmpty
-        $valid.StartsWith($root) | Should -BeTrue
-        $rooted | Should -BeNullOrEmpty
+            $valid  | Should -Not -BeNullOrEmpty
+            $valid.StartsWith($root) | Should -BeTrue
+            $rooted | Should -BeNullOrEmpty
+        }
     }
 
     It 'detects encrypted archive errors through nested exceptions' {
-        $inner = [System.Exception]::new('Entry is encrypted and cannot be extracted')
-        $outer = [System.Exception]::new('Extraction failed', $inner)
-        $err = [System.Management.Automation.ErrorRecord]::new($outer, 'EncryptedZip', [System.Management.Automation.ErrorCategory]::InvalidData, $null)
+        InModuleScope Zip {
+            $inner = [System.Exception]::new('Entry is encrypted and cannot be extracted')
+            $outer = [System.Exception]::new('Extraction failed', $inner)
+            $err   = [System.Management.Automation.ErrorRecord]::new($outer, 'EncryptedZip', [System.Management.Automation.ErrorCategory]::InvalidData, $null)
 
-        (Test-IsEncryptedZipError -ErrorObject $err) | Should -BeTrue
-        {
-            Resolve-ExtractionError -ZipPath '/tmp/test.zip' -ErrorRecord $err
-        } | Should -Throw "*zip may be encrypted*"
+            (Test-IsEncryptedZipError -ErrorObject $err) | Should -BeTrue
+            {
+                Resolve-ExtractionError -ZipPath '/tmp/test.zip' -ErrorRecord $err
+            } | Should -Throw "*zip may be encrypted*"
+        }
     }
 
     It 'PerArchiveSubfolder: file count returned matches archive entry count' {
@@ -174,10 +154,10 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
             $archive.Dispose()
         }
 
-        # Mock Expand-Archive so the test is CI-independent; we are verifying that
-        # Expand-ZipToSubfolder returns ExpectedFileCount directly (not a Get-ChildItem
-        # walk), not that the extraction itself succeeds.
-        Mock Expand-Archive { }
+        # Mock Expand-Archive so the test is CI-independent; verifies that
+        # Expand-ZipToSubfolder returns ExpectedFileCount directly rather than
+        # performing a post-extraction Get-ChildItem walk.
+        Mock Expand-Archive { } -ModuleName Zip
 
         $stats = Get-ZipFileStats -ZipPath $zipPath
         $count = Expand-ZipToSubfolder -ZipPath $zipPath -DestinationRoot $root -SafeSubfolderName 'subfolder-count' -ExpectedFileCount $stats.FileCount
@@ -227,12 +207,12 @@ Describe 'Expand-ZipsAndClean helper extraction refactor' {
             $archive.Dispose()
         }
 
-        # Mock Expand-Archive so the test is CI-independent; we are verifying that
+        # Mock Expand-Archive so the test is CI-independent; verifies that
         # Expand-ZipSmart falls back to Get-ZipFileStats when ExpectedFileCount is
-        # omitted and returns the correct count — not that extraction itself succeeds.
-        Mock Expand-Archive { }
+        # omitted and returns the correct count.
+        Mock Expand-Archive { } -ModuleName Zip
 
-        # Call without -ExpectedFileCount to exercise the Get-ZipFileStats fallback
+        # Call without -ExpectedFileCount to exercise the Get-ZipFileStats fallback.
         $count = Expand-ZipSmart -ZipPath $zipPath -DestinationRoot $root -ExtractMode PerArchiveSubfolder
 
         $count | Should -Be 2
@@ -257,6 +237,7 @@ Describe 'Remove-SourceDirectory' {
         $helpersWithUsing = $usingLines + "`n" + $helpers
 
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
 
         function Write-LogDebug { param([string]$Message) }
@@ -377,6 +358,7 @@ Describe 'Move-ZipFilesToParent' {
         $helpersWithUsing = $usingLines + "`n" + $helpers
 
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
 
         function Write-LogDebug { param([string]$Message) }
@@ -505,6 +487,7 @@ Describe 'Write-PhaseProgress' {
         $helpersWithUsing = $usingLines + "`n" + $helpers
 
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
 
         function Write-LogDebug { param([string]$Message) }

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -15,38 +15,44 @@ Describe 'Core/Zip module — public extraction functions' {
     }
 
     It 'dispatches PerArchiveSubfolder mode to Expand-ZipToSubfolder' {
-        Mock New-DirectoryIfMissing { }
-        Mock Get-FullPath { '/tmp/dest' }
-        Mock Get-SafeName { 'safe-name' }
-        Mock Expand-ZipToSubfolder { 7 } -ModuleName Zip
-        Mock Expand-ZipFlat { 0 } -ModuleName Zip
+        # Mocks for intra-module calls must live inside InModuleScope so they intercept
+        # calls made from within the Zip module (Expand-ZipSmart -> Expand-ZipToSubfolder).
+        InModuleScope Zip {
+            Mock New-DirectoryIfMissing { }
+            Mock Get-FullPath { '/tmp/dest' }
+            Mock Get-SafeName { 'safe-name' }
+            Mock Expand-ZipToSubfolder { 7 }
+            Mock Expand-ZipFlat { 0 }
 
-        $result = Expand-ZipSmart -ZipPath '/tmp/a.zip' -DestinationRoot '/tmp/dest' -ExtractMode PerArchiveSubfolder -SafeNameMaxLen 80 -ExpectedFileCount 7
+            $result = Expand-ZipSmart -ZipPath '/tmp/a.zip' -DestinationRoot '/tmp/dest' -ExtractMode PerArchiveSubfolder -SafeNameMaxLen 80 -ExpectedFileCount 7
 
-        $result | Should -Be 7
-        Should -Invoke Expand-ZipToSubfolder -Times 1 -Exactly -ModuleName Zip -ParameterFilter {
-            $ZipPath -eq '/tmp/a.zip' -and
-            $DestinationRoot -eq '/tmp/dest' -and
-            $SafeSubfolderName -eq 'safe-name' -and
-            $ExpectedFileCount -eq 7
+            $result | Should -Be 7
+            Should -Invoke Expand-ZipToSubfolder -Times 1 -Exactly -ParameterFilter {
+                $ZipPath -eq '/tmp/a.zip' -and
+                $DestinationRoot -eq '/tmp/dest' -and
+                $SafeSubfolderName -eq 'safe-name' -and
+                $ExpectedFileCount -eq 7
+            }
+            Should -Invoke Expand-ZipFlat -Times 0
         }
-        Should -Invoke Expand-ZipFlat -Times 0 -ModuleName Zip
     }
 
     It 'dispatches Flat mode to Expand-ZipFlat with computed destination root' {
-        Mock New-DirectoryIfMissing { }
-        Mock Get-FullPath { '/tmp/dest-full' }
-        Mock Get-SafeName { 'unused-safe-name' }
-        Mock Expand-ZipFlat { 3 } -ModuleName Zip
+        InModuleScope Zip {
+            Mock New-DirectoryIfMissing { }
+            Mock Get-FullPath { '/tmp/dest-full' }
+            Mock Get-SafeName { 'unused-safe-name' }
+            Mock Expand-ZipFlat { 3 }
 
-        $result = Expand-ZipSmart -ZipPath '/tmp/b.zip' -DestinationRoot '/tmp/dest' -ExtractMode Flat -CollisionPolicy Rename
+            $result = Expand-ZipSmart -ZipPath '/tmp/b.zip' -DestinationRoot '/tmp/dest' -ExtractMode Flat -CollisionPolicy Rename
 
-        $result | Should -Be 3
-        Should -Invoke Expand-ZipFlat -Times 1 -Exactly -ModuleName Zip -ParameterFilter {
-            $ZipPath -eq '/tmp/b.zip' -and
-            $DestinationRoot -eq '/tmp/dest' -and
-            $DestinationRootFull -eq '/tmp/dest-full' -and
-            $CollisionPolicy -eq 'Rename'
+            $result | Should -Be 3
+            Should -Invoke Expand-ZipFlat -Times 1 -Exactly -ParameterFilter {
+                $ZipPath -eq '/tmp/b.zip' -and
+                $DestinationRoot -eq '/tmp/dest' -and
+                $DestinationRootFull -eq '/tmp/dest-full' -and
+                $CollisionPolicy -eq 'Rename'
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors `Expand-ZipsAndClean.ps1` by extracting reusable ZIP archive handling functions into a new `Core/Zip` PowerShell module. This improves code reusability, testability, and separation of concerns while maintaining backward compatibility through module imports.

## Key Changes

- **New `Core/Zip` module** (`src/powershell/modules/Core/Zip/`):
  - **Public functions** (in `Public/`):
    - `Get-ZipFileStats` — collects file count, uncompressed total, and compressed bytes without extraction
    - `Expand-ZipToSubfolder` — extracts archives into safe, unique subfolders (PerArchiveSubfolder mode)
    - `Expand-ZipFlat` — streams entries directly to destination root with collision handling (Flat mode)
    - `Expand-ZipSmart` — mode dispatcher routing to the appropriate extraction helper
  - **Private helpers** (in `Private/`):
    - `Test-IsEncryptedZipError` — detects encryption/password-protection in exception chains
    - `Resolve-ExtractionError` — normalizes extraction errors with user-friendly messages
    - `Resolve-ZipEntryDestinationPath` — validates entry paths and blocks Zip Slip path traversal
  - Module loader (`Zip.psm1`), manifest (`Zip.psd1`), and comprehensive documentation (`README.md`, `CHANGELOG.md`)

- **Updated `Expand-ZipsAndClean.ps1`**:
  - Removed the `#region Helpers` block containing the extracted functions
  - Removed `using namespace System.IO.Compression` (no longer needed in script body)
  - Added `Import-Module` for `Core/Zip/Zip.psm1` after FileSystem import
  - Version bumped to 2.3.0 (minor version — import contract change)

- **Updated tests** (`Expand-ZipsAndClean.Tests.ps1`):
  - Changed from extracting helpers from script source to importing the `Core/Zip` module directly
  - Updated mocks to use `-ModuleName Zip` for module-internal functions
  - Private function tests now use `InModuleScope Zip` for proper isolation

- **Documentation updates**:
  - Updated `docs/architecture/module-dependencies.md` to reflect the new Zip module and its dependency on FileSystem
  - Updated `src/powershell/modules/README.md` and `src/powershell/file-management/README.md` to document the new module
  - Added `CHANGELOG.md` to the Zip module with full version history

## Notable Implementation Details

- **Zip Slip protection**: `Resolve-ZipEntryDestinationPath` validates every archive entry before extraction, rejecting rooted paths, `..` traversal segments, and entries that escape the destination root.
- **Collision handling**: `Expand-ZipFlat` supports three per-file policies: Skip, Overwrite, and Rename (default).
- **Encryption detection**: `Test-IsEncryptedZipError` walks the full exception chain looking for encryption/password keywords, providing clear user-facing error messages.
- **Module independence**: The Zip module includes a no-op `Write-LogDebug` stub so it works standalone in tests and other contexts where the logging framework is not loaded.
- **Performance optimization**: `Expand-ZipSmart` accepts a pre-computed `ExpectedFileCount` to avoid redundant archive opens in PerArchiveSubfolder mode.

https://claude.ai/code/session_01PWW5F3RukzxUnA97oFjdWg