### PR TITLE
Remove ZipExtraction wrapper functions; use module export directly

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -18,9 +18,12 @@
 
 ### Added
 
-- Import-success guard after the `ZipExtraction` module import: throws a clear error if
-  `Invoke-ZipExtractions` is not available after `Import-Module`, catching mis-configured
-  or missing module installs early.
+- Import-success guard after the `ZipExtraction` module import: verifies that
+  `Get-Command Invoke-ZipExtractions` returns a command whose `Source -eq 'ZipExtraction'`,
+  throwing a clear error if the module failed to import or if only a session-level name
+  collision would satisfy an unqualified lookup.
+- `Main` now calls `ZipExtraction\Invoke-ZipExtractions` (module-qualified) so the correct
+  export is resolved even when a same-named function exists elsewhere in the session.
 
 ### Tests
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+## 2.6.2 — 2026-05-24
+
+### Removed
+
+- Deleted the script-local ZipExtraction wrapper/command-resolution block (~127 lines):
+  `Resolve-NonWrapperZipExtractionCommand`, `Get-ZipExtractionModuleCandidates`,
+  `Import-ZipExtractionFallbackFiles`, `Get-ZipExtractionCommand`,
+  `Invoke-ZipExtractionDelegate`, and the three thin wrappers
+  (`Invoke-ZipExtractions`, `Invoke-SerialZipExtractions`, `Invoke-ParallelZipExtractions`).
+  These wrappers shadowed the identically-named module exports and required ~120 lines of
+  machinery to re-resolve the "real" command while excluding themselves. The `Main` call to
+  `Invoke-ZipExtractions` (and the serial/parallel runners it dispatches) now resolves
+  directly to the `ZipExtraction` module export, which was already imported at line 185.
+
+### Added
+
+- Import-success guard after the `ZipExtraction` module import: throws a clear error if
+  `Invoke-ZipExtractions` is not available after `Import-Module`, catching mis-configured
+  or missing module installs early.
+
+### Tests
+
+- Replaced the helpers-region dot-source approach in `Invoke-ZipExtractions — parallel
+  extraction` with a direct `Import-Module ZipExtraction` call, since `Invoke-ZipExtractions`
+  is no longer defined in the script helper region.
+- Added `Describe 'Invoke-ZipExtractions resolves to ZipExtraction module'` with one `It`
+  block asserting `Get-Command Invoke-ZipExtractions` returns a command whose `Source` is
+  `ZipExtraction`.
+
+### Documentation
+
+- No comment-based help changes required (helpers described only behavior, not internal
+  resolution machinery).
+- `README.md` in `src/powershell/file-management/` does not reference the removed helper
+  function names; no update needed.
+
+### Versioning
+
+- Bumped version to `2.6.2` (patch — internal refactor; no behavioral change to extraction,
+  move, or summary output).
+
 ## 2.6.1 — 2026-05-23
 
 ### Changed

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -122,7 +122,7 @@ using namespace System.Collections.Concurrent
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.1
+    Version  : 2.6.2
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)
@@ -183,6 +183,10 @@ Import-Module "$PSScriptRoot\..\modules\Core\Zip\Zip.psm1" -Force
 Import-Module "$PSScriptRoot\..\modules\Core\Progress\ProgressReporter.psm1" -Force
 Import-Module "$PSScriptRoot\..\modules\Core\FileOperations\FileOperations.psm1" -Force
 Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1" -Force
+
+if (-not (Get-Command Invoke-ZipExtractions -ErrorAction SilentlyContinue)) {
+    throw "ZipExtraction module failed to import."
+}
 
 # Initialize logger (script name will be extracted from the script file name)
 Initialize-Logger -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
@@ -318,133 +322,6 @@ function New-ExtractionSummary {
     }
 }
 
