### PR TITLE
Refactor: extract help text and improve error handling

### DIFF
--- a/src/python/cloud/CHANGELOG-gdrive-recover.md
+++ b/src/python/cloud/CHANGELOG-gdrive-recover.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `google_drive_root_files_delete.py` are sibling scripts in this directory that are currently
 > unversioned and not covered by this changelog.
 
+## [1.26.10] - 2026-05-24
+
+### Changed
+
+- `gdrive_constants.py`: extracted the argparse help epilog (~66 lines of static example/usage text) from `create_parser()` into a new module-level constant `HELP_EPILOG`; `create_parser()` now references it via `epilog=HELP_EPILOG`. `%(prog)s` substitution is unaffected. `--help` output is byte-for-byte identical to before.
+- `gdrive_cli.py`: `_validate_concurrency_arg` now routes its invalid-value error and its concurrency-cap warning to stderr (`file=sys.stderr`), consistent with every other validator in the module.
+- `gdrive_cli.py`: collapsed duplicate "nothing to retry" messaging — `_load_retry_failed_file` no longer emits a warning when the retry CSV has no actionable rows; the single authoritative error message is now only in `_apply_retry_failed_file`, which also owns the non-zero exit code for that condition.
+- `gdrive_cli.py`: `_acquire_or_bypass_lock` now uses the idiomatic `remaining.is_integer()` instead of `int(remaining) == remaining` to decide between whole-second and fractional lock-wait countdown formatting.
+
 ## [1.26.9] - 2026-05-24
 
 ### Changed

--- a/src/python/cloud/gdrive_cli.py
+++ b/src/python/cloud/gdrive_cli.py
@@ -320,7 +320,9 @@ def _validate_concurrency_arg(args) -> Tuple[bool, int]:
         cpu = 1
     ceiling = min(cpu * 4, 64)
     if args.concurrency < 1:
