### PR TITLE
fix(show-randomimage): log permission-denied file path before open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ kept here — see the linked file for details.
 
 ### Fixed
 
+- **[Show-RandomImage 2.3.1]** Added an explicit read-permission pre-check before `Invoke-Item`; permission-denied selections now emit a console-visible error with the full path and skip viewer handoff (issue #1151).
 - **[Move-ImageFileToBatch 2.1.0]** Renamed `-LogFilePath` to `-LogDirectory` and passed it
   to `Initialize-Logger` so the framework log is written to the caller-supplied directory
   instead of the module default; fixed error-log path derivation in `Write-RunSummary` to

--- a/src/powershell/media/README.md
+++ b/src/powershell/media/README.md
@@ -46,6 +46,10 @@ The Videoscreenshot module has been moved to `src/powershell/modules/Media/Video
 
 All scripts use the PowerShell Logging Framework for structured logging.
 
+## Troubleshooting
+
+- **Show-RandomImage permission denied**: if the selected media file is not readable by the current user, the script now logs a console error that includes the full file path and skips opening the file in the external viewer.
+
 ### Move-ImageFileToBatch.ps1
 
 Use `-LogDirectory` to control where log files are written:

--- a/src/powershell/media/Show-RandomImage.ps1
+++ b/src/powershell/media/Show-RandomImage.ps1
@@ -3,9 +3,13 @@
 This PowerShell script selects and opens a random media file (image or video) from a random subfolder or the main target folder in the specified directory.
 
 .VERSION
-2.3.0
+2.3.1
 
 # Changelog
+## [2.3.1] — 2026-05-27
+### Fixed
+- Added a read-access pre-check before `Invoke-Item` so permission-denied media files now log a clear console error with the full file path and are not handed off silently to the viewer.
+
 ## [2.3.0] — 2026-03-26
 ### Added
 - `.mp4` files are now included as valid candidates alongside `.jpg`, `.jpeg`, and `.png`.
@@ -103,7 +107,7 @@ param(
 
 # Script metadata
 # Expose version programmatically for logs/tests if needed.
-$Script:ScriptVersion = '2.3.0'
+$Script:ScriptVersion = '2.3.1'
 
 # Import logging framework
 Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
@@ -171,6 +175,23 @@ if ($files.Count -gt 0) {
     # Select a random file and open it
     $randomFile = $files | Get-Random
     Write-LogInfo "Opening file: $($randomFile.Name)"
+
+    # Pre-check read access before shell hand-off.
+    try {
+        $readProbe = [System.IO.File]::OpenRead($randomFile.FullName)
+        $readProbe.Close()
+        $readProbe.Dispose()
+    }
+    catch [System.UnauthorizedAccessException] {
+        Write-LogError "Read access denied for selected file: $($randomFile.FullName)"
+        Write-Warning ("Read access denied for selected file: {0}" -f $randomFile.FullName)
+        return
+    }
+    catch {
+        Write-LogError "Unable to verify read access for '$($randomFile.FullName)': $($_.Exception.Message)"
+        Write-Warning ("Unable to verify read access for '{0}': {1}" -f $randomFile.FullName, $_.Exception.Message)
+        return
+    }
 
     # Opening the selected media file; wrap in try/catch for user-friendly feedback
     try {


### PR DESCRIPTION
### Motivation

- Selected media files that were inaccessible due to read permissions were being handed off to the shell/viewer without emitting a clear console-visible error, making the failure silent and hard to diagnose.

### Description

- Add a read-access probe using `[System.IO.File]::OpenRead` immediately before `Invoke-Item`, with targeted handling for `UnauthorizedAccessException` that logs the full file path and skips viewer handoff.
- Add a fallback catch that logs a verification failure message and skips handoff for other read-probe errors.
- Bump the script inline version to `2.3.1` and add a `2.3.1` entry to the script changelog documenting the fix.
- Update `src/powershell/media/README.md` with a troubleshooting note and add an `Unreleased` entry in the repository `CHANGELOG.md` for `Show-RandomImage 2.3.1` referencing issue #1151.

### Testing

- Attempted to run a PowerShell parse check with `pwsh -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('src/powershell/media/Show-RandomImage.ps1',[ref]$null,[ref]$null); 'parse-ok'"`, but `pwsh` is not present in the execution environment so the parse verification could not be executed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1652388be8832584e0c52e6f83c89e)