### PR TITLE
fix(gdrive): correct SemVer historical note and 1.8.x changelog dates

### DIFF
--- a/src/python/cloud/CHANGELOG-gdrive-recover.md
+++ b/src/python/cloud/CHANGELOG-gdrive-recover.md
@@ -6,7 +6,7 @@ documented in this file. The authoritative version is defined in `gdrive_constan
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **SemVer note (historical):** A small subset of pre-2.0 releases included documented breaking changes under a minor-version bump. Known cases are `1.20.0` (default `--log-file` behavior changed), `1.21.0` (`--failed-file` format changed plain text → CSV), and one-way state-schema migrations in `1.23.0` (v1→v2) and `1.24.0` (v2→v3). Per maintainer decision, historical version numbers are retained as published.
+> **SemVer note (historical):** A small subset of pre-2.0 releases documented breaking behavior under a minor-version bump. Under SemVer 2.0 this is only expected before `1.0.0`; for `1.x` lines, breaking changes should increment the major version. Known historical exceptions retained as-published are `1.20.0` (default `--log-file` behavior changed), `1.21.0` (`--failed-file` format changed plain text → CSV), and one-way state-schema migrations in `1.23.0` (v1→v2) and `1.24.0` (v2→v3).
 
 > **Out of scope:** `cloudconvert_utils.py`, `drive_space_monitor.py`, and
 > `google_drive_root_files_delete.py` are sibling scripts in this directory that are currently
@@ -302,7 +302,7 @@ See #789–#856 for issue-by-issue detail.
 
 - Moved embedded `CHANGELOG` block out of `gdrive_recover.py` into this `CHANGELOG.md` file. No logic changes.
 
-## [1.8.1] - 2025-09-23
+## [1.8.1] - 2026-03-26
 
 ### Fixed
 
@@ -320,7 +320,7 @@ See #789–#856 for issue-by-issue detail.
 - No CLI or API changes; backward-compatible patch.
 - Dry-run behavior unchanged (it still performs one-shot discovery and reports counts once).
 
-## [1.8.0] - 2025-09-23
+## [1.8.0] - 2026-03-26
 
 ### Added
 

--- a/src/python/cloud/README.md
+++ b/src/python/cloud/README.md
@@ -27,7 +27,7 @@ Python scripts for cloud service integration, primarily Google Drive operations.
 ## Versioning and changelog
 
 - The Google Drive recovery tool (`gdrive_*` module family) maintains its release history in `CHANGELOG-gdrive-recover.md`.
-- Historical note: a small number of pre-2.0 releases documented breaking behavior under minor-version bumps; the changelog now carries an explicit SemVer caveat while preserving published version numbers.
+- Historical note: a small number of pre-2.0 releases documented breaking behavior under minor-version bumps. Under SemVer 2.0 this is only expected before `1.0.0`; these `1.x` historical exceptions are preserved as published and called out explicitly in the changelog.
 - Changelog heading convention: consolidated rollups use a lowercase `(consolidated)` suffix, and multi-version entries use a single bracketed range like `[1.23.1–1.23.3]`.
 - Recent maintenance refactors from `1.26.2` through `1.26.5` are intentionally grouped as one consolidated release band in the changelog to reduce short-lived refactor churn noise while preserving the key fixes and test deltas.
 


### PR DESCRIPTION
### Motivation

- Clarify the changelog SemVer historical note to accurately reflect that breaking-version expectations under SemVer 2.0 apply to pre-`1.0.0` releases while preserving documented `1.x` historical exceptions.
- Verify and correct the recorded release dates for the `1.8.x` entries so the changelog accurately reflects the historical publication timeline.

### Description

- Updated the SemVer historical guidance in `src/python/cloud/CHANGELOG-gdrive-recover.md` to explicitly distinguish pre-`1.0.0` SemVer expectations from `1.x` historical exceptions.
- Corrected the dates for `## [1.8.1]` and `## [1.8.0]` to `2026-03-26` in `src/python/cloud/CHANGELOG-gdrive-recover.md`.
- Made the matching wording update in `src/python/cloud/README.md` so the README and changelog guidance remain consistent.

### Testing

- Ran text searches with `rg` to locate and verify the updated SemVer note and `1.8.x` section, which returned the expected matches (success).
- Inspected the working-tree diff via `git diff -- src/python/cloud/CHANGELOG-gdrive-recover.md src/python/cloud/README.md` to confirm only the intended documentation lines changed (success).
- Reviewed commit history and tags relevant to the `1.8.x` entries via `git log` queries to validate the corrected dates align with repository history (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ba92eaf4832591efe3c95bf4b076)