### PR TITLE
Rename and update CHANGELOG for Google Drive recovery tool

### DIFF
--- a/src/python/cloud/CHANGELOG-gdrive-recover.md
+++ b/src/python/cloud/CHANGELOG-gdrive-recover.md
@@ -1,9 +1,14 @@
-# Changelog
+# CHANGELOG — Google Drive Trash Recovery Tool
 
-All notable changes to this project will be documented in this file.
+All notable changes to the **Google Drive Trash Recovery tool** (`gdrive_*` module family) are
+documented in this file. The authoritative version is defined in `gdrive_constants.py`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Out of scope:** `cloudconvert_utils.py`, `drive_space_monitor.py`, and
+> `google_drive_root_files_delete.py` are sibling scripts in this directory that are currently
+> unversioned and not covered by this changelog.
 
 ## [Unreleased]
 

--- a/src/python/cloud/gdrive_cli.py
+++ b/src/python/cloud/gdrive_cli.py
@@ -103,7 +103,7 @@ Notes:
   The folder ID is the alphanumeric string at the end of a Drive folder URL:
     https://drive.google.com/drive/folders/<FOLDER_ID>
 
-For the compatibility matrix, transport notes, and performance presets: see README.md and CHANGELOG.md.
+For the compatibility matrix, transport notes, and performance presets: see README.md and CHANGELOG-gdrive-recover.md.
 """,
     )
 

--- a/src/python/cloud/gdrive_recover.py
+++ b/src/python/cloud/gdrive_recover.py
@@ -29,7 +29,7 @@ This tool provides:
 Requirements:
 - Python **3.10+** (uses PEP 604 `X | Y` union types across codebase, including `validators.py`)
 
-See CHANGELOG.md in this directory for version history.
+See CHANGELOG-gdrive-recover.md in this directory for version history.
 
 Examples
 --------


### PR DESCRIPTION
## Summary
Renamed the changelog file to be more specific to the Google Drive Trash Recovery tool and updated all references throughout the codebase to point to the new filename.

## Key Changes
- Renamed `CHANGELOG.md` to `CHANGELOG-gdrive-recover.md` to clarify scope
- Enhanced changelog header to explicitly document it covers the Google Drive Trash Recovery tool (`gdrive_*` module family)
- Added clarification that the authoritative version is defined in `gdrive_constants.py`
- Added "Out of scope" section documenting related but unversioned sibling scripts (`cloudconvert_utils.py`, `drive_space_monitor.py`, `google_drive_root_files_delete.py`)
- Updated references in `gdrive_cli.py` and `gdrive_recover.py` to point to the new changelog filename

## Implementation Details
The changelog now clearly delineates its scope to the Google Drive recovery tool family while documenting that other scripts in the same directory are not covered by this versioning scheme. This prevents confusion about which tools are version-tracked and which are not.

https://claude.ai/code/session_014HUoX7SHsCoDTtxWCJoqCJ