### PR TITLE
Fix PSScriptAnalyzer null comparison warning in Remove-FilenameString

### DIFF
--- a/src/powershell/file-management/CHANGELOG.md
+++ b/src/powershell/file-management/CHANGELOG.md
@@ -5,3 +5,4 @@ This directory contains per-script changelogs. See the relevant file for the scr
 - [Copy-AndroidFiles.CHANGELOG.md](Copy-AndroidFiles.CHANGELOG.md) — `Copy-AndroidFiles.ps1`
 - [Expand-ZipsAndClean.CHANGELOG.md](Expand-ZipsAndClean.CHANGELOG.md) — `Expand-ZipsAndClean.ps1`
 - [FileDistributor.CHANGELOG.md](FileDistributor.CHANGELOG.md) — `FileDistributor.ps1`
+- [Remove-FilenameString.CHANGELOG.md](Remove-FilenameString.CHANGELOG.md) — `Remove-FilenameString.ps1`

--- a/src/powershell/file-management/Remove-FilenameString.CHANGELOG.md
+++ b/src/powershell/file-management/Remove-FilenameString.CHANGELOG.md
@@ -1,0 +1,23 @@
+# CHANGELOG — Remove-FilenameString
+
+## 2.0.1 — 2026-05-29
+
+### Fixed
+
+- Placed `$null` on the left-hand side of the null-check for `$files` (`$null -ne $files` instead of `$files -ne $null`), eliminating the PSScriptAnalyzer `PSPossibleIncorrectComparisonWithNull` warning. PowerShell coerces the right-hand operand to match the left-hand type, so a collection on the left can suppress the comparison; placing `$null` on the left avoids this. No behavior change.
+
+### Versioning
+
+- Bumped `Remove-FilenameString.ps1` script version to `2.0.1`.
+
+## 2.0.0 — (prior)
+
+### Changed
+
+- Refactored to use PowerShellLoggingFramework for standardized logging.
+
+## 1.0.0 — (prior)
+
+### Added
+
+- Initial release with `Add-Content` logging.

--- a/src/powershell/file-management/Remove-FilenameString.ps1
+++ b/src/powershell/file-management/Remove-FilenameString.ps1
@@ -14,8 +14,9 @@
     The path to the log file where renaming actions are recorded. Default: "C:\Users\manoj\Documents\Scripts\scrubname.log"
 
 .NOTES
-    VERSION: 2.0.0
+    VERSION: 2.0.1
     CHANGELOG:
+        2.0.1 - Place $null on the left-hand side of the $files null-check (PSScriptAnalyzer)
         2.0.0 - Refactored to use PowerShellLoggingFramework for standardized logging
         1.0.0 - Initial release with Add-Content logging
 #>
@@ -76,7 +77,7 @@ foreach ($string in $scrubStrings.Keys) {
     # Get files containing the current scrub string
     $files = Get-ChildItem -Path $sourcePath -Filter "*$string*"
 
-    if ($files -ne $null) {
+    if ($null -ne $files) {
 
         # Display the number of files to be processed
         Write-Host "$($files.Count) files to be processed"


### PR DESCRIPTION
## Summary
This PR fixes a PSScriptAnalyzer code analysis warning in the `Remove-FilenameString.ps1` script by correcting the null comparison syntax to follow PowerShell best practices.

## Key Changes
- **Null comparison fix**: Changed `$files -ne $null` to `$null -ne $files` in the null-check condition
  - This eliminates the `PSPossibleIncorrectComparisonWithNull` PSScriptAnalyzer warning
  - PowerShell coerces the right-hand operand to match the left-hand type; placing `$null` on the left avoids this type coercion issue
  - No behavioral change—the logic remains identical
- **Version bump**: Updated script version from `2.0.0` to `2.0.1`
- **Documentation**: Added `Remove-FilenameString.CHANGELOG.md` with version history and updated the directory-level changelog index

## Implementation Details
The fix follows PowerShell best practices for null comparisons by placing the `$null` literal on the left-hand side of the comparison operator. This is the recommended approach in the PowerShell community and eliminates analyzer warnings when comparing collections or objects.

https://claude.ai/code/session_014e9JeBN432QohotaBySzzk