### PR TITLE
fix(expand-zipsandclean): correct help attribution and whitespace env defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ kept here — see the linked file for details.
 
 ### Fixed
 
+- **[Expand-ZipsAndClean 2.6.4]** Fixed misattributed comment-help for env-var default
+  overrides (`SourceDirectory` → `EXPAND_ZIPS_SOURCE_DIR`, `DestinationDirectory` →
+  `EXPAND_ZIPS_DEST_DIR`) and corrected parameter-default resolution so whitespace-only
+  env-var values are treated as unset and correctly fall back to profile-relative defaults
+  (issue #1094).
 - **[Core/Zip tests]** Corrected relative `Import-Module` paths in `tests/powershell/modules/Core/Zip/Zip.Tests.ps1` after relocation so `Invoke-Pester` resolves `src/powershell/modules/...` correctly from `tests/powershell/modules/Core/Zip` (issue #1076).
 - **[Expand-ZipsAndClean]** `Remove-SourceDirectory` reliability series (v2.1.2–v2.1.8):
   iterative fixes to non-zip filter logic, deepest-first deletion ordering, transient

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -310,6 +310,7 @@ These variables enable email notifications for script execution results and erro
 - **Example**: `C:\Users\YourName\Downloads\picconvert` (Windows) or `/home/yourname/Downloads/picconvert` (Linux)
 - **Used By**: `src/powershell/file-management/Expand-ZipsAndClean.ps1`
 - **Precedence**: `$env:EXPAND_ZIPS_SOURCE_DIR` → `$HOME/Downloads/picconvert`
+- **Blank Handling**: Whitespace-only values are treated as unset and fall back to `$HOME/Downloads/picconvert`
 
 #### EXPAND_ZIPS_DEST_DIR
 - **Required**: No
@@ -319,6 +320,7 @@ These variables enable email notifications for script execution results and erro
 - **Example**: `C:\Users\YourName\Desktop\New folder` (Windows) or `/home/yourname/Desktop/New folder` (Linux)
 - **Used By**: `src/powershell/file-management/Expand-ZipsAndClean.ps1`
 - **Precedence**: `$env:EXPAND_ZIPS_DEST_DIR` → `$HOME/Desktop/New folder`
+- **Blank Handling**: Whitespace-only values are treated as unset and fall back to `$HOME/Desktop/New folder`
 
 ---
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Fixed
+
+- Corrected comment-based help attribution for default override environment variables:
+  `SourceDirectory` now explicitly references `EXPAND_ZIPS_SOURCE_DIR` and
+  `DestinationDirectory` references `EXPAND_ZIPS_DEST_DIR`.
+- Fixed parameter default resolution so whitespace-only values in
+  `EXPAND_ZIPS_SOURCE_DIR` / `EXPAND_ZIPS_DEST_DIR` are treated as unset and fall back
+  to profile-relative defaults (`$HOME/Downloads/picconvert`, `$HOME/Desktop/New folder`).
+
 ### Tests
 
 - Removed four low-value/duplicate tests from `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1`:
@@ -16,7 +25,7 @@
 
 ### Versioning
 
-- Bumped version to `2.6.3` (patch — test-suite maintenance only; no runtime behavior change).
+- Bumped version to `2.6.4` (patch — comment-help attribution fix + whitespace env-var default resolution fix).
 
 ## 2.6.2 — 2026-05-24
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -33,7 +33,7 @@ using namespace System.Collections.Concurrent
       archive appears to be password-protected.
 
 .PARAMETER SourceDirectory
-    Directory containing .zip files to extract.
+    Directory containing .zip files to extract (default override via EXPAND_ZIPS_SOURCE_DIR).
     Default resolved in order:
       1. Environment variable EXPAND_ZIPS_SOURCE_DIR (if set, non-null, and non-blank)
       2. Join-Path $HOME 'Downloads/picconvert'
@@ -41,7 +41,7 @@ using namespace System.Collections.Concurrent
     and the profile-relative fallback is used instead.
 
 .PARAMETER DestinationDirectory
-    Directory to extract contents into.
+    Directory to extract contents into (default override via EXPAND_ZIPS_DEST_DIR).
     Default resolved in order:
       1. Environment variable EXPAND_ZIPS_DEST_DIR (if set, non-null, and non-blank)
       2. Join-Path $HOME 'Desktop/New folder'
@@ -122,7 +122,7 @@ using namespace System.Collections.Concurrent
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.3
+    Version  : 2.6.4
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)
@@ -143,12 +143,12 @@ param(
     [Parameter()]
     [Alias('Src')]
     [ValidateNotNullOrEmpty()]
-    [string]$SourceDirectory = ($env:EXPAND_ZIPS_SOURCE_DIR ? $env:EXPAND_ZIPS_SOURCE_DIR : (Join-Path $HOME 'Downloads/picconvert')),
+    [string]$SourceDirectory = ([string]::IsNullOrWhiteSpace($env:EXPAND_ZIPS_SOURCE_DIR) ? (Join-Path $HOME 'Downloads/picconvert') : $env:EXPAND_ZIPS_SOURCE_DIR),
 
     [Parameter()]
     [Alias('Dest')]
     [ValidateNotNullOrEmpty()]
-    [string]$DestinationDirectory = ($env:EXPAND_ZIPS_DEST_DIR ? $env:EXPAND_ZIPS_DEST_DIR : (Join-Path $HOME 'Desktop/New folder')),
+    [string]$DestinationDirectory = ([string]::IsNullOrWhiteSpace($env:EXPAND_ZIPS_DEST_DIR) ? (Join-Path $HOME 'Desktop/New folder') : $env:EXPAND_ZIPS_DEST_DIR),
 
     [Parameter()]
     [ValidateSet('PerArchiveSubfolder', 'Flat')]

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -48,6 +48,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean comment-help and env-var default fix** (2026-05-24)
+  - Corrected comment-help attribution so `SourceDirectory` maps to `EXPAND_ZIPS_SOURCE_DIR` and `DestinationDirectory` maps to `EXPAND_ZIPS_DEST_DIR`.
+  - Fixed default resolution logic to treat whitespace-only `EXPAND_ZIPS_SOURCE_DIR` / `EXPAND_ZIPS_DEST_DIR` values as unset and use profile-relative fallbacks.
+  - Version bump: `2.6.4` (patch — bug fix, no breaking change).
+
 - **Expand-ZipsAndClean test-suite pruning** (2026-05-24)
   - Removed four low-value/duplicate tests from `Expand-ZipsAndClean.Tests.ps1` (28 → 24 tests).
   - Dropped the dedicated `Write-ExtractionSummary` non-`-PassThru` interactive-header test because interactive header output is already asserted by the existing `-PassThru` interactive coverage.


### PR DESCRIPTION
### Motivation
- Fix misattributed comment-based help so each parameter documents the correct environment-variable override for default values.
- Ensure parameter default resolution treats whitespace-only env-var values as unset so profile-relative fallbacks are used instead of invalid blank paths.

### Description
- Changed parameter default expressions in `Expand-ZipsAndClean.ps1` to use `[string]::IsNullOrWhiteSpace(...)` for `EXPAND_ZIPS_SOURCE_DIR` and `EXPAND_ZIPS_DEST_DIR` so whitespace-only env values are treated as unset.
- Updated the script `.NOTES` version from `2.6.3` to `2.6.4` to reflect the patch change.
- Corrected comment-help text for `.PARAMETER SourceDirectory` and `.PARAMETER DestinationDirectory` to explicitly reference `EXPAND_ZIPS_SOURCE_DIR` and `EXPAND_ZIPS_DEST_DIR` respectively.
- Updated documentation and metadata: `src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md`, top-level `CHANGELOG.md`, `src/powershell/file-management/README.md`, and `docs/ENVIRONMENT.md` to record the fix and the blank/whitespace handling behavior.

### Testing
- Attempted to run the `Expand-ZipsAndClean` Pester suite via `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1 ..."` but the environment lacks `pwsh` so the automated test run could not be executed (`pwsh: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1326b82b448325a7d3d48bb27d37ec)