### PR TITLE
Refactor log purge logic into dedicated helper function

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG — FileDistributor
 
+## 4.9.3 — 2026-05-29
+
+### Changed
+
+- Extracted log-file purge policy logic from `Main` into a dedicated `Invoke-LogFilePurge` helper function, reducing `Main`'s cognitive complexity from 22 to 5 (limit: 15). `Invoke-LogFilePurge` carries the extracted logic at complexity 10. No behavior change.
+
+### Versioning
+
+- Bumped `FileDistributor.ps1` script version to `4.9.3`.
+
 ## 4.9.2 — 2026-04-22
 
 ### Fixed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -331,7 +331,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.9.2"
+$script:Version = "4.9.3"
 $script:Warnings = 0
 $script:Errors = 0
 
@@ -368,6 +368,26 @@ Initialize-Logger -resolvedLogDir $logDirectory -ScriptName "FileDistributor" -L
 $null = Set-LoggerLogFilePath -Path $LogFilePath
 Reset-LogCounters
 
+# Builds and applies the log-file purge policy (truncate / age-out / timestamp-prune).
+# Extracted from Main to keep Main's cognitive complexity within limits.
+function Invoke-LogFilePurge {
+    $beforeTimestamp = $null
+    if ($RemoveEntriesBefore) {
+        try { $beforeTimestamp = [datetime]::Parse($RemoveEntriesBefore) }
+        catch { throw "Invalid timestamp format. Use 'YYYY-MM-DD HH:MM:SS' or ISO 8601." }
+    }
+    $purgeParams = @{ LogFilePath = $LogFilePath }
+    if ($beforeTimestamp) { $purgeParams.BeforeTimestamp = $beforeTimestamp }
+    if ($RemoveEntriesOlderThan) { $purgeParams.RetentionDays = $RemoveEntriesOlderThan }
+    if ($TruncateIfLarger) { $purgeParams.TruncateIfLarger = $TruncateIfLarger }
+    if ($TruncateLog) { $purgeParams.TruncateLog = $true }
+
+    if ($purgeParams.Keys.Count -gt 1) {
+        try { Clear-LogFile @purgeParams }
+        catch { Write-LogError "Failed to apply log file cleanup policy: $($_.Exception.Message)" }
+    }
+}
+
 # Main script logic
 function Main {
     $script:DebugMode = ($DebugPreference -ne 'SilentlyContinue')
@@ -383,21 +403,7 @@ function Main {
     $priorErrors = 0
 
     if (-not $Restart) {
-        $beforeTimestamp = $null
-        if ($RemoveEntriesBefore) {
-            try { $beforeTimestamp = [datetime]::Parse($RemoveEntriesBefore) }
-            catch { throw "Invalid timestamp format. Use 'YYYY-MM-DD HH:MM:SS' or ISO 8601." }
-        }
-        $purgeParams = @{ LogFilePath = $LogFilePath }
-        if ($beforeTimestamp) { $purgeParams.BeforeTimestamp = $beforeTimestamp }
-        if ($RemoveEntriesOlderThan) { $purgeParams.RetentionDays = $RemoveEntriesOlderThan }
-        if ($TruncateIfLarger) { $purgeParams.TruncateIfLarger = $TruncateIfLarger }
-        if ($TruncateLog) { $purgeParams.TruncateLog = $true }
-
-        if ($purgeParams.Keys.Count -gt 1) {
-            try { Clear-LogFile @purgeParams }
-            catch { Write-LogError "Failed to apply log file cleanup policy: $($_.Exception.Message)" }
-        }
+        Invoke-LogFilePurge
     }
     $script:Warnings = [Math]::Max($script:Warnings, (Get-LogWarningCount))
     $script:Errors = [Math]::Max($script:Errors, (Get-LogErrorCount))


### PR DESCRIPTION
## Summary

Extracted the log-file purge policy logic from the `Main` function into a dedicated `Invoke-LogFilePurge` helper function to improve code maintainability and reduce cognitive complexity.

## Key Changes

- **New function `Invoke-LogFilePurge`**: Encapsulates all log file purge policy logic (timestamp parsing, parameter building, and `Clear-LogFile` invocation) that was previously inline in `Main`
- **Simplified `Main` function**: Replaced 18 lines of purge logic with a single function call, reducing `Main`'s cognitive complexity from 22 to 5 (well below the 15-point limit)
- **Preserved behavior**: No functional changes—the extracted logic operates identically to the original implementation
- **Version bump**: Updated script version from `4.9.2` to `4.9.3`
- **Documentation**: Added changelog entry documenting the refactoring and complexity metrics

## Implementation Details

The `Invoke-LogFilePurge` function:
- Handles timestamp parsing with proper error handling for the `RemoveEntriesBefore` parameter
- Dynamically builds purge parameters based on provided options (`RemoveEntriesOlderThan`, `TruncateIfLarger`, `TruncateLog`)
- Only invokes `Clear-LogFile` when purge parameters are specified (maintains original guard logic)
- Catches and logs errors via `Write-LogError` for graceful failure handling

This refactoring improves code readability and makes the purge logic reusable if needed elsewhere in the future.

https://claude.ai/code/session_01Q9txDs7UNuHkKmM7EJjohJ