### PR TITLE
test(expand-zipsandclean): collapse redundant script-helper tests (Show-ProgressPhase, Write-ExtractionSummary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ kept here — see the linked file for details.
 ### Changed
 
 - **[Expand-ZipsAndClean tests]** Collapsed redundant helper assertions in `Show-ProgressPhase` and `Write-ExtractionSummary` blocks to keep script-helper coverage behavior-focused while reducing duplicate setup/output checks (issue #1080).
+- **[Expand-ZipsAndClean tests]** Restored explicit interactive (ConsoleHost) header assertion for `Write-ExtractionSummary` without `-PassThru`, protecting the default output path from regressions after helper-test consolidation (issue #1080 follow-up).
 - **[Core/Zip tests]** Relocated Zip module extraction tests from `Expand-ZipsAndClean.Tests.ps1` into dedicated `tests/powershell/modules/Core/Zip/Zip.Tests.ps1` for module-scoped ownership and clearer suite boundaries (issue #1076).
 - **[gdrive_recover docs]** Moved `gdrive_recover.py` embedded usage examples to `docs/gdrive-recover-usage.md` and linked the new page from README (issue #1117).
 - **[Expand-ZipsAndClean 2.5.2]** Replaced script-local `Write-PhaseProgress` usage with shared `Core/Progress` `Show-Progress` (via `Show-ProgressPhase` adapter) and added `Show-Progress -Suppress` for quiet-mode suppression (issue #1063).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ kept here — see the linked file for details.
 
 ### Changed
 
+- **[Expand-ZipsAndClean tests]** Collapsed redundant helper assertions in `Show-ProgressPhase` and `Write-ExtractionSummary` blocks to keep script-helper coverage behavior-focused while reducing duplicate setup/output checks (issue #1080).
 - **[Core/Zip tests]** Relocated Zip module extraction tests from `Expand-ZipsAndClean.Tests.ps1` into dedicated `tests/powershell/modules/Core/Zip/Zip.Tests.ps1` for module-scoped ownership and clearer suite boundaries (issue #1076).
 - **[gdrive_recover docs]** Moved `gdrive_recover.py` embedded usage examples to `docs/gdrive-recover-usage.md` and linked the new page from README (issue #1117).
 - **[Expand-ZipsAndClean 2.5.2]** Replaced script-local `Write-PhaseProgress` usage with shared `Core/Progress` `Show-Progress` (via `Show-ProgressPhase` adapter) and added `Show-Progress -Suppress` for quiet-mode suppression (issue #1063).

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Tests
+
+- Collapsed redundant script-helper assertions in `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` for:
+  - `Describe 'Show-ProgressPhase'`: merged duplicate active-mode `Write-Progress` checks (percent and `CurrentOperation`) into one consolidated payload test; retained quiet-mode suppression, completed-state, and zero-total guard coverage.
+  - `Describe 'Write-ExtractionSummary'`: merged interactive header emission and `-PassThru` summary-object field assertions into one test; retained non-interactive no-output behavior and non-interactive error-note emission coverage.
+- Net result: lower duplication in helper-focused tests with equivalent behavioral coverage intent (issue #1080).
+
 ## 2.6.2 — 2026-05-24
 
 ### Removed

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -7,6 +7,7 @@
 - Collapsed redundant script-helper assertions in `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` for:
   - `Describe 'Show-ProgressPhase'`: merged duplicate active-mode `Write-Progress` checks (percent and `CurrentOperation`) into one consolidated payload test; retained quiet-mode suppression, completed-state, and zero-total guard coverage.
   - `Describe 'Write-ExtractionSummary'`: merged interactive header emission and `-PassThru` summary-object field assertions into one test; retained non-interactive no-output behavior and non-interactive error-note emission coverage.
+- Follow-up coverage hardening: added a dedicated `Write-ExtractionSummary` assertion that `ConsoleHost` emits the summary header **without** `-PassThru`, preserving explicit validation of the default interactive output path.
 - Net result: lower duplication in helper-focused tests with equivalent behavioral coverage intent (issue #1080).
 
 ## 2.6.2 — 2026-05-24

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -52,6 +52,7 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
   - Collapsed redundant script-helper tests in `Expand-ZipsAndClean.Tests.ps1` for `Show-ProgressPhase` and `Write-ExtractionSummary`.
   - Combined duplicate progress assertions into a single active-mode payload test, retaining quiet suppression, completed-state, and zero-total guard coverage.
   - Merged interactive summary header and `-PassThru` payload-shape checks into one test while preserving non-interactive/no-error suppression and non-interactive/error-note coverage.
+  - Follow-up: restored a dedicated interactive `ConsoleHost` header assertion **without** `-PassThru` to ensure the default summary output path remains explicitly covered.
 
 - **Expand-ZipsAndClean.ps1 v2.6.0 review follow-up** (2026-05-23)
   - Restored explicit/named-parameter wrappers for extraction orchestration delegation so script call sites keep normal binding semantics.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -48,6 +48,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean helper-test cleanup** (2026-05-24)
+  - Collapsed redundant script-helper tests in `Expand-ZipsAndClean.Tests.ps1` for `Show-ProgressPhase` and `Write-ExtractionSummary`.
+  - Combined duplicate progress assertions into a single active-mode payload test, retaining quiet suppression, completed-state, and zero-total guard coverage.
+  - Merged interactive summary header and `-PassThru` payload-shape checks into one test while preserving non-interactive/no-error suppression and non-interactive/error-note coverage.
+
 - **Expand-ZipsAndClean.ps1 v2.6.0 review follow-up** (2026-05-23)
   - Restored explicit/named-parameter wrappers for extraction orchestration delegation so script call sites keep normal binding semantics.
   - Moved parallel runspace helper `Expand-ZipInRunspace` into the new `FileManagement/ZipExtraction` module private scope to keep parallel mode self-contained.

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -281,24 +281,18 @@ Describe 'Show-ProgressPhase' {
         Should -Invoke Write-Progress -Times 0
     }
 
-    It 'calls Write-Progress with computed percentage when QuietMode is false' {
+    It 'passes expected progress payload to Write-Progress in active mode' {
         Mock Write-Progress { }
 
         Show-ProgressPhase -Activity 'Extracting' -Status 'file.zip' -Current 2 -Total 4 -QuietMode $false
+        Show-ProgressPhase -Activity 'Moving' -Status '1 / 3 : a.zip' `
+            -Current 1 -Total 3 -QuietMode $false -CurrentOperation 'Moving: 10 B of 30 B bytes'
 
         Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
             $Activity -eq 'Extracting' -and
             $Status -eq 'file.zip' -and
             $PercentComplete -eq 50
         }
-    }
-
-    It 'includes CurrentOperation when provided' {
-        Mock Write-Progress { }
-
-        Show-ProgressPhase -Activity 'Moving' -Status '1 / 3 : a.zip' `
-            -Current 1 -Total 3 -QuietMode $false -CurrentOperation 'Moving: 10 B of 30 B bytes'
-
         Should -Invoke Write-Progress -Times 1 -Exactly -ParameterFilter {
             $CurrentOperation -eq 'Moving: 10 B of 30 B bytes'
         }
@@ -355,19 +349,29 @@ Describe 'Write-ExtractionSummary' {
         $script:testElapsed = [timespan]::FromSeconds(2.5)
     }
 
-    It 'emits summary header when host is interactive (ConsoleHost)' {
+    It 'emits interactive summary header and view payload' {
         Mock Format-Table { }
         Mock Format-List  { }
 
-        $output = @(Write-ExtractionSummary `
-            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+        $allOutput = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\mysrc' -DestinationDirectory 'C:\mydest' `
             -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 5 -ProcessedZips 5 -FilesExtracted 20 `
-            -UncompressedBytes ([int64]1000000) -CompressedBytes ([int64]300000) `
+            -ZipCount 7 -ProcessedZips 6 -FilesExtracted 30 `
+            -UncompressedBytes ([int64]2000000) -CompressedBytes ([int64]600000) `
             -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
-            -Elapsed $script:testElapsed -HostName 'ConsoleHost')
+            -Elapsed ([timespan]::FromSeconds(10)) -HostName 'ConsoleHost' -PassThru)
 
-        $output | Should -Contain '==== Expand-ZipsAndClean Summary ===='
+        $allOutput | Should -Contain '==== Expand-ZipsAndClean Summary ===='
+        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
+
+        $view             | Should -Not -BeNullOrEmpty
+        $view.SrcDir      | Should -Be 'C:\mysrc'
+        $view.DestDir     | Should -Be 'C:\mydest'
+        $view.ZipsFound   | Should -Be 7
+        $view.ZipsDone    | Should -Be 6
+        $view.Files       | Should -Be 30
+        $view.Ratio       | Should -Be '3.3x'
+        $view.Duration    | Should -BeLike '00:00:10*'
     }
 
     It 'suppresses summary table and header when non-interactive and no errors' {
@@ -407,31 +411,6 @@ Describe 'Write-ExtractionSummary' {
         ($output | Where-Object { $_ -like '* - Archive is corrupt' }) | Should -Not -BeNullOrEmpty
     }
 
-    It 'summary view contains expected fields (SrcDir, ZipsFound, Ratio, Duration)' {
-        # -PassThru emits the PSCustomObject to the pipeline alongside string output;
-        # filter by type to extract it without relying on Format-Table/-List mocks.
-        Mock Format-Table { }
-        Mock Format-List  { }
-
-        $allOutput = @(Write-ExtractionSummary `
-            -SourceDirectory 'C:\mysrc' -DestinationDirectory 'C:\mydest' `
-            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 7 -ProcessedZips 6 -FilesExtracted 30 `
-            -UncompressedBytes ([int64]2000000) -CompressedBytes ([int64]600000) `
-            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
-            -Elapsed ([timespan]::FromSeconds(10)) -HostName 'ConsoleHost' -PassThru)
-
-        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
-
-        $view             | Should -Not -BeNullOrEmpty
-        $view.SrcDir      | Should -Be 'C:\mysrc'
-        $view.DestDir     | Should -Be 'C:\mydest'
-        $view.ZipsFound   | Should -Be 7
-        $view.ZipsDone    | Should -Be 6
-        $view.Files       | Should -Be 30
-        $view.Ratio       | Should -Be '3.3x'
-        $view.Duration    | Should -BeLike '00:00:10*'
-    }
 }
 
 Describe 'Invoke-ZipExtractions resolves to ZipExtraction module' {

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -374,6 +374,21 @@ Describe 'Write-ExtractionSummary' {
         $view.Duration    | Should -BeLike '00:00:10*'
     }
 
+    It 'emits interactive summary header without requiring PassThru' {
+        Mock Format-Table { }
+        Mock Format-List  { }
+
+        $output = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 5 -ProcessedZips 5 -FilesExtracted 20 `
+            -UncompressedBytes ([int64]1000000) -CompressedBytes ([int64]300000) `
+            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
+            -Elapsed $script:testElapsed -HostName 'ConsoleHost')
+
+        $output | Should -Contain '==== Expand-ZipsAndClean Summary ===='
+    }
+
     It 'suppresses summary table and header when non-interactive and no errors' {
         Mock Format-Table { }
         Mock Format-List  { }


### PR DESCRIPTION
### Motivation
- Reduce duplicated assertions in script-local helper tests to keep coverage behavior-focused and easier to maintain (issue #1080). 
- Prevent fragile/redundant test scaffolding while preserving coverage of quiet-mode suppression, completed-state, zero-total guard, non-interactive suppression, and error-note emission.

### Description
- Consolidated duplicate assertions in `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` by merging active-mode `Show-ProgressPhase` checks into one payload-focused test and combining interactive header + `-PassThru` payload assertions for `Write-ExtractionSummary` while retaining other guard/error tests. 
- Updated repository-level `CHANGELOG.md` with an Unreleased `Changed` entry for the helper-test collapse and added a note to `src/powershell/file-management/README.md` under `Recent Updates`. 
- Added a `Tests` entry to `src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md` describing the collapsed helper assertions and retained coverage goals. 
- Committed changes using a commitizen-style message: `test(expand-zipsandclean): collapse redundant helper assertions`.

### Testing
- Attempted to run the updated helper suite with `Invoke-Pester tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1 -PassThru`, but the runner lacks `pwsh` and the command failed with `pwsh: command not found`. 
- No other automated test failures were observed in this environment because PowerShell/Pester execution was not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131bb123ac832590c5aa5420309174)