### PR TITLE
Fix pipeline stage indentation in Update-ScheduledTaskScriptPaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ kept here — see the linked file for details.
 
 ## [Unreleased]
 
+### Fixed
+
+- **[Update-ScheduledTaskScriptPaths 3.0.1]** Consistent pipeline stage indentation: each cmdlet on its own line with pipe at end of preceding line.
+  → Full detail: [automation/CHANGELOG.md](src/powershell/automation/CHANGELOG.md)
+
 ### Security
 
 - **[Expand-ZipsAndClean/ZipWorkflow]** Added module-scope `Write-LogDebug` fallback to prevent helper-load failures when logging framework is not imported in test/module scope (issue #1096 follow-up).

--- a/src/powershell/automation/CHANGELOG.md
+++ b/src/powershell/automation/CHANGELOG.md
@@ -1,0 +1,33 @@
+# CHANGELOG — automation
+
+## Update-ScheduledTaskScriptPaths.ps1
+
+### 3.0.1 - 2026-05-29
+
+#### Fixed
+- Consistent pipeline stage indentation: each cmdlet (`Get-ScheduledTask`, `Where-Object`,
+  `ForEach-Object`) starts on its own line with the pipe operator at the end of the preceding
+  line, making all three stages visually uniform.
+
+### 3.0.0 - 2025-11-28
+
+#### Changed
+- Removed hardcoded paths, added configurable parameters (Issue #513)
+- Added environment variable support for all paths
+- Default output directory now uses repository structure
+
+### 2.0.0 - 2025-11-16
+
+#### Changed
+- Migrated to PowerShellLoggingFramework.psm1 for standardized logging
+- Replaced `Write-Host` calls with `Write-LogInfo`
+- Replaced `Write-Warning` calls with `Write-LogWarning`
+
+### 1.0.0 - Previous
+
+- Uses `Export-ScheduledTask` for exporting
+- Parses XML using XPath with NamespaceManager for full Exec node visibility
+- Handles regex path matching with subfolder tolerance and optional quotes
+- Ensures UTF-8 export using StreamWriter and proper Dispose (without BOM)
+- Explicitly updates the XML declaration's `encoding` attribute to `utf-8`
+- Validates presence of nodes before accessing them

--- a/src/powershell/automation/Update-ScheduledTaskScriptPaths.ps1
+++ b/src/powershell/automation/Update-ScheduledTaskScriptPaths.ps1
@@ -23,9 +23,13 @@
     Directory where modified task XML files will be saved. Default: Uses TASK_SCHEDULER_OUTPUT environment variable or repository's config/tasks directory
 
 .NOTES
-    Version: 3.0.0
+    Version: 3.0.1
 
     CHANGELOG
+    ## 3.0.1 - 2026-05-29
+    ### Fixed
+    - Consistent pipeline stage indentation: each cmdlet on its own line with pipe at end of preceding line
+
     ## 3.0.0 - 2025-11-28
     ### Changed
     - Removed hardcoded paths, added configurable parameters (Issue #513)
@@ -123,10 +127,12 @@ else {
 
 Write-LogInfo "Starting scan and export of scheduled tasks..."
 
-Get-ScheduledTask | Where-Object {
+Get-ScheduledTask |
+Where-Object {
     # Exclude Microsoft and Windows system tasks
     $_.TaskPath -notlike "\Microsoft*" -and $_.TaskPath -notlike "\Windows*"
-} | ForEach-Object {
+} |
+ForEach-Object {
     $taskName = $_.TaskName
     $taskPath = $_.TaskPath
     $fullTaskName = "$taskPath$taskName"


### PR DESCRIPTION
## Summary
Improved code formatting consistency in the `Update-ScheduledTaskScriptPaths.ps1` script by standardizing pipeline stage indentation. Each cmdlet in the pipeline now starts on its own line with the pipe operator positioned at the end of the preceding line.

## Changes Made
- **Pipeline formatting**: Restructured the `Get-ScheduledTask | Where-Object | ForEach-Object` pipeline so each stage begins on a new line with consistent indentation
  - `Get-ScheduledTask` followed by pipe on same line
  - `Where-Object` block on new line, followed by pipe
  - `ForEach-Object` block on new line
- **Version bump**: Updated script version from 3.0.0 to 3.0.1
- **Documentation**: Added changelog entries in both the script's `.NOTES` section and the dedicated `automation/CHANGELOG.md` file
- **Root changelog**: Updated main `CHANGELOG.md` to reference the fix

## Implementation Details
This is a pure formatting improvement with no functional changes. The modification enhances code readability by making the multi-stage pipeline visually uniform and easier to follow, following PowerShell best practices for pipeline formatting.

https://claude.ai/code/session_015nXEFxVqNiFbFxvJ4SjMYH