-        print(f"{console.sym_fail()} Invalid --concurrency value. It must be >= 1.", file=sys.stderr)
+        print(
+            f"{console.sym_fail()} Invalid --concurrency value. It must be >= 1.", file=sys.stderr
+        )
         return False, 2
     if args.concurrency > ceiling:
         print(

--- a/src/python/cloud/gdrive_cli.py
+++ b/src/python/cloud/gdrive_cli.py
@@ -23,6 +23,7 @@ from gdrive_console import ConsoleHelper
 from gdrive_validators import validate_extensions, normalize_policy_token
 from gdrive_constants import (
     VERSION,
+    HELP_EPILOG,
     EXTENSION_MIME_TYPES,
     DEFAULT_BURST,
     DEFAULT_FAILED_FILE,
@@ -45,73 +46,7 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description=f"Google Drive Trash Recovery Tool v{__version__}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=r"""
-Examples:
-  Dry-run (preview — no changes made):
-    %(prog)s dry-run
-    %(prog)s dry-run --extensions jpg png --no-emoji
-    %(prog)s dry-run --after-date 2024-01-01
-    %(prog)s dry-run --file-ids FILE_ID_1 FILE_ID_2
-    %(prog)s dry-run --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
-    %(prog)s dry-run --download-dir ./recovered --extensions jpg png
-
-  Recover-only (restore trashed files to Drive — no local download):
-    %(prog)s recover-only --extensions pdf docx
-    %(prog)s recover-only --after-date 2024-06-01 --yes
-    %(prog)s recover-only --file-ids FILE_ID_1 FILE_ID_2 --yes
-    %(prog)s recover-only --state-file ./state.json --yes
-
-  Recover-and-download (restore trashed files and save locally):
-    %(prog)s recover-and-download --download-dir ./recovered --post-restore-policy retain
-    %(prog)s recover-and-download --download-dir ./recovered --extensions jpg png --post-restore-policy retain --yes
-    %(prog)s recover-and-download --download-dir ./recovered --file-ids FILE_ID_1 --post-restore-policy retain
-    %(prog)s recover-and-download --download-dir ./recovered --state-file ./state.json --yes
-    %(prog)s recover-and-download --download-dir ./recovered --direct-download --post-restore-policy retain
-    %(prog)s recover-and-download --download-dir ./recovered --overwrite --post-restore-policy retain
-    %(prog)s recover-and-download --download-dir ./recovered --skip-existing --post-restore-policy retain
-
-  Folder-scoped download (download a live Drive folder and all subfolders):
-    %(prog)s dry-run --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
-    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
-    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --extensions pdf --post-restore-policy retain --yes
-    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --overwrite --post-restore-policy retain --yes
-
-  Performance presets:
-    %(prog)s recover-and-download --download-dir ./out --concurrency 16 --process-batch-size 500 --max-rps 8 --burst 32 --post-restore-policy retain -v
-    %(prog)s recover-and-download --download-dir ./out --http-transport requests --http-pool-maxsize 16 --concurrency 16 --post-restore-policy retain
-
-  Logging and failure tracking:
-    %(prog)s recover-and-download --download-dir ./out --log-file ./run.log
-    %(prog)s recover-and-download --download-dir ./out --failed-file ./failed.csv
-    %(prog)s recover-and-download --download-dir ./out --log-file ./logs/run.log --failed-file ./logs/failed.csv
-    %(prog)s recover-and-download --download-dir ./out --fresh-run --failed-file ./failed.csv  # clears state + failed.csv first
-
-  Fresh run (ignore prior progress, regenerate run identity, truncate failed-file):
-    %(prog)s recover-only --fresh-run --state-file ./state.json --yes
-    %(prog)s recover-and-download --download-dir ./out --fresh-run --failed-file ./failed.csv --yes
-
-  Retry failed downloads from a previous run:
-    %(prog)s recover-and-download --download-dir ./out --retry-failed-file ./failed.csv
-    %(prog)s recover-and-download --download-dir ./out --retry-failed-file ./failed.csv --post-restore-policy retain --yes
-
-  Locking and automation:
-    %(prog)s recover-and-download --download-dir ./out --lock-timeout 60 --state-file ./state.json
-    %(prog)s recover-and-download --download-dir ./out --force --state-file ./state.json
-    %(prog)s recover-and-download --download-dir ./out --yes --no-emoji
-
-Policies: trash (default), retain, delete
-  trash  — move file to Drive Trash after download (WARNING: avoid with --folder-id)
-  retain — leave the file in its current Drive location (recommended with --folder-id)
-  delete — permanently delete from Drive after download (irreversible)
-
-Notes:
-  --folder-id targets non-trashed live files; it cannot be combined with --file-ids or recover-only.
-  Use --post-restore-policy retain with --folder-id to avoid moving live files to Trash.
-  The folder ID is the alphanumeric string at the end of a Drive folder URL:
-    https://drive.google.com/drive/folders/<FOLDER_ID>
-
-For the compatibility matrix, transport notes, and performance presets: see README.md and CHANGELOG-gdrive-recover.md.
-""",
+        epilog=HELP_EPILOG,
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Operation mode")
@@ -385,11 +320,12 @@ def _validate_concurrency_arg(args) -> Tuple[bool, int]:
         cpu = 1
     ceiling = min(cpu * 4, 64)
     if args.concurrency < 1:
-        print(f"{console.sym_fail()} Invalid --concurrency value. It must be >= 1.")
+        print(f"{console.sym_fail()} Invalid --concurrency value. It must be >= 1.", file=sys.stderr)
         return False, 2
     if args.concurrency > ceiling:
         print(
-            f"{console.sym_warn()} --concurrency {args.concurrency} is high; capping to {ceiling} to avoid resource exhaustion and 429s."
+            f"{console.sym_warn()} --concurrency {args.concurrency} is high; capping to {ceiling} to avoid resource exhaustion and 429s.",
+            file=sys.stderr,
         )
         args.concurrency = ceiling
     return True, 0
@@ -531,11 +467,6 @@ def _load_retry_failed_file(
             file=sys.stderr,
         )
         return False, 2, {}
-    if not target_path_overrides:
-        print(
-            f"{console.sym_warn()} --retry-failed-file '{path_str}' contains no actionable rows; nothing to retry.",
-            file=sys.stderr,
-        )
     return True, 0, target_path_overrides
 
 
@@ -687,7 +618,7 @@ def _acquire_or_bypass_lock(tool, args) -> Tuple[bool, int]:
     acquired = tool.state_manager._acquire_state_lock()
     while (not acquired) and timeout > 0 and (time.time() - start_wait) < timeout:
         remaining = max(0.0, timeout - (time.time() - start_wait))
-        if int(remaining) == remaining:
+        if remaining.is_integer():
             remaining_str = f"{int(remaining)}s"
         else:
             remaining_str = f"{remaining:.1f}s"

--- a/src/python/cloud/gdrive_constants.py
+++ b/src/python/cloud/gdrive_constants.py
@@ -12,7 +12,78 @@ import os
 # ---------------------------------------------------------------------------
 # Version
 # ---------------------------------------------------------------------------
-VERSION = "1.26.9"
+VERSION = "1.26.10"
+
+# ---------------------------------------------------------------------------
+# CLI help text
+# ---------------------------------------------------------------------------
+HELP_EPILOG = r"""
+Examples:
+  Dry-run (preview — no changes made):
+    %(prog)s dry-run
+    %(prog)s dry-run --extensions jpg png --no-emoji
+    %(prog)s dry-run --after-date 2024-01-01
+    %(prog)s dry-run --file-ids FILE_ID_1 FILE_ID_2
+    %(prog)s dry-run --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
+    %(prog)s dry-run --download-dir ./recovered --extensions jpg png
+
+  Recover-only (restore trashed files to Drive — no local download):
+    %(prog)s recover-only --extensions pdf docx
+    %(prog)s recover-only --after-date 2024-06-01 --yes
+    %(prog)s recover-only --file-ids FILE_ID_1 FILE_ID_2 --yes
+    %(prog)s recover-only --state-file ./state.json --yes
+
+  Recover-and-download (restore trashed files and save locally):
+    %(prog)s recover-and-download --download-dir ./recovered --post-restore-policy retain
+    %(prog)s recover-and-download --download-dir ./recovered --extensions jpg png --post-restore-policy retain --yes
+    %(prog)s recover-and-download --download-dir ./recovered --file-ids FILE_ID_1 --post-restore-policy retain
+    %(prog)s recover-and-download --download-dir ./recovered --state-file ./state.json --yes
+    %(prog)s recover-and-download --download-dir ./recovered --direct-download --post-restore-policy retain
+    %(prog)s recover-and-download --download-dir ./recovered --overwrite --post-restore-policy retain
+    %(prog)s recover-and-download --download-dir ./recovered --skip-existing --post-restore-policy retain
+
+  Folder-scoped download (download a live Drive folder and all subfolders):
+    %(prog)s dry-run --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
+    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --post-restore-policy retain
+    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --extensions pdf --post-restore-policy retain --yes
+    %(prog)s recover-and-download --folder-id FOLDER_ID --download-dir ./backup --overwrite --post-restore-policy retain --yes
+
+  Performance presets:
+    %(prog)s recover-and-download --download-dir ./out --concurrency 16 --process-batch-size 500 --max-rps 8 --burst 32 --post-restore-policy retain -v
+    %(prog)s recover-and-download --download-dir ./out --http-transport requests --http-pool-maxsize 16 --concurrency 16 --post-restore-policy retain
+
+  Logging and failure tracking:
+    %(prog)s recover-and-download --download-dir ./out --log-file ./run.log
+    %(prog)s recover-and-download --download-dir ./out --failed-file ./failed.csv
+    %(prog)s recover-and-download --download-dir ./out --log-file ./logs/run.log --failed-file ./logs/failed.csv
+    %(prog)s recover-and-download --download-dir ./out --fresh-run --failed-file ./failed.csv  # clears state + failed.csv first
+
+  Fresh run (ignore prior progress, regenerate run identity, truncate failed-file):
+    %(prog)s recover-only --fresh-run --state-file ./state.json --yes
+    %(prog)s recover-and-download --download-dir ./out --fresh-run --failed-file ./failed.csv --yes
+
+  Retry failed downloads from a previous run:
+    %(prog)s recover-and-download --download-dir ./out --retry-failed-file ./failed.csv
+    %(prog)s recover-and-download --download-dir ./out --retry-failed-file ./failed.csv --post-restore-policy retain --yes
+
+  Locking and automation:
+    %(prog)s recover-and-download --download-dir ./out --lock-timeout 60 --state-file ./state.json
+    %(prog)s recover-and-download --download-dir ./out --force --state-file ./state.json
+    %(prog)s recover-and-download --download-dir ./out --yes --no-emoji
+
+Policies: trash (default), retain, delete
+  trash  — move file to Drive Trash after download (WARNING: avoid with --folder-id)
+  retain — leave the file in its current Drive location (recommended with --folder-id)
+  delete — permanently delete from Drive after download (irreversible)
+
+Notes:
+  --folder-id targets non-trashed live files; it cannot be combined with --file-ids or recover-only.
+  Use --post-restore-policy retain with --folder-id to avoid moving live files to Trash.
+  The folder ID is the alphanumeric string at the end of a Drive folder URL:
+    https://drive.google.com/drive/folders/<FOLDER_ID>
+
+For the compatibility matrix, transport notes, and performance presets: see README.md and CHANGELOG-gdrive-recover.md.
+"""
 
 # ---------------------------------------------------------------------------
 # API / OAuth

--- a/tests/python/unit/test_gdrive_cli_console_helper.py
+++ b/tests/python/unit/test_gdrive_cli_console_helper.py
@@ -41,22 +41,22 @@ def test_validate_concurrency_arg_below_one_fails(capsys):
     args = _args(concurrency=0)
     ok, code = _validate_concurrency_arg(args)
     assert not ok and code == 2
-    out = capsys.readouterr().out
-    assert "Invalid --concurrency" in out
+    err = capsys.readouterr().err
+    assert "Invalid --concurrency" in err
 
 
 def test_validate_concurrency_arg_below_one_emoji(capsys):
     args = _args(concurrency=0, no_emoji=False)
     ok, code = _validate_concurrency_arg(args)
     assert not ok and code == 2
-    assert "❌" in capsys.readouterr().out
+    assert "❌" in capsys.readouterr().err
 
 
 def test_validate_concurrency_arg_below_one_no_emoji(capsys):
     args = _args(concurrency=0, no_emoji=True)
     ok, code = _validate_concurrency_arg(args)
     assert not ok and code == 2
-    assert "ERROR" in capsys.readouterr().out
+    assert "ERROR" in capsys.readouterr().err
 
 
 def test_validate_concurrency_arg_above_ceiling_caps_and_warns(capsys):
@@ -64,19 +64,19 @@ def test_validate_concurrency_arg_above_ceiling_caps_and_warns(capsys):
     ok, code = _validate_concurrency_arg(args)
     assert ok and code == 0
     assert args.concurrency <= 64
-    assert "high" in capsys.readouterr().out
+    assert "high" in capsys.readouterr().err
 
 
 def test_validate_concurrency_arg_above_ceiling_warn_emoji(capsys):
     args = _args(concurrency=9999, no_emoji=False)
     _validate_concurrency_arg(args)
-    assert "⚠️" in capsys.readouterr().out
+    assert "⚠️" in capsys.readouterr().err
 
 
 def test_validate_concurrency_arg_above_ceiling_warn_no_emoji(capsys):
     args = _args(concurrency=9999, no_emoji=True)
     _validate_concurrency_arg(args)
-    assert "WARN" in capsys.readouterr().out
+    assert "WARN" in capsys.readouterr().err
 
 
 def test_validate_concurrency_arg_valid_passes():

--- a/tests/python/unit/test_gdrive_cli_lock_management.py
+++ b/tests/python/unit/test_gdrive_cli_lock_management.py
@@ -5,6 +5,12 @@ Covers the three correctness fixes from issue #1122:
   - _print_lockfile_messages stale-lock branches are reachable
   - _run_and_release_lock dispatches all commands through _run_tool
   - _acquire_or_bypass_lock surfaces real exceptions instead of swallowing them
+
+Also covers the wait-loop paths added in issue #1133:
+  - _acquire_or_bypass_lock lock_timeout > 0: acquired on retry
+  - _acquire_or_bypass_lock remaining.is_integer() integer display ("5s")
+  - _acquire_or_bypass_lock remaining.is_integer() fractional display ("2.7s")
+  - _acquire_or_bypass_lock timeout expires without acquiring
 """
 
 import sys
@@ -23,6 +29,7 @@ from gdrive_cli import (  # noqa: E402
     _print_lockfile_messages,
     _run_and_release_lock,
     _acquire_or_bypass_lock,
+    _apply_retry_failed_file,
 )
 from gdrive_state import StateScopeMismatchError  # noqa: E402
 from gdrive_models import RecoveryStateScope  # noqa: E402
@@ -231,3 +238,83 @@ def test_acquire_or_bypass_lock_stale_lock_no_force_emits_stale_message(capsys):
     err = capsys.readouterr().err
     assert not ok
     assert "stale" in err
+
+
+# ---------------------------------------------------------------------------
+# _acquire_or_bypass_lock — wait-loop paths (lock_timeout > 0)
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_or_bypass_lock_acquired_on_retry(capsys):
+    """Lock fails on the first attempt but succeeds after one wait iteration."""
+    tool = MagicMock()
+    tool.state_manager._acquire_state_lock.side_effect = [False, True]
+    args = _args(lock_timeout=5.0)
+    # time.time(): start=100, while-check=100 (enters loop), remaining=100, while-check=100 (exits)
+    with patch("gdrive_cli.time") as mock_time:
+        mock_time.time.side_effect = [100.0, 100.0, 100.0, 100.0]
+        mock_time.sleep = MagicMock()
+        ok, code = _acquire_or_bypass_lock(tool, args)
+    assert ok and code == 0
+    mock_time.sleep.assert_called_once()
+
+
+def test_acquire_or_bypass_lock_wait_loop_integer_remaining_display(capsys):
+    """When remaining time is a whole number, display uses integer format ('5s')."""
+    tool = MagicMock()
+    tool.state_manager._acquire_state_lock.side_effect = [False, True]
+    args = _args(lock_timeout=5.0)
+    # elapsed = 0 at the time remaining is computed → remaining = 5.0 → is_integer() True
+    with patch("gdrive_cli.time") as mock_time:
+        mock_time.time.side_effect = [100.0, 100.0, 100.0, 100.0]
+        mock_time.sleep = MagicMock()
+        _acquire_or_bypass_lock(tool, args)
+    err = capsys.readouterr().err
+    assert "remaining 5s" in err
+
+
+def test_acquire_or_bypass_lock_wait_loop_fractional_remaining_display(capsys):
+    """When remaining time is fractional, display uses one-decimal format ('2.7s')."""
+    tool = MagicMock()
+    tool.state_manager._acquire_state_lock.side_effect = [False, True]
+    args = _args(lock_timeout=5.0)
+    # elapsed = 2.3 when remaining is computed → remaining = 2.7 → is_integer() False
+    with patch("gdrive_cli.time") as mock_time:
+        mock_time.time.side_effect = [100.0, 102.3, 102.3, 102.3]
+        mock_time.sleep = MagicMock()
+        _acquire_or_bypass_lock(tool, args)
+    err = capsys.readouterr().err
+    assert "remaining 2.7s" in err
+
+
+def test_acquire_or_bypass_lock_timeout_expires_returns_failure(capsys):
+    """When lock_timeout expires without acquiring, returns False with code 2."""
+    tool = MagicMock()
+    tool.state_manager._acquire_state_lock.side_effect = [False, False]
+    args = _args(lock_timeout=5.0, force=False)
+    # Last time.time() call returns start+6 so the while condition fails
+    with patch("gdrive_cli.time") as mock_time:
+        mock_time.time.side_effect = [100.0, 100.0, 100.0, 106.0]
+        mock_time.sleep = MagicMock()
+        with patch("gdrive_cli._read_lockfile_metadata", return_value=("999", "run-abc")):
+            with patch("gdrive_cli._check_pid_alive", return_value=""):
+                ok, code = _acquire_or_bypass_lock(tool, args)
+    assert not ok and code == 2
+
+
+# ---------------------------------------------------------------------------
+# _apply_retry_failed_file — empty-CSV error message (issue #1133)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_retry_failed_file_empty_csv_error_on_stderr(tmp_path, capsys):
+    """Empty retry CSV emits a single error to stderr and returns exit code 1."""
+    csv_file = tmp_path / "empty.csv"
+    csv_file.write_text("source_folder_id,file_id,target_path\n")
+    args = _args(retry_failed_file=str(csv_file), failed_file="")
+    ok, code = _apply_retry_failed_file(args)
+    assert not ok and code == 1
+    err = capsys.readouterr().err
+    assert "nothing to retry" in err
+    # Confirm no duplicate message on stdout
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary
This PR refactors the CLI help text into a module constant, improves error output routing, and makes minor code quality improvements.

## Key Changes

- **Extract help epilog to constant**: Moved ~66 lines of static argparse help text from `create_parser()` in `gdrive_cli.py` to a new `HELP_EPILOG` constant in `gdrive_constants.py`. The `%(prog)s` substitution and help output remain byte-for-byte identical.

- **Improve error output routing**: Updated `_validate_concurrency_arg()` to route both its invalid-value error and concurrency-cap warning to stderr (via `file=sys.stderr`), making it consistent with all other validators in the module.

- **Consolidate retry-failed messaging**: Removed duplicate "nothing to retry" warning from `_load_retry_failed_file()`. The single authoritative error message now lives only in `_apply_retry_failed_file()`, which also owns the non-zero exit code for that condition.

- **Improve lock-wait countdown logic**: Replaced `int(remaining) == remaining` with the more idiomatic `remaining.is_integer()` in `_acquire_or_bypass_lock()` for deciding between whole-second and fractional lock-wait countdown formatting.

- **Version bump**: Updated VERSION from 1.26.9 to 1.26.10.

## Implementation Details

- The help text extraction is purely structural; no functional changes to argument parsing or help output.
- Error routing changes improve consistency and make debugging easier by ensuring all validation errors go to stderr.
- The retry-failed messaging consolidation eliminates redundant warnings while preserving the error signal.

https://claude.ai/code/session_01AZww67HZrKdie57PFFLbBu