-<#
-.SYNOPSIS
-    Aggregates per-runspace results into a single summary object.
-#>
-# ZIP extraction orchestration moved to FileManagement/ZipExtraction module (issue #1065).
-function Resolve-NonWrapperZipExtractionCommand {
-    param(
-        [Parameter(Mandatory)][string]$CommandName,
-        [string]$ExcludeScriptPath
-    )
-
-    $all = @(Get-Command -Name $CommandName -All -ErrorAction SilentlyContinue)
-    foreach ($candidate in $all) {
-        if ($candidate.Source -eq 'ZipExtraction') { return $candidate }
-        $file = $candidate.ScriptBlock?.File
-        if (-not [string]::IsNullOrWhiteSpace($file) -and $file -ne $ExcludeScriptPath -and $file -like '*modules*FileManagement*ZipExtraction*') {
-            return $candidate
-        }
-    }
-    return $null
-}
-
-function Get-ZipExtractionModuleCandidates {
-    param([string]$FileSystemModulePath)
-
-    $candidates = [System.Collections.Generic.List[string]]::new()
-    if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
-        $candidates.Add((Join-Path $PSScriptRoot '..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1')) | Out-Null
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($FileSystemModulePath)) {
-        $modulesRoot = Split-Path -Path (Split-Path -Path $FileSystemModulePath -Parent) -Parent
-        if (-not [string]::IsNullOrWhiteSpace($modulesRoot)) {
-            $candidates.Add((Join-Path $modulesRoot 'FileManagement/ZipExtraction/ZipExtraction.psm1')) | Out-Null
-        }
-    }
-
-    $cwdPath = (Get-Location).Path
-    if (-not [string]::IsNullOrWhiteSpace($cwdPath)) {
-        $candidates.Add((Join-Path $cwdPath 'src/powershell/modules/FileManagement/ZipExtraction/ZipExtraction.psm1')) | Out-Null
-    }
-
-    return @($candidates | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-}
-
-function Import-ZipExtractionFallbackFiles {
-    param([string]$FileSystemModulePath)
-
-    $cwdPath = (Get-Location).Path
-    $zipExtractionRoot = $null
-    if (-not [string]::IsNullOrWhiteSpace($FileSystemModulePath)) {
-        $coreModulesRoot = Split-Path -Path (Split-Path -Path $FileSystemModulePath -Parent) -Parent
-        if ($coreModulesRoot) { $zipExtractionRoot = Join-Path $coreModulesRoot 'FileManagement/ZipExtraction' }
-    }
-    if (-not $zipExtractionRoot -and -not [string]::IsNullOrWhiteSpace($cwdPath)) {
-        $zipExtractionRoot = Join-Path $cwdPath 'src/powershell/modules/FileManagement/ZipExtraction'
-    }
-
-    if (-not $zipExtractionRoot -or -not (Test-Path -LiteralPath $zipExtractionRoot)) { return }
-
-    foreach ($subdir in 'Private','Public') {
-        $dir = Join-Path $zipExtractionRoot $subdir
-        if (Test-Path -LiteralPath $dir) {
-            Get-ChildItem -LiteralPath $dir -Filter '*.ps1' -File -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
-        }
-    }
-}
-
-function Get-ZipExtractionCommand {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$Name)
-
-    $excludePath = $PSCommandPath
-    $resolved = Resolve-NonWrapperZipExtractionCommand -CommandName $Name -ExcludeScriptPath $excludePath
-    if ($resolved) { return $resolved }
-
-    $fsModulePath = (Get-Module -Name FileSystem -ErrorAction SilentlyContinue)?.Path
-    foreach ($candidate in (Get-ZipExtractionModuleCandidates -FileSystemModulePath $fsModulePath)) {
-        if (Test-Path -LiteralPath $candidate) {
-            Import-Module -Name $candidate -Force -ErrorAction SilentlyContinue
-            $resolved = Resolve-NonWrapperZipExtractionCommand -CommandName $Name -ExcludeScriptPath $excludePath
-            if ($resolved) { return $resolved }
-        }
-    }
-
-    Import-ZipExtractionFallbackFiles -FileSystemModulePath $fsModulePath
-    $resolved = Resolve-NonWrapperZipExtractionCommand -CommandName $Name -ExcludeScriptPath $excludePath
-    if ($resolved) { return $resolved }
-
-    throw "The module 'ZipExtraction' could not be loaded. For more information, run 'Import-Module ZipExtraction'."
-}
-
-function Invoke-ZipExtractionDelegate {
-    param(
-        [Parameter(Mandatory)][string]$Name,
-        [Parameter(Mandatory)]$Parameters
-    )
-    $cmd = Get-ZipExtractionCommand -Name $Name
-    if ($Parameters -is [System.Collections.IDictionary]) { return (& $cmd @Parameters) }
-    if ($Parameters -is [array]) { return (& $cmd @Parameters) }
-    return (& $cmd $Parameters)
-}
-
-function Invoke-ParallelZipExtractions {
-    [CmdletBinding()]
-    param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
-    return Invoke-ZipExtractionDelegate -Name 'Invoke-ParallelZipExtractions' -Parameters $Arguments
-}
-function Invoke-SerialZipExtractions {
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
-    return Invoke-ZipExtractionDelegate -Name 'Invoke-SerialZipExtractions' -Parameters $Arguments
-}
-function Invoke-ZipExtractions {
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    param(
-        [Parameter(Mandatory)][string]$SourceDir,
-        [Parameter(Mandatory)][string]$DestinationDir,
-        [Parameter(Mandatory)][string]$Mode,
-        [Parameter(Mandatory)][string]$Policy,
-        [Parameter(Mandatory)][int]$SafeNameMaxLen,
-        [Parameter(Mandatory)][bool]$QuietMode,
-        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$ErrorList,
-        [int]$ThrottleLimit = 1
-    )
-    return Invoke-ZipExtractionDelegate -Name 'Invoke-ZipExtractions' -Parameters $PSBoundParameters
-}
 
 <#
 .SYNOPSIS

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -184,9 +184,11 @@ Import-Module "$PSScriptRoot\..\modules\Core\Progress\ProgressReporter.psm1" -Fo
 Import-Module "$PSScriptRoot\..\modules\Core\FileOperations\FileOperations.psm1" -Force
 Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1" -Force
 
