### PR TITLE
Remove redundant test cases from Expand-ZipsAndClean.Tests.ps1

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 2.5.4 — 2026-05-22
+
+### Tests
+
+- Removed four duplicate/low-value `It` blocks from `Expand-ZipsAndClean.Tests.ps1`; no script logic changed:
+  - `Flat: file count returned matches archive entry count` — redundant with `Flat Overwrite` and `Flat Rename`, which already exercise `Expand-ZipFlat` write-count paths; `Get-ZipFileStats` is already covered by `PerArchiveSubfolder: file count returned matches archive entry count` and the `Expand-ZipSmart` fallback test.
+  - `delegates per-item non-zip removal to Remove-FileWithRetry` — overlaps with `deletes nested non-zip files deepest-first …`, which drives the same per-item removal path over a richer tree; `Remove-FileWithRetry` is a test stub so the delegation assertion verifies harness wiring only.
+  - `delegates move operation to Move-FileWithRetry` — identical single-zip, no-collision scenario to `moves zip files from source to parent directory`; `Move-FileWithRetry` is likewise a test stub, so the `Should -Invoke` assertion verifies harness wiring rather than script logic.
+  - `omits CurrentOperation when not provided` — redundant with `calls Write-Progress with computed percentage when QuietMode is false`, which already invokes the function with no `-CurrentOperation`, exercising the same branch.
+- Suite now contains 33 tests (was 37).
+
+### Versioning
+
+- Bumped version to `2.5.4` (patch — test-suite maintenance only; no script behaviour change).
+
 ## 2.5.3 — 2026-05-21
 
 ### Changed

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -122,7 +122,7 @@ using namespace System.Collections.Concurrent
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.5.3
+    Version  : 2.5.4
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -151,30 +151,6 @@ Describe 'Core/Zip module — public extraction functions' {
         $count | Should -Be 3
     }
 
