### PR TITLE
Suppress noisy PostgresBackup warning during profile lazy module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ kept here — see the linked file for details.
 
 ### Fixed
 
+- **[Profile-Helpers]** Suppressed non-fatal import warnings during lazy repo module loading (`Import-Module ... -WarningAction SilentlyContinue`) so profile-driven script dispatch no longer surfaces PostgresBackup `pg_dump` detection warnings during unrelated command usage.
+
 - **[gdrive_recover 1.26.14]** Restored streaming folder traversal behavior to continue processing queued sibling folders after a per-folder fetch error while still returning a non-success status for the run (issue #1088 review follow-up).
   → Full detail: [src/python/cloud/CHANGELOG-gdrive-recover.md](src/python/cloud/CHANGELOG-gdrive-recover.md)
 - **[Show-RandomImage 2.3.1]** Added an explicit read-permission pre-check before `Invoke-Item`; permission-denied selections now emit a console-visible error with the full path and skip viewer handoff (issue #1151).

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ pip install -e .
 See individual module READMEs for detailed documentation, usage examples, and API reference.
 For installation troubleshooting, see the [Module Deployment Guide](docs/guides/module-deployment.md).
 
+> **PowerShell profile note:** If your profile dot-sources `scripts/Profile-Helpers.ps1`, lazy module import now suppresses non-fatal module warnings (such as PostgresBackup `pg_dump` auto-detection) so unrelated commands are not noisy at prompt time.
+
 ---
 
 ## Logging

--- a/scripts/Profile-Helpers.ps1
+++ b/scripts/Profile-Helpers.ps1
@@ -299,7 +299,7 @@ function Ensure-RepoModulesLoaded {
 
     foreach ($mf in $moduleFiles) {
         try {
-            Import-Module $mf -Force -Global -ErrorAction Stop
+            Import-Module $mf -Force -Global -ErrorAction Stop -WarningAction SilentlyContinue
         }
         catch {
             # Import failures are silently swallowed to keep the session


### PR DESCRIPTION
### Motivation
- Interactive sessions were getting an unrelated `Could not auto-detect pg_dump` warning because the profile helper lazily imports all repo modules at prompt time, and `PostgresBackup` emits a non-fatal warning during import; the intent is to avoid surfacing such non-fatal module import warnings during ordinary interactive use.

### Description
- Added `-WarningAction SilentlyContinue` to the `Import-Module` call in `Ensure-RepoModulesLoaded` in `scripts/Profile-Helpers.ps1` so non-fatal import warnings are suppressed during lazy loading.
- Added a short note to `README.md` documenting the profile behavior and the suppression of non-fatal module warnings when dot-sourcing `scripts/Profile-Helpers.ps1`.
- Recorded the fix in the top-level `CHANGELOG.md` under Unreleased → Fixed describing the change to `Import-Module` warning handling.

### Testing
- No automated tests were executed for this small, low-risk change; the patch was validated via repository search and a Git diff to confirm only the import warning behaviour and documentation entries were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1798d0112483258142bb29eed4479c)