-if (-not (Get-Command Invoke-ZipExtractions -ErrorAction SilentlyContinue)) {
+$_zipExtractionCmd = Get-Command Invoke-ZipExtractions -ErrorAction SilentlyContinue
+if (-not $_zipExtractionCmd -or $_zipExtractionCmd.Source -ne 'ZipExtraction') {
     throw "ZipExtraction module failed to import."
 }
+Remove-Variable _zipExtractionCmd
 
 # Initialize logger (script name will be extracted from the script file name)
 Initialize-Logger -ScriptName (Split-Path -Leaf $PSCommandPath) -LogLevel 20
@@ -705,7 +707,7 @@ try {
     Test-ScriptPreconditions -SourceDir $SourceDirectory -DestinationDir $DestinationDirectory
     Initialize-Destination -DestinationDir $DestinationDirectory
 
-    $extractionResult = Invoke-ZipExtractions `
+    $extractionResult = ZipExtraction\Invoke-ZipExtractions `
         -SourceDir $SourceDirectory `
         -DestinationDir $DestinationDirectory `
         -Mode $ExtractMode `

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -434,30 +434,26 @@ Describe 'Write-ExtractionSummary' {
     }
 }
 
-Describe 'Invoke-ZipExtractions — parallel extraction' {
+Describe 'Invoke-ZipExtractions resolves to ZipExtraction module' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd   = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipExtraction\ZipExtraction.psm1') -Force
+    }
 
-        function Write-LogDebug { param([string]$Message) }
-        function Write-LogInfo  { param([string]$Message) }
-        . ([ScriptBlock]::Create($helpersWithUsing))
+    It 'Invoke-ZipExtractions is exported by the ZipExtraction module' {
+        $cmd = Get-Command -Name Invoke-ZipExtractions -ErrorAction SilentlyContinue
+        $cmd | Should -Not -BeNullOrEmpty
+        $cmd.Source | Should -Be 'ZipExtraction'
+    }
+}
+
+Describe 'Invoke-ZipExtractions — parallel extraction' {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipExtraction\ZipExtraction.psm1') -Force
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
     }
 
     It 'parallel path (-ThrottleLimit 2) extracts all archives and aggregates results correctly' {


### PR DESCRIPTION
## Summary
Removed ~127 lines of script-local wrapper and command-resolution machinery from `Expand-ZipsAndClean.ps1` that shadowed the `ZipExtraction` module's exported functions. The script now calls `Invoke-ZipExtractions` directly from the module, eliminating unnecessary indirection and complexity.

## Key Changes

- **Removed wrapper functions** (`Invoke-ZipExtractions`, `Invoke-SerialZipExtractions`, `Invoke-ParallelZipExtractions`) and their supporting helpers:
  - `Resolve-NonWrapperZipExtractionCommand`
  - `Get-ZipExtractionModuleCandidates`
  - `Import-ZipExtractionFallbackFiles`
  - `Get-ZipExtractionCommand`
  - `Invoke-ZipExtractionDelegate`

- **Added import-success guard**: After importing the `ZipExtraction` module, the script now validates that `Invoke-ZipExtractions` is available, throwing a clear error if the module failed to load.

- **Updated tests**:
  - Replaced the helpers-region dot-source approach with direct `Import-Module` calls for the `ZipExtraction` module
  - Added new test `Describe 'Invoke-ZipExtractions resolves to ZipExtraction module'` to verify the command is exported by the module

- **Version bumped** to `2.6.2` (patch release for internal refactor with no behavioral changes)

## Implementation Details

The removed wrapper functions existed to re-resolve the "real" `Invoke-ZipExtractions` command from the `ZipExtraction` module while excluding the script-local wrappers themselves. This required ~120 lines of fallback logic and multiple resolution attempts. Since the `ZipExtraction` module is already imported at line 185, the script can now call the module's export directly without any shadowing or re-resolution machinery.

The new import-success guard provides early detection of misconfigured or missing module installations, improving debuggability.

https://claude.ai/code/session_01Aim6UDQBRJQcScYbfyQn84