-    It 'Flat: file count returned matches archive entry count' {
-        $root = Join-Path $TestDrive 'flat-filecount'
-        New-Item -ItemType Directory -Path $root -Force | Out-Null
-
-        $zipPath = Join-Path $TestDrive 'flat-filecount.zip'
-        $archive = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
-        try {
-            foreach ($name in 'x.txt', 'y.txt') {
-                $entry  = $archive.CreateEntry($name)
-                $stream = $entry.Open()
-                $writer = New-Object System.IO.StreamWriter($stream)
-                try { $writer.Write("content-$name") } finally { $writer.Dispose() }
-            }
-        } finally {
-            $archive.Dispose()
-        }
-
-        $stats = Get-ZipFileStats -ZipPath $zipPath
-        $count = Expand-ZipFlat -ZipPath $zipPath -DestinationRoot $root -DestinationRootFull ([System.IO.Path]::GetFullPath($root)) -CollisionPolicy Rename
-
-        $count | Should -Be $stats.FileCount
-        $count | Should -Be 2
-    }
-
     It 'Expand-ZipSmart PerArchiveSubfolder: returns correct count when ExpectedFileCount is omitted' {
         $root = Join-Path $TestDrive 'smart-fallback'
         New-Item -ItemType Directory -Path $root -Force | Out-Null
@@ -383,24 +359,6 @@ Describe 'Remove-SourceDirectory' {
         Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter { $Message -like '*scan*' }
     }
 
-    It 'delegates per-item non-zip removal to Remove-FileWithRetry' {
-        $sourceDir = Join-Path $TestDrive 'source-retry-delegate'
-        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
-        $leftover = Join-Path $sourceDir 'leftover.txt'
-        Set-Content -LiteralPath $leftover -Value 'data'
-
-        # Mock Remove-FileWithRetry to actually delete so the source dir can be removed.
-        Mock Remove-FileWithRetry {
-            param([string]$Path)
-            if (Test-Path -LiteralPath $Path) { Remove-Item -LiteralPath $Path -Force }
-        }
-
-        $errors = [System.Collections.Generic.List[string]]::new()
-        Remove-SourceDirectory -SourceDir $sourceDir -ShouldDeleteSource $true -ShouldCleanNonZips $true -ErrorList $errors
-
-        Should -Invoke Remove-FileWithRetry -Times 1 -Exactly -ParameterFilter { $Path -eq $leftover }
-        $errors.Count | Should -Be 0
-    }
 }
 
 Describe 'Move-ZipFilesToParent' {
@@ -523,26 +481,6 @@ Describe 'Move-ZipFilesToParent' {
         $parentZips.Count | Should -Be 2
     }
 
-    It 'delegates move operation to Move-FileWithRetry' {
-        $parentDir = Join-Path $TestDrive 'parent-retry-delegate'
-        $sourceDir = Join-Path $parentDir 'source'
-        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
-        $srcZip = Join-Path $sourceDir 'test.zip'
-        Set-Content -LiteralPath $srcZip -Value 'dummy' -NoNewline
-
-        # Mock Move-FileWithRetry to actually move so result.Count stays correct.
-        Mock Move-FileWithRetry {
-            param([string]$Source, [string]$Destination, [switch]$Force)
-            Move-Item -LiteralPath $Source -Destination $Destination -Force:$Force
-        }
-
-        $result = Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true
-
-        Should -Invoke Move-FileWithRetry -Times 1 -Exactly -ParameterFilter {
-            $Source -eq $srcZip -and $Destination -eq (Join-Path $parentDir 'test.zip')
-        }
-        $result.Count | Should -Be 1
-    }
 }
 
 Describe 'Show-ProgressPhase' {
@@ -599,16 +537,6 @@ Describe 'Show-ProgressPhase' {
         Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
             $CurrentOperation -eq 'Moving: 10 B of 30 B bytes'
         }
-    }
-
-    It 'omits CurrentOperation when not provided' {
-        $capturedParams = @{}
-        Mock Write-Progress { $capturedParams['keys'] = $PSBoundParameters.Keys -join ',' }
-
-        Show-ProgressPhase -Activity 'Moving' -Status '1 / 3 : a.zip' `
-            -Current 1 -Total 3 -QuietMode $false
-
-        $capturedParams['keys'] | Should -Not -BeLike '*CurrentOperation*'
     }
 
     It 'calls Write-Progress -Completed and suppresses update parameters' {


### PR DESCRIPTION
## Summary

This PR removes four redundant or low-value test cases from the `Expand-ZipsAndClean.Tests.ps1` test suite. No changes to the actual script logic or functionality—this is purely test-suite maintenance to improve clarity and reduce duplication.

## Changes

- **Removed `Flat: file count returned matches archive entry count`** — This test was redundant with existing `Flat Overwrite` and `Flat Rename` tests, which already exercise the same `Expand-ZipFlat` write-count paths. The `Get-ZipFileStats` function is already covered by other tests.

- **Removed `delegates per-item non-zip removal to Remove-FileWithRetry`** — This test overlaps with the `deletes nested non-zip files deepest-first …` test, which exercises the same per-item removal path over a richer directory tree. Since `Remove-FileWithRetry` is a test stub, the assertion only verified harness wiring rather than actual script logic.

- **Removed `delegates move operation to Move-FileWithRetry`** — This test was nearly identical to the existing `moves zip files from source to parent directory` test, using the same single-zip, no-collision scenario. Like the previous case, it only verified test harness wiring.

- **Removed `omits CurrentOperation when not provided`** — This test was redundant with `calls Write-Progress with computed percentage when QuietMode is false`, which already invokes the function without `-CurrentOperation` and exercises the same code branch.

## Details

- Test suite reduced from 37 to 33 tests
- Version bumped to `2.5.4` (patch release for test-suite maintenance only)
- No changes to script behavior or public API

https://claude.ai/code/session_01ReoNw5dvyYmNYMSAdkW6fN