### PR TITLE
feat(videoscreenshot): bound preflight video probes

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,16 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-05-29
+### Added
+- **Opt-in video pre-flight skip**: `Start-VideoBatch -VerifyVideos` (aliases `-PreflightProbe`, `-SkipUnplayable`) now runs `Test-VideoPlayable` before launching the main VLC capture session. Videos that fail the probe are logged as `Skipped`/`NotPlayable` in the processed log so resume runs do not retry them.
+- **`VideoProbeTimeoutSeconds`** (default `5`) in `Get-DefaultConfig`, plus a `Start-VideoBatch -VideoProbeTimeoutSeconds` override for the pre-flight probe deadline.
+- **Pester coverage** for `Test-VideoPlayable` success, non-zero exit, and hung-probe force-kill behavior, plus the batch-loop skip path.
+
+### Fixed
+- **Bounded playability probe**: `Test-VideoPlayable` now uses `WaitForExit(timeout)` and force-kills VLC on timeout, treating the video as unplayable instead of hanging indefinitely.
+- **VLC executable fallback quoting**: replaced smart quotes around the default `vlc` executable name with straight quotes so the helper parses and executes reliably.
+
 ## [3.1.0] - 2026-05-28
 ### Added
 - **Duration-aware per-video snapshot cap**: `Start-VideoBatch -UseVlcSnapshots` now probes each video's duration (via `Get-VideoDuration`) and computes `cap = duration + SnapshotDurationGraceSeconds` instead of the previous flat `SnapshotFallbackTimeoutSeconds = 300` constant. Short clips no longer incur a 300 s worst-case wait; long videos are no longer cut off early.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -9,7 +9,7 @@
     - Discovery: Start-VideoBatch honors -IncludeExtensions; otherwise uses
       Config.VideoExtensions.
     - Timing: Helpers (e.g., Start-VlcProcess / Stop-Vlc) read PollIntervalMs,
-      StopVlcWaitMs, and WaitProcessTimeoutSeconds.
+      VideoProbeTimeoutSeconds, StopVlcWaitMs, and WaitProcessTimeoutSeconds.
     - GDI: When neither MaxPerVideoSeconds nor TimeLimitSeconds is set,
       Invoke-GdiCapture uses GdiCaptureDefaultSeconds as a safe fallback.
     - Cropper: Invoke-Cropper consults Python.RequiredPackages for preflight.
@@ -17,9 +17,9 @@
   These defaults are intended to be sane and conservative. Tune with care.
 .OUTPUTS
   [hashtable] with well-known keys:
-    - Timing: PollIntervalMs, SnapshotFallbackTimeoutSeconds,
-              SnapshotDurationGraceSeconds, SnapshotTerminationExtraSeconds,
-              StopVlcWaitMs, WaitProcessTimeoutSeconds
+    - Timing: PollIntervalMs, VideoProbeTimeoutSeconds,
+              SnapshotFallbackTimeoutSeconds, SnapshotDurationGraceSeconds,
+              SnapshotTerminationExtraSeconds, StopVlcWaitMs, WaitProcessTimeoutSeconds
     - Discovery: VideoExtensions
     - GDI: GdiCaptureDefaultSeconds
     - Python: RequiredPackages (used by Invoke-Cropper preflight)
