### PR TITLE
Add idle-frame stall detection to VLC snapshot monitoring

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,16 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.0.9] - 2026-05-27
+### Fixed
+- **VLC snapshot hang on undecodable videos**: `Wait-ForSnapshotFrames` previously waited the full `SnapshotFallbackTimeoutSeconds` (~300 s) when VLC stalled on a corrupt or unsupported video. Undecodable files are now abandoned within `SnapshotIdleTimeoutSeconds` (~20 s by default).
+
+### Added
+- **Idle-frame stall detection** in `Wait-ForSnapshotFrames` (`Private/Snapshot.Monitor.ps1`): tracks the timestamp of the last frame-count increase and breaks out early when no new frame appears for `IdleTimeoutSeconds` while the VLC process is still alive. A `Warn`-level message is emitted when the idle break fires.
+- **`WarmUpSeconds` parameter** on `Wait-ForSnapshotFrames`: suppresses idle detection for an initial window so slow-starting sources (cold network shares, large files) are not killed before their first frame arrives.
+- **`SnapshotIdleTimeoutSeconds`** (default `20`) and **`SnapshotIdleWarmUpSeconds`** (default `10`) in `Get-DefaultConfig` (`Private/Config.ps1`).
+- **Pester tests** for `Wait-ForSnapshotFrames` (`tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1`) covering: idle-break fires on stalled process, idle detection disabled when `IdleTimeoutSeconds=0`, warm-up suppresses premature break, idle fires after warm-up, normal completion via process exit, correct `FramesDelta` return.
+
 ## [3.0.5] - 2026-01-03
 ### Fixed
 - **Processed videos tracking**: Fixed bug where some videos, despite being processed and having screenshots taken, were not being written to the `.processed_videos` file, causing unnecessary reprocessing on restart. Changes include:

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -49,6 +49,17 @@ function Get-DefaultConfig {
         # Typical range: 2–10 s.
         SnapshotTerminationExtraSeconds = 5
 
+        # Seconds without a new frame before Wait-ForSnapshotFrames abandons a stalled
+        # VLC session (idle-frame stall detection). Only triggers after the warm-up window
+        # elapses. Set to 0 to disable. Typical range: 10–60 s.
+        SnapshotIdleTimeoutSeconds      = 20
+
+        # Seconds at the start of a snapshot session during which idle detection is
+        # suppressed, to allow slow-starting sources (e.g., cold network shares) to
+        # produce their first frame before the idle timer starts counting.
+        # Typical range: 5–30 s.
+        SnapshotIdleWarmUpSeconds       = 10
+
         # Milliseconds to wait after CloseMainWindow() before force-terminating VLC
         # in Stop-Vlc. Larger values are gentler on VLC; smaller values speed up
         # teardown on stubborn processes. Typical range: 2000–10000 ms.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Monitor.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Monitor.ps1
@@ -14,6 +14,12 @@ function Wait-ForSnapshotFrames {
   Optional VLC process to monitor. When provided, polling stops early after process exits + grace period.
   .PARAMETER GracePeriodSeconds
   Seconds to continue polling after VLC exits to capture buffered frames (default 2).
+  .PARAMETER IdleTimeoutSeconds
+  Seconds without a new frame before breaking early (idle-frame stall detection). Only active after
+  WarmUpSeconds have elapsed and while the process is still alive. Set to 0 to disable (default).
+  .PARAMETER WarmUpSeconds
+  Seconds at the start of the session during which idle detection is suppressed, to allow
+  slow-starting sources to produce their first frame (default 10).
   .OUTPUTS
   PSCustomObject with FramesDelta and ElapsedSeconds.
   #>
@@ -24,18 +30,23 @@ function Wait-ForSnapshotFrames {
         [ValidateRange(1, 86400)][int]$MaxSeconds = 300,
         [ValidateRange(50, 5000)][int]$PollMs = 200,
         [System.Diagnostics.Process]$Process,
-        [ValidateRange(0, 60)][int]$GracePeriodSeconds = 2
+        [ValidateRange(0, 60)][int]$GracePeriodSeconds = 2,
+        [ValidateRange(0, 3600)][int]$IdleTimeoutSeconds = 0,
+        [ValidateRange(0, 3600)][int]$WarmUpSeconds = 10
     )
     $start = Get-Date
     $pattern = "$ScenePrefix*.png"
     $initial = (Get-ChildItem -Path $SaveFolder -Filter $pattern -File -ErrorAction SilentlyContinue | Measure-Object).Count
     $lastCount = $initial
     $vlcExitTime = $null
+    $lastFrameTime = $start
 
     while ((New-TimeSpan -Start $start -End (Get-Date)).TotalSeconds -lt $MaxSeconds) {
+        $now = Get-Date
         $count = (Get-ChildItem -Path $SaveFolder -Filter $pattern -File -ErrorAction SilentlyContinue | Measure-Object).Count
         if ($count -gt $lastCount) {
             $lastCount = $count
+            $lastFrameTime = $now
         }
 
         # Check if VLC has exited (early termination to prevent duplicate screenshots)
@@ -44,7 +55,7 @@ function Wait-ForSnapshotFrames {
                 $Process.Refresh()
                 if ($Process.HasExited) {
                     if ($null -eq $vlcExitTime) {
-                        $vlcExitTime = Get-Date
+                        $vlcExitTime = $now
                         Write-Debug "VLC exited; continuing for grace period of $GracePeriodSeconds seconds"
                     }
                     # Exit polling after grace period to avoid duplicate frames
@@ -53,11 +64,22 @@ function Wait-ForSnapshotFrames {
                         break
                     }
                 }
+                elseif ($IdleTimeoutSeconds -gt 0) {
+                    # Idle-frame stall detection: only fire after warm-up window has elapsed
+                    $elapsed = (New-TimeSpan -Start $start -End $now).TotalSeconds
+                    if ($elapsed -ge $WarmUpSeconds) {
+                        $idleSeconds = (New-TimeSpan -Start $lastFrameTime -End $now).TotalSeconds
+                        if ($idleSeconds -ge $IdleTimeoutSeconds) {
+                            Write-Message -Level Warn -Message ("Idle-frame stall detected: no new frames for {0:F0}s; abandoning VLC session early." -f $idleSeconds)
+                            break
+                        }
+                    }
+                }
             }
             catch {
                 # Process object may be disposed; treat as exited
                 if ($null -eq $vlcExitTime) {
-                    $vlcExitTime = Get-Date
+                    $vlcExitTime = $now
                 }
             }
         }

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -352,7 +352,9 @@ function Start-VideoBatch {
                 $baseWait = if ($capSeconds -gt 0) { [int]$capSeconds } else { [int]$context.Config.SnapshotFallbackTimeoutSeconds }
                 $waitSeconds = [int]([Math]::Max(1, $baseWait + [int]$StartupGraceSeconds))
                 Write-Debug ("TRACE Start-VideoBatch: about to call Wait-ForSnapshotFrames (MaxSeconds={0}, Prefix={1})" -f $waitSeconds, $scenePrefix)
-                $snapStats = Wait-ForSnapshotFrames -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -MaxSeconds $waitSeconds -Process $p
+                $snapStats = Wait-ForSnapshotFrames -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -MaxSeconds $waitSeconds -Process $p `
+                    -IdleTimeoutSeconds ([int]$context.Config.SnapshotIdleTimeoutSeconds) `
+                    -WarmUpSeconds ([int]$context.Config.SnapshotIdleWarmUpSeconds)
                 $snapType = if ($null -ne $snapStats) { $snapStats.GetType().FullName } else { '<null>' }
                 $snapStr = if ($null -ne $snapStats) { $snapStats.ToString() } else { '<null>' }
                 Write-Debug ("TRACE Start-VideoBatch: Wait-ForSnapshotFrames returned type={0} tostring={1}" -f $snapType, $snapStr)

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -332,3 +332,16 @@ For module history, see this folder’s `CHANGELOG.md`. For repository-wide chan
 
 ### Notes on timings
 Runtime measurements reported by the cropper use wall-clock time (not CPU time) to better reflect I/O-bound workloads.
+
+### Idle-frame stall detection (VLC snapshot mode)
+When VLC cannot decode a file (corrupt, unsupported codec, zero-duration stream), it stalls indefinitely with a black screen. The module detects this situation and abandons the session early rather than waiting for the full fallback timeout.
+
+Key config knobs (in `Get-DefaultConfig`, `Private/Config.ps1`):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `SnapshotIdleTimeoutSeconds` | `20` | Seconds without a new frame before the session is abandoned. Set to `0` to disable. |
+| `SnapshotIdleWarmUpSeconds` | `10` | Seconds at session start during which idle detection is suppressed (allows slow-starting sources their first frame). |
+| `SnapshotFallbackTimeoutSeconds` | `300` | Hard cap when no per-video duration is specified. |
+
+A `WARNING` log line is emitted when idle-break fires so the problem video is visible in the run log.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.0.8'
+  ModuleVersion     = '3.0.9'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.0.8: Replaced hardcoded --no-audio with a -NoAudio switch parameter; use it when the VLC audio plugin crashes on your system.'
+      ReleaseNotes = '3.0.9: Added idle-frame stall detection to Wait-ForSnapshotFrames; undecodable videos are now abandoned in ~SnapshotIdleTimeoutSeconds (default 20 s) instead of hanging for the full ~300 s fallback timeout.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -22,14 +22,14 @@ BeforeAll {
 
     # Starts a real process that stays alive for the duration of a test.
     # -WindowStyle is intentionally omitted: it is Windows-only and throws on Linux.
-    function script:New-LongRunningProcess {
+    function Script:New-LongRunningProcess {
         Start-Process -FilePath $script:PwshExe `
             -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 120' `
             -PassThru
     }
 
     # Starts a real process that exits immediately and waits for it to finish.
-    function script:New-AlreadyExitedProcess {
+    function Script:New-AlreadyExitedProcess {
         $p = Start-Process -FilePath $script:PwshExe `
             -ArgumentList '-NoProfile', '-Command', 'exit 0' `
             -PassThru
@@ -37,7 +37,7 @@ BeforeAll {
         $p
     }
 
-    function script:New-TempSnapshotFolder {
+    function Script:New-TempSnapshotFolder {
         param([string]$Prefix = 'prefix_', [int]$PngCount = 0)
         $dir = New-Item -ItemType Directory `
             -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) `
@@ -57,8 +57,8 @@ Describe 'Wait-ForSnapshotFrames' {
     Context 'idle-frame stall detection' {
 
         It 'breaks early when no new frames appear past the idle timeout while process is alive' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 3
-            $proc = script:New-LongRunningProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 3
+            $proc = Script:New-LongRunningProcess
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 $result = Wait-ForSnapshotFrames `
@@ -79,8 +79,8 @@ Describe 'Wait-ForSnapshotFrames' {
         }
 
         It 'does not idle-break when IdleTimeoutSeconds is 0 (detection disabled)' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 2
-            $proc = script:New-LongRunningProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 2
+            $proc = Script:New-LongRunningProcess
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 # MaxSeconds=3 is the only exit; idle detection is off
@@ -104,8 +104,8 @@ Describe 'Wait-ForSnapshotFrames' {
     Context 'warm-up grace period' {
 
         It 'suppresses idle detection during the warm-up window' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
-            $proc = script:New-LongRunningProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            $proc = Script:New-LongRunningProcess
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 # Without warm-up, IdleTimeout=1 would fire in ~1 s.
@@ -127,8 +127,8 @@ Describe 'Wait-ForSnapshotFrames' {
         }
 
         It 'fires idle detection after the warm-up window expires' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
-            $proc = script:New-LongRunningProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            $proc = Script:New-LongRunningProcess
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 # WarmUp=2 + IdleTimeout=1 → idle break at ~3 s; MaxSeconds generous
@@ -152,8 +152,8 @@ Describe 'Wait-ForSnapshotFrames' {
     Context 'normal completion via VLC process exit' {
 
         It 'stops after the grace period when VLC has already exited' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 5
-            $proc = script:New-AlreadyExitedProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 5
+            $proc = Script:New-AlreadyExitedProcess
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 $result = Wait-ForSnapshotFrames `
@@ -173,8 +173,8 @@ Describe 'Wait-ForSnapshotFrames' {
         }
 
         It 'returns correct FramesDelta and positive ElapsedSeconds' {
-            $folder = script:New-TempSnapshotFolder -Prefix 'clip_' -PngCount 2
-            $proc = script:New-AlreadyExitedProcess
+            $folder = Script:New-TempSnapshotFolder -Prefix 'clip_' -PngCount 2
+            $proc = Script:New-AlreadyExitedProcess
             try {
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'clip_' `

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -7,29 +7,44 @@ BeforeAll {
     $script:MonitorPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Snapshot.Monitor.ps1'
     $script:LoggingPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Logging.ps1'
 
-    if (-not (Test-Path -LiteralPath $script:MonitorPath)) {
-        throw "Snapshot.Monitor.ps1 not found: $script:MonitorPath"
-    }
-    if (-not (Test-Path -LiteralPath $script:LoggingPath)) {
-        throw "Logging.ps1 not found: $script:LoggingPath"
+    foreach ($f in $script:MonitorPath, $script:LoggingPath) {
+        if (-not (Test-Path -LiteralPath $f)) { throw "Required file not found: $f" }
     }
 
     . $script:LoggingPath
     . $script:MonitorPath
 
-    function script:New-MockProcess {
-        param([bool]$HasExited = $false)
-        $p = [pscustomobject]@{ HasExited = $HasExited }
-        $p | Add-Member -MemberType ScriptMethod -Name Refresh -Value {}
+    # Locate pwsh for spawning real System.Diagnostics.Process instances
+    $pwsh = Get-Command -Name 'pwsh' -ErrorAction SilentlyContinue
+    if (-not $pwsh) { $pwsh = Get-Command -Name 'powershell' -ErrorAction SilentlyContinue }
+    if (-not $pwsh) { throw 'No PowerShell executable found; cannot spawn real processes for tests.' }
+    $script:PwshExe = $pwsh.Source
+
+    # Starts a real process that stays alive for the duration of a test
+    function script:New-LongRunningProcess {
+        Start-Process -FilePath $script:PwshExe `
+            -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 120' `
+            -WindowStyle Hidden -PassThru
+    }
+
+    # Starts a real process that exits immediately and waits for it to finish
+    function script:New-AlreadyExitedProcess {
+        $p = Start-Process -FilePath $script:PwshExe `
+            -ArgumentList '-NoProfile', '-Command', 'exit 0' `
+            -WindowStyle Hidden -PassThru
+        $p.WaitForExit(10000) | Out-Null
         $p
     }
 
     function script:New-TempSnapshotFolder {
         param([string]$Prefix = 'prefix_', [int]$PngCount = 0)
-        $dir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) -Force
+        $dir = New-Item -ItemType Directory `
+            -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) `
+            -Force
         if ($PngCount -gt 0) {
             1..$PngCount | ForEach-Object {
-                New-Item -Path (Join-Path $dir.FullName ("{0}{1:D4}.png" -f $Prefix, $_)) -ItemType File -Force | Out-Null
+                New-Item -Path (Join-Path $dir.FullName ("{0}{1:D4}.png" -f $Prefix, $_)) `
+                    -ItemType File -Force | Out-Null
             }
         }
         $dir.FullName
@@ -42,9 +57,8 @@ Describe 'Wait-ForSnapshotFrames' {
 
         It 'breaks early when no new frames appear past the idle timeout while process is alive' {
             $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 3
+            $proc = script:New-LongRunningProcess
             try {
-                $proc = script:New-MockProcess -HasExited $false
-
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'vid_' `
@@ -58,17 +72,17 @@ Describe 'Wait-ForSnapshotFrames' {
                 $result.FramesDelta | Should -Be 0
             }
             finally {
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
                 Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
-        It 'does not idle-break when IdleTimeoutSeconds is 0 (disabled)' {
+        It 'does not idle-break when IdleTimeoutSeconds is 0 (detection disabled)' {
             $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 2
+            $proc = script:New-LongRunningProcess
             try {
-                $proc = script:New-MockProcess -HasExited $false
-
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
-                # MaxSeconds=3 caps the run; idle detection disabled → should run ~3s
+                # MaxSeconds=3 is the only exit; idle detection is off
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'vid_' `
                     -MaxSeconds 3 -PollMs 100 `
@@ -76,10 +90,11 @@ Describe 'Wait-ForSnapshotFrames' {
                     -IdleTimeoutSeconds 0 -WarmUpSeconds 0
                 $sw.Stop()
 
-                # Function ran for the full MaxSeconds, not cut short by idle detection
+                # Function ran for the full MaxSeconds, not cut short by idle
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
             }
             finally {
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
                 Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
@@ -89,12 +104,11 @@ Describe 'Wait-ForSnapshotFrames' {
 
         It 'suppresses idle detection during the warm-up window' {
             $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            $proc = script:New-LongRunningProcess
             try {
-                $proc = script:New-MockProcess -HasExited $false
-
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
-                # WarmUpSeconds=3 > IdleTimeoutSeconds=1: idle break must not fire inside warm-up
-                # MaxSeconds=5 caps the run so the test completes in reasonable time
+                # Without warm-up, IdleTimeout=1 would fire in ~1 s.
+                # WarmUpSeconds=3 pushes idle detection past the MaxSeconds=5 cap.
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'vid_' `
                     -MaxSeconds 5 -PollMs 100 `
@@ -102,21 +116,21 @@ Describe 'Wait-ForSnapshotFrames' {
                     -IdleTimeoutSeconds 1 -WarmUpSeconds 3
                 $sw.Stop()
 
-                # Without warm-up suppression the function would exit in ~1 s; with it, at least 3 s
+                # Must have run for at least the warm-up window, not bailed at 1 s
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2.5
             }
             finally {
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
                 Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
         It 'fires idle detection after the warm-up window expires' {
             $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            $proc = script:New-LongRunningProcess
             try {
-                $proc = script:New-MockProcess -HasExited $false
-
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
-                # WarmUp=2 + IdleTimeout=1 = should break at ~3 s; MaxSeconds is generous
+                # WarmUp=2 + IdleTimeout=1 → idle break at ~3 s; MaxSeconds generous
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'vid_' `
                     -MaxSeconds 60 -PollMs 100 `
@@ -124,11 +138,11 @@ Describe 'Wait-ForSnapshotFrames' {
                     -IdleTimeoutSeconds 1 -WarmUpSeconds 2
                 $sw.Stop()
 
-                # Should break around WarmUp+IdleTimeout, well before MaxSeconds=60
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
                 $sw.Elapsed.TotalSeconds | Should -BeLessThan 15
             }
             finally {
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
                 Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
@@ -138,9 +152,8 @@ Describe 'Wait-ForSnapshotFrames' {
 
         It 'stops after the grace period when VLC has already exited' {
             $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 5
+            $proc = script:New-AlreadyExitedProcess
             try {
-                $proc = script:New-MockProcess -HasExited $true  # exited before polling starts
-
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'vid_' `
@@ -158,19 +171,17 @@ Describe 'Wait-ForSnapshotFrames' {
             }
         }
 
-        It 'returns correct FramesDelta when process exits with new frames' {
+        It 'returns correct FramesDelta and positive ElapsedSeconds' {
             $folder = script:New-TempSnapshotFolder -Prefix 'clip_' -PngCount 2
+            $proc = script:New-AlreadyExitedProcess
             try {
-                # Simulate a process that has already exited
-                $proc = script:New-MockProcess -HasExited $true
-
                 $result = Wait-ForSnapshotFrames `
                     -SaveFolder $folder -ScenePrefix 'clip_' `
                     -MaxSeconds 60 -PollMs 100 `
                     -Process $proc -GracePeriodSeconds 1 `
                     -IdleTimeoutSeconds 0 -WarmUpSeconds 0
 
-                # 2 PNGs existed at start; none added → delta is 0
+                # 2 PNGs present at start, none added during run → delta is 0
                 $result.FramesDelta | Should -Be 0
                 $result.ElapsedSeconds | Should -BeGreaterThan 0
             }

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -20,18 +20,19 @@ BeforeAll {
     if (-not $pwsh) { throw 'No PowerShell executable found; cannot spawn real processes for tests.' }
     $script:PwshExe = $pwsh.Source
 
-    # Starts a real process that stays alive for the duration of a test
+    # Starts a real process that stays alive for the duration of a test.
+    # -WindowStyle is intentionally omitted: it is Windows-only and throws on Linux.
     function script:New-LongRunningProcess {
         Start-Process -FilePath $script:PwshExe `
             -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 120' `
-            -WindowStyle Hidden -PassThru
+            -PassThru
     }
 
-    # Starts a real process that exits immediately and waits for it to finish
+    # Starts a real process that exits immediately and waits for it to finish.
     function script:New-AlreadyExitedProcess {
         $p = Start-Process -FilePath $script:PwshExe `
             -ArgumentList '-NoProfile', '-Command', 'exit 0' `
-            -WindowStyle Hidden -PassThru
+            -PassThru
         $p.WaitForExit(10000) | Out-Null
         $p
     }

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -1,0 +1,182 @@
+<#
+.SYNOPSIS
+Pester tests for Wait-ForSnapshotFrames (Snapshot.Monitor.ps1).
+#>
+
+BeforeAll {
+    $script:MonitorPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Snapshot.Monitor.ps1'
+    $script:LoggingPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Logging.ps1'
+
+    if (-not (Test-Path -LiteralPath $script:MonitorPath)) {
+        throw "Snapshot.Monitor.ps1 not found: $script:MonitorPath"
+    }
+    if (-not (Test-Path -LiteralPath $script:LoggingPath)) {
+        throw "Logging.ps1 not found: $script:LoggingPath"
+    }
+
+    . $script:LoggingPath
+    . $script:MonitorPath
+
+    function script:New-MockProcess {
+        param([bool]$HasExited = $false)
+        $p = [pscustomobject]@{ HasExited = $HasExited }
+        $p | Add-Member -MemberType ScriptMethod -Name Refresh -Value {}
+        $p
+    }
+
+    function script:New-TempSnapshotFolder {
+        param([string]$Prefix = 'prefix_', [int]$PngCount = 0)
+        $dir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) -Force
+        if ($PngCount -gt 0) {
+            1..$PngCount | ForEach-Object {
+                New-Item -Path (Join-Path $dir.FullName ("{0}{1:D4}.png" -f $Prefix, $_)) -ItemType File -Force | Out-Null
+            }
+        }
+        $dir.FullName
+    }
+}
+
+Describe 'Wait-ForSnapshotFrames' {
+
+    Context 'idle-frame stall detection' {
+
+        It 'breaks early when no new frames appear past the idle timeout while process is alive' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 3
+            try {
+                $proc = script:New-MockProcess -HasExited $false
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'vid_' `
+                    -MaxSeconds 60 -PollMs 100 `
+                    -Process $proc `
+                    -IdleTimeoutSeconds 2 -WarmUpSeconds 0
+                $sw.Stop()
+
+                # Should idle-break at ~2 s, not wait out the full 60 s cap
+                $sw.Elapsed.TotalSeconds | Should -BeLessThan 15
+                $result.FramesDelta | Should -Be 0
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'does not idle-break when IdleTimeoutSeconds is 0 (disabled)' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 2
+            try {
+                $proc = script:New-MockProcess -HasExited $false
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                # MaxSeconds=3 caps the run; idle detection disabled → should run ~3s
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'vid_' `
+                    -MaxSeconds 3 -PollMs 100 `
+                    -Process $proc `
+                    -IdleTimeoutSeconds 0 -WarmUpSeconds 0
+                $sw.Stop()
+
+                # Function ran for the full MaxSeconds, not cut short by idle detection
+                $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'warm-up grace period' {
+
+        It 'suppresses idle detection during the warm-up window' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            try {
+                $proc = script:New-MockProcess -HasExited $false
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                # WarmUpSeconds=3 > IdleTimeoutSeconds=1: idle break must not fire inside warm-up
+                # MaxSeconds=5 caps the run so the test completes in reasonable time
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'vid_' `
+                    -MaxSeconds 5 -PollMs 100 `
+                    -Process $proc `
+                    -IdleTimeoutSeconds 1 -WarmUpSeconds 3
+                $sw.Stop()
+
+                # Without warm-up suppression the function would exit in ~1 s; with it, at least 3 s
+                $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2.5
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'fires idle detection after the warm-up window expires' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'vid_'  # no PNGs
+            try {
+                $proc = script:New-MockProcess -HasExited $false
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                # WarmUp=2 + IdleTimeout=1 = should break at ~3 s; MaxSeconds is generous
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'vid_' `
+                    -MaxSeconds 60 -PollMs 100 `
+                    -Process $proc `
+                    -IdleTimeoutSeconds 1 -WarmUpSeconds 2
+                $sw.Stop()
+
+                # Should break around WarmUp+IdleTimeout, well before MaxSeconds=60
+                $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
+                $sw.Elapsed.TotalSeconds | Should -BeLessThan 15
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'normal completion via VLC process exit' {
+
+        It 'stops after the grace period when VLC has already exited' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'vid_' -PngCount 5
+            try {
+                $proc = script:New-MockProcess -HasExited $true  # exited before polling starts
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'vid_' `
+                    -MaxSeconds 60 -PollMs 100 `
+                    -Process $proc -GracePeriodSeconds 1 `
+                    -IdleTimeoutSeconds 30 -WarmUpSeconds 0
+                $sw.Stop()
+
+                # Should exit after GracePeriodSeconds (~1 s), not wait 60 s
+                $sw.Elapsed.TotalSeconds | Should -BeLessThan 10
+                $result.FramesDelta | Should -Be 0
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'returns correct FramesDelta when process exits with new frames' {
+            $folder = script:New-TempSnapshotFolder -Prefix 'clip_' -PngCount 2
+            try {
+                # Simulate a process that has already exited
+                $proc = script:New-MockProcess -HasExited $true
+
+                $result = Wait-ForSnapshotFrames `
+                    -SaveFolder $folder -ScenePrefix 'clip_' `
+                    -MaxSeconds 60 -PollMs 100 `
+                    -Process $proc -GracePeriodSeconds 1 `
+                    -IdleTimeoutSeconds 0 -WarmUpSeconds 0
+
+                # 2 PNGs existed at start; none added → delta is 0
+                $result.FramesDelta | Should -Be 0
+                $result.ElapsedSeconds | Should -BeGreaterThan 0
+            }
+            finally {
+                Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -4,8 +4,8 @@ Pester tests for Wait-ForSnapshotFrames (Snapshot.Monitor.ps1).
 #>
 
 BeforeAll {
-    $script:MonitorPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Snapshot.Monitor.ps1'
-    $script:LoggingPath = Join-Path $PSScriptRoot '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Logging.ps1'
+    $script:MonitorPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Snapshot.Monitor.ps1'
+    $script:LoggingPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Logging.ps1'
 
     foreach ($f in $script:MonitorPath, $script:LoggingPath) {
         if (-not (Test-Path -LiteralPath $f)) { throw "Required file not found: $f" }


### PR DESCRIPTION
## Summary
Adds idle-frame stall detection to `Wait-ForSnapshotFrames` to prevent indefinite hangs when VLC encounters undecodable videos. The function now abandons stalled sessions within a configurable timeout (~20s by default) instead of waiting the full fallback duration (~300s).

## Key Changes

- **Idle-frame stall detection** in `Wait-ForSnapshotFrames`: tracks the timestamp of the last frame-count increase and breaks early when no new frames appear for `IdleTimeoutSeconds` while the VLC process is alive
- **`WarmUpSeconds` parameter**: suppresses idle detection during an initial window to allow slow-starting sources (cold network shares, large files) to produce their first frame before the idle timer activates
- **Configuration defaults** in `Get-DefaultConfig`:
  - `SnapshotIdleTimeoutSeconds = 20` (seconds without new frame before abandonment)
  - `SnapshotIdleWarmUpSeconds = 10` (grace period at session start)
- **Updated `Start-VideoBatch.ps1`** to pass idle timeout and warm-up parameters to `Wait-ForSnapshotFrames`
- **Comprehensive Pester test suite** (`Snapshot.Monitor.Tests.ps1`) covering:
  - Idle-break fires on stalled process
  - Idle detection disabled when `IdleTimeoutSeconds=0`
  - Warm-up window suppresses premature break
  - Idle detection fires after warm-up expires
  - Normal completion via process exit
  - Correct `FramesDelta` return values
- **Documentation** in README.md explaining the feature and configuration knobs
- **Warning log message** emitted when idle-break fires for visibility in run logs
- **Version bump** to 3.0.9

## Implementation Details

The idle detection logic:
1. Tracks `$lastFrameTime` whenever frame count increases
2. Only activates after `WarmUpSeconds` have elapsed (prevents killing slow-starting sources)
3. Checks if idle duration exceeds `IdleTimeoutSeconds` on each poll iteration
4. Only applies while the VLC process is still alive (separate logic handles post-exit grace period)
5. Can be disabled by setting `IdleTimeoutSeconds = 0`

https://claude.ai/code/session_01LS6qGkZSG4V3u3NN1wvFEf