@@ -38,6 +38,11 @@ function Get-DefaultConfig {
         # VLC to start/exit. Smaller = snappier detection, higher CPU; larger =
         # lower CPU, slower responsiveness. Typical range: 100–500 ms.
         PollIntervalMs                  = 200
+
+        # Maximum seconds to wait for the optional Test-VideoPlayable pre-flight
+        # VLC probe. If the probe does not exit in this window, it is force-killed
+        # and the video is treated as not playable. Typical range: 3–15 s.
+        VideoProbeTimeoutSeconds        = 5
 
         # Last-resort cap (seconds) used when no explicit per-video limit is given
         # AND duration detection fails. When duration is detectable, Start-VideoBatch

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Video.Validate.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Video.Validate.ps1
@@ -4,30 +4,34 @@ function Test-VideoPlayable {
   Lightweight validation that VLC can open a video.
   .DESCRIPTION
   Launches VLC in a headless/dummy interface for ~1 second and checks the exit code
-  as a quick “can this open & start?” probe. This is intentionally fast to keep
-  batch throughput high and to avoid long delays on broken files.
+  as a quick “can this open & start?” probe. The probe is bounded by
+  TimeoutSeconds and force-killed when VLC does not exit in time. This is
+  intentionally fast to keep batch throughput high and to avoid long delays on
+  broken files.
 
   Exit policy:
     - Returns $true on exit code 0 (success).
     - Returns $false on a clean non-zero exit. In this case, stderr/stdout are captured
       and emitted at Debug level to aid troubleshooting.
+    - Returns $false on probe timeout after force-killing the VLC process.
     - Throws only on immediate startup failures (e.g., process launch errors).
 
   Notes:
     - The 1s window is a trade-off; longer probes reduce false negatives on slow sources
-      (e.g., cold network shares) but slow the batch. If you need a longer probe, adjust
-      the stop-time flag here or add a parameterized variant.
+      (e.g., cold network shares) but slow the batch. Use TimeoutSeconds to bound
+      how long the process may run before it is treated as not playable.
   #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Path,
-        [string]$VlcExe
+        [string]$VlcExe,
+        [ValidateRange(1, 300)][int]$TimeoutSeconds = 5
     )
     if (-not (Test-Path -LiteralPath $Path)) { return $false }
 
     # Process setup
     $psi = [Diagnostics.ProcessStartInfo]::new()
-    $psi.FileName = if (-not [string]::IsNullOrWhiteSpace($VlcExe)) { $VlcExe } else { ‘vlc’ }
+    $psi.FileName = if (-not [string]::IsNullOrWhiteSpace($VlcExe)) { $VlcExe } else { 'vlc' }
     # ArgumentList handles quoting for us; we run a minimal, non-interactive session:
     #   --intf dummy       : no UI
     #   --play-and-exit    : exit once playback ends/hits stop-time
@@ -45,24 +49,41 @@ function Test-VideoPlayable {
     $p = [Diagnostics.Process]::new()
     $p.StartInfo = $psi
     if (-not $p.Start()) { throw "Failed to start VLC for validation." }
-    $p.WaitForExit()
 
-    if ($p.ExitCode -eq 0) { return $true }
-
-    # Non-zero exit: capture stderr/stdout for diagnostics (Debug level to avoid noise).
-    # We read after the process exits to avoid async complexity.
     try {
-        $stderr = $p.StandardError.ReadToEnd()
-    }
-    catch { $stderr = '' }
-    try {
-        $stdout = $p.StandardOutput.ReadToEnd()
-    }
-    catch { $stdout = '' }
+        $timeoutMs = [Math]::Max(1, $TimeoutSeconds) * 1000
+        if (-not $p.WaitForExit($timeoutMs)) {
+            Write-Debug ("Test-VideoPlayable: VLC probe timed out after {0}s for '{1}'" -f $TimeoutSeconds, $Path)
+            try {
+                $p.Kill($true)
+            }
+            catch {
+                try { $p.Kill() } catch { }
+            }
+            try { $p.WaitForExit(1000) | Out-Null } catch { }
+            return $false
+        }
 
-    if ($stderr) { Write-Debug ("Test-VideoPlayable: VLC stderr => {0}" -f $stderr.Trim()) }
-    if ($stdout) { Write-Debug ("Test-VideoPlayable: VLC stdout => {0}" -f $stdout.Trim()) }
-    Write-Debug ("Test-VideoPlayable: VLC exited with code {0} for '{1}'" -f $p.ExitCode, $Path)
+        if ($p.ExitCode -eq 0) { return $true }
+
+        # Non-zero exit: capture stderr/stdout for diagnostics (Debug level to avoid noise).
+        # We read after the process exits to avoid async complexity.
+        try {
+            $stderr = $p.StandardError.ReadToEnd()
+        }
+        catch { $stderr = '' }
+        try {
+            $stdout = $p.StandardOutput.ReadToEnd()
+        }
+        catch { $stdout = '' }
+
+        if ($stderr) { Write-Debug ("Test-VideoPlayable: VLC stderr => {0}" -f $stderr.Trim()) }
+        if ($stdout) { Write-Debug ("Test-VideoPlayable: VLC stdout => {0}" -f $stdout.Trim()) }
+        Write-Debug ("Test-VideoPlayable: VLC exited with code {0} for '{1}'" -f $p.ExitCode, $Path)
+    }
+    finally {
+        $p.Dispose()
+    }
 
     # Treat non-zero as not playable; caller decides to skip
     return $false

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -32,6 +32,12 @@ Use VLC scene snapshots; otherwise use GDI capture.
 With GDI capture, request fullscreen/top-most playback.
 .PARAMETER VlcStartupTimeoutSeconds
 Timeout for VLC process to initialize.
+.PARAMETER VerifyVideos
+Opt-in pre-flight that runs Test-VideoPlayable before launching the main VLC session.
+Unplayable videos are logged as Skipped/NotPlayable and omitted from later resume runs.
+Aliases: -PreflightProbe, -SkipUnplayable.
+.PARAMETER VideoProbeTimeoutSeconds
+Timeout for the VerifyVideos/Test-VideoPlayable pre-flight probe. Defaults to Config.VideoProbeTimeoutSeconds.
 .PARAMETER RunCropper
 Run the Python cropper after capture completes.
 .PARAMETER CropOnly
@@ -77,7 +83,9 @@ function Start-VideoBatch {
         [switch]$GdiFullscreen,
         [int]$VlcStartupTimeoutSeconds = 10,
         # Optional validation / discovery flexibility
+        [Alias('PreflightProbe', 'SkipUnplayable')]
         [switch]$VerifyVideos,
+        [ValidateRange(0, 300)][int]$VideoProbeTimeoutSeconds = 0,
         [string[]]$IncludeExtensions,
 
         # Pipeline completion parameters
@@ -109,7 +117,7 @@ function Start-VideoBatch {
     if ($CropOnly) {
         # Warn about ignored capture-related parameters if supplied
         $captureParams = @('SourceFolder', 'UseVlcSnapshots', 'FramesPerSecond', 'TimeLimitSeconds', 'MaxPerVideoSeconds',
-            'GdiFullscreen', 'VlcStartupTimeoutSeconds', 'VerifyVideos', 'IncludeExtensions',
+            'GdiFullscreen', 'VlcStartupTimeoutSeconds', 'VerifyVideos', 'VideoProbeTimeoutSeconds', 'IncludeExtensions',
             'ClearSnapshotsBeforeRun', 'VideoLimit', 'ResumeFile', 'ProcessedLogPath')
         $ignored = @()
         foreach ($n in $captureParams) {
@@ -252,6 +260,13 @@ function Start-VideoBatch {
         Write-Message -Level Info -Message ("Resume enabled: {0} item(s) will be skipped based on processed/resume lists." -f $processedSet.Count)
     }
 
+    $probeTimeoutSeconds = if ($VideoProbeTimeoutSeconds -gt 0) {
+        $VideoProbeTimeoutSeconds
+    }
+    else {
+        [Math]::Max(1, [int]$context.Config.VideoProbeTimeoutSeconds)
+    }
+
     # If requested, verify videos only when a verifier is available
     $canVerify = $false
     if ($VerifyVideos) {
@@ -297,16 +312,15 @@ function Start-VideoBatch {
         # Optional: verify video playability before spending time on it
         if ($canVerify) {
             try {
-                if (-not (Test-VideoPlayable -Path $video.FullName -VlcExe $resolvedVlcExe)) {
+                if (-not (Test-VideoPlayable -Path $video.FullName -VlcExe $resolvedVlcExe -TimeoutSeconds $probeTimeoutSeconds)) {
                     Write-Message -Level Warn -Message ("Skipping not-playable video: {0}" -f $video.FullName)
-                    if (Get-Command -Name Write-ProcessedLog -ErrorAction SilentlyContinue) {
-                        $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Skipped' -Reason 'NotPlayable'
-                    }
+                    $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Skipped' -Reason 'NotPlayable'
                     continue
                 }
             }
             catch {
                 Write-Message -Level Warn -Message ("Video verification error for {0}: {1}" -f $video.FullName, $_.Exception.Message)
+                $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Skipped' -Reason 'VideoProbeError'
                 continue
             }
         }

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -39,7 +39,8 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
 - `TimeLimitSeconds` (int, default config): Per-video capture duration; `0` uses module default.
 - `VideoLimit` (int, default `0`): Maximum number of videos to process (0 = all).
 - `IncludeExtensions` (string[]): Extensions to consider (overrides defaults).
-- `VerifyVideos` (switch): Attempt lightweight playability checks before processing.
+- `VerifyVideos` (switch): Attempt lightweight playability checks before processing. Aliases: `-PreflightProbe`, `-SkipUnplayable`.
+- `VideoProbeTimeoutSeconds` (int, default config value `5`): Maximum time to wait for the `-VerifyVideos` probe before force-killing it and treating the video as unplayable.
 - `RunCropper` (switch): Invoke the Python cropper after capture.
 - `CropOnly` (switch): Run the cropper without taking screenshots.
 - `PythonScriptPath` (string): Path to `crop_colours.py` when cropping.
@@ -64,6 +65,7 @@ catch {
 - Set `FramesPerSecond` conservatively for long runs to reduce I/O and disk usage.
 - Enable `-IncludeExtensions` to skip unsupported formats early and speed up discovery.
 - Processed logs allow resumable runs—point `-ProcessedLogPath` at fast storage to avoid lock contention.
+- Use `-VerifyVideos` (`-PreflightProbe`/`-SkipUnplayable`) to skip corrupt or unsupported files before launching the main VLC capture session; tune the bounded probe with `-VideoProbeTimeoutSeconds`.
 - Cropper runs can be CPU intensive; use `-VideoLimit`/`-TimeLimitSeconds` to batch work into smaller chunks.
 
 ## Usage
@@ -141,16 +143,19 @@ Requirements/behavior:
 #### Custom video extensions & preflight video verification
 ```powershell
 Import-Module .\src\powershell\module\Videoscreenshot\Videoscreenshot.psd1
-  -Start-VideoBatch `
+Start-VideoBatch `
   -SourceFolder .\videos `
   -SaveFolder .\shots `
   -FramesPerSecond 2 `
   -UseVlcSnapshots `
   -IncludeExtensions '.mp4','.mkv','.webm' `
-  -VerifyVideos
+  -VerifyVideos `
+  -VideoProbeTimeoutSeconds 5
 ```
 * -IncludeExtensions overrides the discovery set (defaults come from module config).
-* -VerifyVideos attempts a lightweight playability check if Test-VideoPlayable is available; otherwise it logs a warning and skips verification.
+* -VerifyVideos attempts a lightweight, bounded `Test-VideoPlayable` check before the main VLC session. `-PreflightProbe` and `-SkipUnplayable` are aliases for the same switch.
+* If the probe returns false or times out, the video is logged as `Skipped`/`NotPlayable` in the processed log and skipped on later resume runs.
+* `-VideoProbeTimeoutSeconds` controls the force-kill deadline for the probe; omit it to use `VideoProbeTimeoutSeconds` from module config.
 
 #### What the cropper flags do
 * --preserve-alpha — consider transparency when trimming borders; useful for PNGs with transparent edges.
@@ -349,6 +354,7 @@ Key config knobs (in `Get-DefaultConfig`, `Private/Config.ps1`):
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `VideoProbeTimeoutSeconds` | `5` | Seconds to wait for the optional `-VerifyVideos` pre-flight VLC probe before force-killing it and marking the video unplayable. |
 | `SnapshotDurationGraceSeconds` | `30` | Grace margin (s) added to detected video duration to form the per-video cap. Absorbs VLC startup, buffering, and end-of-stream flush. |
 | `SnapshotIdleTimeoutSeconds` | `20` | Seconds without a new frame before the session is abandoned. Set to `0` to disable. |
 | `SnapshotIdleWarmUpSeconds` | `10` | Seconds at session start during which idle detection is suppressed (allows slow-starting sources their first frame). |

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.1.0'
+  ModuleVersion     = '3.2.0'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.1.0: Duration-aware per-video snapshot cap: Start-VideoBatch now probes each video duration via ffprobe (falling back to Windows Shell) and uses cap = duration + SnapshotDurationGraceSeconds (default 30 s) instead of the flat 300 s constant. The flat fallback is retained when duration detection fails.'
+      ReleaseNotes = '3.2.0: Optional VerifyVideos/PreflightProbe pre-flight now skips unplayable videos before the main VLC session, logs them as Skipped/NotPlayable for resume, and bounds Test-VideoPlayable with VideoProbeTimeoutSeconds plus force-kill on timeout.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+Pester tests for Start-VideoBatch pre-flight video validation.
+#>
+
+BeforeAll {
+    $script:StartPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Public' 'Start-VideoBatch.ps1'
+    if (-not (Test-Path -LiteralPath $script:StartPath)) {
+        throw "Required file not found: $script:StartPath"
+    }
+
+    . $script:StartPath
+
+    function Assert-Pwsh7OrThrow { }
+    function Write-Message { param([string]$Level, [string]$Message) }
+    function New-VideoRunContext {
+        param([int]$RequestedFps, [string]$SaveFolder, [string]$RunGuid)
+        [pscustomobject]@{
+            Version = 'test'
+            Config = @{
+                VideoExtensions                 = @('.mp4')
+                VideoProbeTimeoutSeconds        = 1
+                SnapshotFallbackTimeoutSeconds  = 1
+                SnapshotDurationGraceSeconds    = 1
+                SnapshotIdleTimeoutSeconds      = 0
+                SnapshotIdleWarmUpSeconds       = 0
+                GdiCaptureDefaultSeconds        = 1
+            }
+            RunGuid = $RunGuid
+            SaveFolder = $SaveFolder
+            RequestedFps = $RequestedFps
+        }
+    }
+    function Test-FolderWritable { param([string]$Folder) New-Item -ItemType Directory -Path $Folder -Force | Out-Null }
+    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
+    function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
+    function Write-ProcessedLog {
+        param([string]$Path, [string]$VideoPath, [string]$Status, [string]$Reason = '')
+        $script:ProcessedLogCalls += [pscustomobject]@{ Path = $Path; VideoPath = $VideoPath; Status = $Status; Reason = $Reason }
+    }
+    function Test-VideoPlayable {
+        param([string]$Path, [string]$VlcExe, [int]$TimeoutSeconds)
+        $script:ProbeCalls += [pscustomobject]@{ Path = $Path; VlcExe = $VlcExe; TimeoutSeconds = $TimeoutSeconds }
+        return $false
+    }
+    function Start-Vlc {
+        $script:StartVlcCalls++
+        throw 'Start-Vlc should not be called for an unplayable pre-flight result.'
+    }
+}
+
+Describe 'Start-VideoBatch -VerifyVideos pre-flight' {
+    BeforeEach {
+        $script:ProbeCalls = @()
+        $script:ProcessedLogCalls = @()
+        $script:StartVlcCalls = 0
+
+        $script:SourceFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-source-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        $script:SaveFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-save-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:SourceFolder, $script:SaveFolder -Force | Out-Null
+        $script:VideoPath = Join-Path $script:SourceFolder 'bad.mp4'
+        Set-Content -LiteralPath $script:VideoPath -Value 'not a video' -NoNewline
+        $script:FakeVlc = Join-Path $script:SourceFolder 'vlc.exe'
+        Set-Content -LiteralPath $script:FakeVlc -Value 'fake vlc' -NoNewline
+    }
+
+    AfterEach {
+        foreach ($path in @($script:SourceFolder, $script:SaveFolder)) {
+            if ($path -and (Test-Path -LiteralPath $path -ErrorAction SilentlyContinue)) {
+                Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'skips and logs unplayable videos without launching the main VLC session' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -VerifyVideos -VideoProbeTimeoutSeconds 3
+
+        $script:StartVlcCalls | Should -Be 0
+        $script:ProbeCalls | Should -HaveCount 1
+        $script:ProbeCalls[0].TimeoutSeconds | Should -Be 3
+        $script:ProcessedLogCalls | Should -HaveCount 1
+        $script:ProcessedLogCalls[0].Status | Should -Be 'Skipped'
+        $script:ProcessedLogCalls[0].Reason | Should -Be 'NotPlayable'
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.Validate.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.Validate.Tests.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+Pester tests for Test-VideoPlayable (Video.Validate.ps1).
+#>
+
+BeforeAll {
+    $script:ValidatePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Video.Validate.ps1'
+
+    if (-not (Test-Path -LiteralPath $script:ValidatePath)) {
+        throw "Required file not found: $script:ValidatePath"
+    }
+
+    . $script:ValidatePath
+
+    function Script:New-TempVideoFile {
+        $tmpBase = [System.IO.Path]::GetTempFileName()
+        $dest = [System.IO.Path]::ChangeExtension($tmpBase, '.mp4')
+        Move-Item -LiteralPath $tmpBase -Destination $dest -Force
+        Set-Content -LiteralPath $dest -Value 'fake video' -NoNewline
+        $dest
+    }
+
+    function Script:New-FakeVlcExecutable {
+        param(
+            [Parameter(Mandatory)][string]$UnixBody,
+            [Parameter(Mandatory)][string]$WindowsBody
+        )
+
+        $extension = if ($IsWindows) { '.cmd' } else { '.sh' }
+        $path = Join-Path ([System.IO.Path]::GetTempPath()) ("fake-vlc-{0}{1}" -f [System.Guid]::NewGuid().ToString('N'), $extension)
+        if ($IsWindows) {
+            Set-Content -LiteralPath $path -Value "@echo off`r`n$WindowsBody" -NoNewline
+        }
+        else {
+            Set-Content -LiteralPath $path -Value "#!/usr/bin/env bash`n$UnixBody" -NoNewline
+            chmod +x $path
+        }
+        $path
+    }
+}
+
+Describe 'Test-VideoPlayable' {
+    BeforeEach {
+        $script:FakeVideo = Script:New-TempVideoFile
+        $script:FakeVlc = $null
+    }
+
+    AfterEach {
+        foreach ($path in @($script:FakeVideo, $script:FakeVlc)) {
+            if ($path -and (Test-Path -LiteralPath $path -ErrorAction SilentlyContinue)) {
+                Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'returns true when the VLC probe exits successfully' {
+        $script:FakeVlc = Script:New-FakeVlcExecutable -UnixBody 'exit 0' -WindowsBody 'exit /b 0'
+
+        Test-VideoPlayable -Path $script:FakeVideo -VlcExe $script:FakeVlc -TimeoutSeconds 2 | Should -BeTrue
+    }
+
+    It 'returns false when the VLC probe exits with a non-zero code' {
+        $script:FakeVlc = Script:New-FakeVlcExecutable -UnixBody 'echo probe failed >&2; exit 7' -WindowsBody 'echo probe failed 1>&2& exit /b 7'
+
+        Test-VideoPlayable -Path $script:FakeVideo -VlcExe $script:FakeVlc -TimeoutSeconds 2 | Should -BeFalse
+    }
+
+    It 'force-kills a hung VLC probe and treats the video as not playable' {
+        $script:FakeVlc = Script:New-FakeVlcExecutable -UnixBody 'sleep 60' -WindowsBody 'timeout /t 60 /nobreak >NUL'
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $result = Test-VideoPlayable -Path $script:FakeVideo -VlcExe $script:FakeVlc -TimeoutSeconds 1
+        $sw.Stop()
+
+        $result | Should -BeFalse
+        $sw.Elapsed.TotalSeconds | Should -BeLessThan 10
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent the batch run from hanging on corrupt/undecodable videos by probing playability before launching the main VLC session and bounding that probe with a timeout. 
- Make pre-flight failures actionable by skipping and logging unplayable videos so resume runs do not retry them. 

### Description
- Added a bounded probe to `Test-VideoPlayable` via a new `-TimeoutSeconds` parameter that uses `WaitForExit(timeout)`, force-kills stalled VLC probes, and disposes the process to avoid hangs. 
- Wired an opt-in pre-flight into `Start-VideoBatch` with a `-VerifyVideos` switch (aliases `-PreflightProbe`, `-SkipUnplayable`) and a `-VideoProbeTimeoutSeconds` override that defaults from `Get-DefaultConfig`. 
- On probe failure or timeout, `Start-VideoBatch` logs the video as `Skipped`/`NotPlayable` (or `VideoProbeError` on probe errors) via `Write-ProcessedLog` and does not launch the main VLC capture for that file. 
- Documentation and metadata updates: bumped module version to `3.2.0` in the manifest, updated `CHANGELOG.md` and `README.md` to document the pre-flight behaviour and the new config knob, and fixed VLC fallback quoting. 
- Added Pester tests covering `Test-VideoPlayable` success/non-zero/timeout cases and a `Start-VideoBatch` pre-flight test that verifies skipped videos are logged and `Start-Vlc` is not called.

### Testing
- Ran repository checks including `git diff --check` and formatting normalization (passed). 
- Verified module metadata and changelog updates with automated Python assertions that confirmed `ModuleVersion = '3.2.0'` and the new `VideoProbeTimeoutSeconds` config entry (passed). 
- Added Pester test suites for the probe and pre-flight batch path, but `Invoke-Pester` was not executed here because `pwsh` is not available in the run environment (tests are present and ready to run in CI or a developer environment). 
- All automated checks performed in this environment succeeded; unit/integration Pester execution should be run in an environment with PowerShell 7+ to validate runtime behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190f56e4588325af8c046426c8c923)