### PR TITLE
refactor(powershell): move Write-ExtractionSummary into Core/Progress and slim Expand-ZipsAndClean orchestrator

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.14 — 2026-05-29
+
+### Fixed
+
+- Suppressed the boolean success output from `Move-FileWithRetry` inside
+  `ZipWorkflow\Move-ZipFilesToParent`, restoring the function's single summary-object
+  output contract. This fixes callers/tests seeing an extra pipeline object and treating
+  `$result.Count` as the array length (`2`) instead of the summary object's moved-zip
+  count (`1`).
+
+---
+
 ## 2.6.13 — 2026-05-29
 
 ### Refactor

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.13 — 2026-05-29
+
+### Refactor
+
+- Moved `Write-ExtractionSummary` to `Core/Progress/Public/Write-ExtractionSummary.ps1` and
+  consume it through `ProgressReporter.psm1`; summary output, host detection, width
+  selection, `PassThru`, and compression-ratio formatting are unchanged.
+- Removed the remaining script-local helper definitions so `Expand-ZipsAndClean.ps1` is a
+  thin orchestrator: parameter binding, module imports, logger/throttle setup, main
+  workflow, and final summary call only.
+- Promoted `Move-ZipFilesToParent` to `FileManagement/ZipWorkflow` so the top-level script
+  can call the module implementation directly.
+
+### Tests
+
+- Relocated `Write-ExtractionSummary` Pester coverage to
+  `tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1`.
+- Added a script-structure assertion that `Expand-ZipsAndClean.ps1` contains no
+  `FunctionDefinitionAst` nodes.
+
+---
+
 ## 2.6.12 — 2026-05-29
 
 ### Refactor

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -1,7 +1,4 @@
 #requires -Version 7.0
-using namespace System.Collections.Generic
-using namespace System.Collections.Concurrent
-
 <#
 .SYNOPSIS
     Unzips all .zip files from a source folder into a destination folder, moves the .zip files
@@ -122,7 +119,7 @@ using namespace System.Collections.Concurrent
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.12
+    Version  : 2.6.13
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)
@@ -198,242 +195,11 @@ if ($ThrottleLimit -gt [Environment]::ProcessorCount) {
     Write-Warning "ThrottleLimit ($ThrottleLimit) exceeds the logical processor count ($([Environment]::ProcessorCount)). Consider reducing it to avoid scheduling overhead."
 }
 
-#region Helpers
-
-<#
-.SYNOPSIS
-    Validates source/destination safety constraints before any file operations.
-#>
-function Test-ScriptPreconditions { [CmdletBinding()] param([Parameter(Mandatory)][string]$SourceDir,[Parameter(Mandatory)][string]$DestinationDir) ZipWorkflow\Test-ScriptPreconditions -SourceDir $SourceDir -DestinationDir $DestinationDir }
-
-<#
-.SYNOPSIS
-    Ensures destination root exists before extraction begins.
-#>
-function Initialize-Destination { [CmdletBinding(SupportsShouldProcess = $true)] param([Parameter(Mandatory)][string]$DestinationDir) ZipWorkflow\Initialize-Destination -DestinationDir $DestinationDir }
-
-<#
-.SYNOPSIS
-    Resolves the move target path and collision policy for a single zip file.
-.DESCRIPTION
-    Determines the destination path for moving a zip file to the parent directory,
-    applying the collision policy when a file with the same name already exists.
-    Returns an object with TargetPath (the resolved destination) and PolicyTag
-    (None / Skip / Overwrite / Rename). The caller is responsible for performing
-    the actual move and updating counters.
-#>
-function Resolve-MoveTarget { param([Parameter(Mandatory)][System.IO.FileInfo]$Zip,[Parameter(Mandatory)][string]$Parent,[Parameter(Mandatory)][ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy) ZipWorkflow\Resolve-MoveTarget -Zip $Zip -Parent $Parent -CollisionPolicy $CollisionPolicy }
-
-<#
-.SYNOPSIS
-    Moves .zip files from SourceDir to its parent folder with per-file progress.
-
-.PARAMETER SourceDir
-    The source directory containing .zip files to move.
-
-.PARAMETER QuietMode
-    Suppresses progress bar output when $true.
-
-.PARAMETER CollisionPolicy
-    Behavior when a zip with the same name already exists in the parent directory:
-      - Skip       : leave the existing parent zip untouched and do not move the source zip.
-      - Overwrite  : replace the existing parent zip with the source zip (Move-Item -Force).
-      - Rename     : move the source zip with a unique suffix (default, prior behavior).
-#>
-function Move-ZipFilesToParent {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$SourceDir,
-        [Parameter(Mandatory)][bool]$QuietMode,
-        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
-    )
-
-    $parentItem = Get-Item -LiteralPath $SourceDir
-    $parent = $parentItem.Parent?.FullName
-    if (-not $parent) {
-        throw "Cannot move zip files: source directory '$SourceDir' is at drive root (no parent directory exists)"
-    }
-
-    if (-not [System.IO.Directory]::Exists($parent)) {
-        throw "Parent directory not found: $parent"
-    }
-
-    # Writability probe (skip if WhatIf)
-    if (-not $WhatIfPreference) {
-        $null = Test-DirectoryWritable -Path $parent -ThrowOnFailure
-    }
-
-    $zipsToMove = @(Get-ChildItem -LiteralPath $SourceDir -Filter *.zip -File)
-    $total = $zipsToMove.Count
-    $totalBytes = [int64](($zipsToMove | Measure-Object Length -Sum).Sum)
-
-    $idx = 0
-    $moved = 0
-    $bytes = [int64]0
-    $skipped = 0
-    $overwritten = 0
-    $renamed = 0
-
-    foreach ($zf in $zipsToMove) {
-        $idx++
-        # Include the current file's size in the display so the byte counter reflects
-        # the running total up to and including the file being processed (fixes the
-        # off-by-one where the caption previously showed only bytes from prior files).
-        Show-ProgressPhase -Activity "Moving zip files to parent" `
-            -Status "$idx / $total : $($zf.Name) ($(Format-Bytes $zf.Length))" `
-            -Current $idx -Total $total -QuietMode $QuietMode `
-            -CurrentOperation ("Moving: {0} of {1} bytes" -f (Format-Bytes ($bytes + $zf.Length)), (Format-Bytes $totalBytes))
-
-        $mt = Resolve-MoveTarget -Zip $zf -Parent $parent -CollisionPolicy $CollisionPolicy
-
-        if ($mt.PolicyTag -eq 'Skip') {
-            $skipped++
-            continue
-        }
-
-        Move-FileWithRetry -Source $zf.FullName -Destination $mt.TargetPath -Force:($mt.PolicyTag -eq 'Overwrite')
-        if ($mt.PolicyTag -eq 'Overwrite') { $overwritten++ }
-        elseif ($mt.PolicyTag -eq 'Rename') { $renamed++ }
-        $moved++
-        $bytes += $zf.Length
-    }
-
-    Show-ProgressPhase -Activity "Moving zip files to parent" -Status "Done" `
-        -Current $total -Total $total -QuietMode $QuietMode -Completed
-
-    [pscustomobject]@{ Count = $moved; Bytes = $bytes; Destination = $parent; Skipped = $skipped; Overwritten = $overwritten; Renamed = $renamed }
-}
-
-<#
-.SYNOPSIS
-    Writes the end-of-run extraction summary to the host.
-.DESCRIPTION
-    Formats and displays a summary table (or list on narrow consoles) of all
-    extraction, move, and error statistics collected during the run.
-
-    Behavior varies by host interactivity:
-    - Interactive hosts (ConsoleHost, Visual Studio Code Host): full output —
-      header, Format-Table/-List view, and error notes.
-    - Non-interactive hosts (scheduled tasks, redirected streams): the
-      formatted table is suppressed, but any accumulated errors are still
-      written to the success stream so failures are never silent in
-      automation logs.
-.PARAMETER SourceDirectory
-    Source directory passed to the script.
-.PARAMETER DestinationDirectory
-    Destination directory passed to the script.
-.PARAMETER ExtractMode
-    Extraction mode used (PerArchiveSubfolder or Flat).
-.PARAMETER CollisionPolicy
-    Collision policy used (Skip, Overwrite, or Rename).
-.PARAMETER ZipCount
-    Total number of zip files found.
-.PARAMETER ProcessedZips
-    Number of zip files successfully processed.
-.PARAMETER FilesExtracted
-    Total number of files extracted across all archives.
-.PARAMETER UncompressedBytes
-    Total uncompressed bytes extracted.
-.PARAMETER CompressedBytes
-    Total compressed (on-disk) bytes of the zip files processed.
-.PARAMETER MoveSummary
-    PSCustomObject returned by Move-ZipFilesToParent containing Count, Bytes,
-    Destination, Skipped, Overwritten, and Renamed.
-.PARAMETER Errors
-    List of non-fatal error messages accumulated during the run.
-.PARAMETER Elapsed
-    Total elapsed time for the run.
-.PARAMETER HostName
-    Name of the current host. Defaults to $Host.Name. Accepted as a parameter
-    so that tests can inject a synthetic value without spawning a new host.
-.PARAMETER ConsoleWidth
-    Override the detected console width. 0 (default) means auto-detect via
-    $Host.UI.RawUI.WindowSize.Width. Pass a positive value to force Format-Table
-    (>= 120) or Format-List (< 120) regardless of the actual terminal width.
-    Useful in tests and when piping output to a fixed-width formatter.
-.PARAMETER PassThru
-    Switch. When set, emits the summary PSCustomObject to the pipeline in addition
-    to writing it to the host. Intended for testing so callers can inspect the
-    computed fields without needing to intercept Format-Table/-List.
-.NOTES
-    Error notes are always emitted when errors exist, regardless of host type,
-    so that failures are never silently swallowed in scheduled tasks or
-    automation pipelines.
-#>
-function Write-ExtractionSummary {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$SourceDirectory,
-        [Parameter(Mandatory)][string]$DestinationDirectory,
-        [Parameter(Mandatory)][string]$ExtractMode,
-        [Parameter(Mandatory)][string]$CollisionPolicy,
-        [Parameter(Mandatory)][int]$ZipCount,
-        [Parameter(Mandatory)][int]$ProcessedZips,
-        [Parameter(Mandatory)][int]$FilesExtracted,
-        [Parameter(Mandatory)][int64]$UncompressedBytes,
-        [Parameter(Mandatory)][int64]$CompressedBytes,
-        [Parameter(Mandatory)][pscustomobject]$MoveSummary,
-        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Errors,
-        [Parameter(Mandatory)][timespan]$Elapsed,
-        [string]$HostName = $Host.Name,
-        [int]$ConsoleWidth = 0,
-        [switch]$PassThru
-    )
-
-    $isInteractive = $HostName -in ('ConsoleHost', 'Visual Studio Code Host')
-
-    if ($isInteractive) {
-        $compressionRatio = ($CompressedBytes -gt 0) ? ("{0:N1}x" -f ($UncompressedBytes / [double]$CompressedBytes)) : "n/a"
-
-        $summaryView = [pscustomobject]@{
-            SrcDir          = $SourceDirectory
-            DestDir         = $DestinationDirectory
-            Mode            = $ExtractMode
-            Policy          = $CollisionPolicy
-            ZipsFound       = $ZipCount
-            ZipsDone        = $ProcessedZips
-            Files           = $FilesExtracted
-            Uncompressed    = (Format-Bytes $UncompressedBytes)
-            Compressed      = (Format-Bytes $CompressedBytes)
-            Ratio           = $compressionRatio
-            ZipsMoved       = ($MoveSummary.Count)
-            MoveSkipped     = ($MoveSummary.Skipped)
-            MoveOverwritten = ($MoveSummary.Overwritten)
-            MoveRenamed     = ($MoveSummary.Renamed)
-            MovedBytes      = (Format-Bytes $MoveSummary.Bytes)
-            MovedTo         = ($MoveSummary.Destination)
-            Errors          = ($Errors.Count)
-            Duration        = ("{0:hh\:mm\:ss\.fff}" -f $Elapsed)
-        }
-
-        Write-Output ""
-        Write-Output "==== Expand-ZipsAndClean Summary ===="
-
-        $rawWidth = try { $Host.UI.RawUI.WindowSize.Width } catch { $null }
-        $effectiveWidth = ($ConsoleWidth -gt 0) ? $ConsoleWidth : ($rawWidth ?? 120)
-
-        if ($effectiveWidth -lt 120) {
-            $summaryView | Format-List
-        } else {
-            $summaryView | Format-Table -AutoSize
-        }
-
-        if ($PassThru) { $summaryView }
-    }
-
-    if ($Errors.Count -gt 0) {
-        if ($isInteractive) { Write-Output "" }
-        Write-Output "Notes / Errors:"
-        $Errors | ForEach-Object { Write-Output " - $_" }
-    }
-}
-
-#endregion Helpers
 
 #------------------------------- Main -------------------------------#
 
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-$errors = [List[string]]::new()
+$errors = [System.Collections.Generic.List[string]]::new()
 
 # State for summary
 $zipCount = 0
@@ -444,8 +210,8 @@ $totalCompressedZipBytes = [int64]0
 $moveSummary = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = ""; Skipped = 0; Overwritten = 0; Renamed = 0 }
 
 try {
-    Test-ScriptPreconditions -SourceDir $SourceDirectory -DestinationDir $DestinationDirectory
-    Initialize-Destination -DestinationDir $DestinationDirectory
+    ZipWorkflow\Test-ScriptPreconditions -SourceDir $SourceDirectory -DestinationDir $DestinationDirectory
+    ZipWorkflow\Initialize-Destination -DestinationDir $DestinationDirectory
 
     $extractionResult = ZipExtraction\Invoke-ZipExtractions `
         -SourceDir $SourceDirectory `
@@ -465,7 +231,7 @@ try {
 
     try {
         if ($PSCmdlet.ShouldProcess($SourceDirectory, "Move .zip files to parent")) {
-            $moveSummary = Move-ZipFilesToParent -SourceDir $SourceDirectory -QuietMode $Quiet.IsPresent -CollisionPolicy $CollisionPolicy
+            $moveSummary = ZipWorkflow\Move-ZipFilesToParent -SourceDir $SourceDirectory -QuietMode $Quiet.IsPresent -CollisionPolicy $CollisionPolicy
         }
     } catch {
         $msg = "Moving .zip files to parent failed: $($_.Exception.Message)"
@@ -473,7 +239,7 @@ try {
         $errors.Add($msg) | Out-Null
     }
 
-    Remove-SourceDirectory `
+    FileSystem\Remove-SourceDirectory `
         -SourceDir $SourceDirectory `
         -ShouldDeleteSource $DeleteSource.IsPresent `
         -ShouldCleanNonZips $CleanNonZips.IsPresent `
@@ -487,7 +253,7 @@ try {
 
 #------------------------------ Summary -----------------------------#
 
-Write-ExtractionSummary `
+ProgressReporter\Write-ExtractionSummary `
     -SourceDirectory    $SourceDirectory `
     -DestinationDirectory $DestinationDirectory `
     -ExtractMode        $ExtractMode `

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.13
+    Version  : 2.6.14
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,10 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean ZipWorkflow move output fix** (2026-05-29)
+  - Suppressed `Move-FileWithRetry`'s boolean success output inside `ZipWorkflow\Move-ZipFilesToParent` so callers receive only the move-summary object.
+  - Version bump: `2.6.14` (patch — output contract bug fix).
+
 - **Expand-ZipsAndClean thin orchestrator refactor (issue #1098)** (2026-05-29)
   - Moved `Write-ExtractionSummary` into `Core/Progress` and updated the script to consume the exported presentation helper without changing summary output.
   - Removed remaining script-local helper definitions so `Expand-ZipsAndClean.ps1` is now a parameter/import/logger/throttle/main/summary orchestrator.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -21,6 +21,8 @@ Scripts for file operations, distribution, copying, and archiving.
 - **FileSystem** (`src/powershell/modules/Core/FileSystem/`) - Path normalization, safe naming, unique path resolution
 - **Zip** (`src/powershell/modules/Core/Zip/`) - ZIP archive primitives used by `Expand-ZipsAndClean.ps1`
 - **ZipExtraction** (`src/powershell/modules/FileManagement/ZipExtraction/`) - ZIP extraction orchestration helpers used by `Expand-ZipsAndClean.ps1`
+- **ZipWorkflow** (`src/powershell/modules/FileManagement/ZipWorkflow/`) - ZIP workflow precondition, destination, move-target, and zip-move helpers used by `Expand-ZipsAndClean.ps1`
+- **ProgressReporter** (`src/powershell/modules/Core/Progress/`) - Progress and summary presentation helpers used by `Expand-ZipsAndClean.ps1`
 - **AdbHelpers** (`src/powershell/modules/Android/AdbHelpers/`) - Shared ADB/device helpers used by `Copy-AndroidFiles.ps1`
 
 ### External Tools
@@ -47,6 +49,12 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 - These versions are intentionally independent and may advance separately under SemVer.
 
 ## Recent Updates
+
+- **Expand-ZipsAndClean thin orchestrator refactor (issue #1098)** (2026-05-29)
+  - Moved `Write-ExtractionSummary` into `Core/Progress` and updated the script to consume the exported presentation helper without changing summary output.
+  - Removed remaining script-local helper definitions so `Expand-ZipsAndClean.ps1` is now a parameter/import/logger/throttle/main/summary orchestrator.
+  - Promoted `Move-ZipFilesToParent` into `FileManagement/ZipWorkflow` to keep zip-move workflow logic module-owned.
+  - Version bump: `2.6.13` (patch — internal refactor, no intended behavior change).
 
 - **Expand-ZipsAndClean ZipWorkflow logging fallback fix (issue #1096 follow-up)** (2026-05-27)
   - Added a `Write-LogDebug` no-op fallback in `ZipWorkflow.psm1` so helper-only test loads can call `Resolve-MoveTarget` Skip-collision path without requiring the logging framework in module scope.

--- a/src/powershell/modules/Core/ErrorHandling/ErrorHandling.psd1
+++ b/src/powershell/modules/Core/ErrorHandling/ErrorHandling.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ErrorHandling.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.1.1'
 
     # ID used to uniquely identify this module
     GUID = '7f8e9a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b'
@@ -47,7 +47,7 @@
             Tags = @('ErrorHandling', 'Retry', 'Elevation', 'Utilities')
             LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.1.0: Added Invoke-WithRetry -IgnoreFileNotFound switch for warning-and-skip file-not-found handling.'
+            ReleaseNotes = '1.1.1: Hardened module loader for missing Private/Public directories. 1.1.0: Added Invoke-WithRetry -IgnoreFileNotFound switch for warning-and-skip file-not-found handling.'
         }
     }
 }

--- a/src/powershell/modules/Core/ErrorHandling/ErrorHandling.psm1
+++ b/src/powershell/modules/Core/ErrorHandling/ErrorHandling.psm1
@@ -1,17 +1,17 @@
 # Module loader for ErrorHandling
 
 $privateDir = Join-Path $PSScriptRoot 'Private'
-if (Test-Path -LiteralPath $privateDir) {
-    Get-ChildItem -Path $privateDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+if ([System.IO.Directory]::Exists($privateDir)) {
+    Get-ChildItem -LiteralPath $privateDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
 }
 
 $publicDir = Join-Path $PSScriptRoot 'Public'
-if (Test-Path -LiteralPath $publicDir) {
-    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
+if ([System.IO.Directory]::Exists($publicDir)) {
+    Get-ChildItem -LiteralPath $publicDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
 }
 
-$publicFunctions = if (Test-Path -LiteralPath $publicDir) {
-    Get-ChildItem -Path $publicDir -Filter '*.ps1' -File | Select-Object -ExpandProperty BaseName
+$publicFunctions = if ([System.IO.Directory]::Exists($publicDir)) {
+    Get-ChildItem -LiteralPath $publicDir -Filter '*.ps1' -File | Select-Object -ExpandProperty BaseName
 }
 else {
     @()

--- a/src/powershell/modules/Core/ErrorHandling/Private/.gitkeep
+++ b/src/powershell/modules/Core/ErrorHandling/Private/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain Private directory structure

--- a/src/powershell/modules/Core/ErrorHandling/README.md
+++ b/src/powershell/modules/Core/ErrorHandling/README.md
@@ -184,6 +184,9 @@ Assert-Elevated
 
 ## Version History
 
+### 1.1.1 (Unreleased)
+- Hardened the module loader to skip missing `Private`/`Public` folders without provider errors.
+
 ### 1.1.0 (2026-03-26)
 - Added `IgnoreFileNotFound` switch to `Invoke-WithRetry` for warning-and-skip handling of file-not-found conditions.
 

--- a/src/powershell/modules/Core/FileOperations/FileOperations.psd1
+++ b/src/powershell/modules/Core/FileOperations/FileOperations.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'FileOperations.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.2'
+    ModuleVersion     = '1.0.3'
 
     # ID used to uniquely identify this module
     GUID              = '8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d'
@@ -54,7 +54,8 @@
             Tags         = @('FileOperations', 'Retry', 'IO', 'Utilities')
             LicenseUri   = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri   = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.0.2: Added Import-RandomNameProvider for reusable RandomName module resolution across scripts.
+            ReleaseNotes = '1.0.3: Fixed private ErrorHandling dependency import path when loading from the Public/Private module layout.
+1.0.2: Added Import-RandomNameProvider for reusable RandomName module resolution across scripts.
 1.0.1: Adopted Public/Private layout with module loader and dependency import cleanup.'
         }
     }

--- a/src/powershell/modules/Core/FileOperations/Private/Dependencies.ps1
+++ b/src/powershell/modules/Core/FileOperations/Private/Dependencies.ps1
@@ -1,5 +1,5 @@
 # Import ErrorHandling module for retry logic
-$ErrorHandlingPath = Join-Path $PSScriptRoot "..\ErrorHandling\ErrorHandling.psm1"
+$ErrorHandlingPath = Join-Path $PSScriptRoot "..\..\ErrorHandling\ErrorHandling.psm1"
 if (Test-Path $ErrorHandlingPath) {
     Import-Module $ErrorHandlingPath -Force
 }

--- a/src/powershell/modules/Core/FileOperations/README.md
+++ b/src/powershell/modules/Core/FileOperations/README.md
@@ -313,6 +313,9 @@ Example with `RetryDelay=2` and `MaxBackoff=60`:
 
 ## Version History
 
+### 1.0.3 (Unreleased)
+- Fixed the private dependency loader to resolve `Core/ErrorHandling/ErrorHandling.psm1` from the module layout correctly.
+
 ### 1.0.0 (2025-11-20)
 - Initial release
 - `Copy-FileWithRetry` function

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -1,6 +1,23 @@
 # CHANGELOG — Core/Progress (ProgressReporter)
 
-## 1.1.0 — Unreleased
+## 1.2.0 — Unreleased
+
+### Added
+
+- `Write-ExtractionSummary` (`Public/Write-ExtractionSummary.ps1`): public summary renderer
+  relocated from `Expand-ZipsAndClean.ps1`. It preserves interactive host header and
+  table/list rendering, non-interactive error-note emission, `ConsoleWidth`/`HostName`/
+  `PassThru` test-injection parameters, the 120-column table threshold, and the existing
+  compression-ratio formatting.
+
+### Changed
+
+- `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.1.0` to `1.2.0` (MINOR —
+  additive new export); `FunctionsToExport` updated to include `Write-ExtractionSummary`.
+- `ProgressReporter.psm1`: imports `Core/FileSystem` so summary byte formatting uses the
+  shared `Format-Bytes` implementation.
+
+## 1.1.0 — 2026-05-29
 
 ### Added
 

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -16,6 +16,8 @@
   additive new export); `FunctionsToExport` updated to include `Write-ExtractionSummary`.
 - `ProgressReporter.psm1`: imports `Core/FileSystem` so summary byte formatting uses the
   shared `Format-Bytes` implementation.
+- `ProgressReporter.psd1`: `PowerShellVersion` raised from `5.1` to `7.0` because
+  the module now imports the PS 7-only `Core/FileSystem` module for `Format-Bytes`.
 
 ## 1.1.0 — 2026-05-29
 

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG — Core/Progress (ProgressReporter)
 
+## 1.2.2 — Unreleased
+
+### Changed
+
+- Reduced duplicated new-code lines in `Write-ExtractionSummary.ps1` by deriving the
+  internal summary state from `$PSBoundParameters` instead of repeating the full summary
+  parameter list at the helper call site. Public behavior is unchanged.
+- `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.2.1` to `1.2.2` (PATCH —
+  internal refactor/no behavioral change).
+
 ## 1.2.1 — Unreleased
 
 ### Changed

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG — Core/Progress (ProgressReporter)
 
+## 1.2.1 — Unreleased
+
+### Changed
+
+- Refactored `Write-ExtractionSummary` into focused helper functions for summary-object
+  construction, console-width selection, formatted view output, and error-note output.
+  Public behavior and the `Write-ExtractionSummary` export are unchanged; this only lowers
+  the public function's Cognitive Complexity below the quality-gate limit.
+- `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.2.0` to `1.2.1` (PATCH —
+  internal refactor/no behavioral change).
+
 ## 1.2.0 — Unreleased
 
 ### Added

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ProgressReporter.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.2.0'
 
     # ID used to uniquely identify this module
     GUID = '9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e'
@@ -31,7 +31,8 @@
         'New-ProgressTracker',
         'Update-ProgressTracker',
         'Complete-ProgressTracker',
-        'Write-ProgressStatus'
+        'Write-ProgressStatus',
+        'Write-ExtractionSummary'
     )
 
     # Cmdlets to export from this module
@@ -49,7 +50,7 @@
             Tags = @('Progress', 'Logging', 'Reporting', 'Utilities')
             LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
+            ReleaseNotes = '1.2.0: Added Write-ExtractionSummary public summary renderer. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
         }
     }
 }

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ProgressReporter.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.0'
+    ModuleVersion = '1.2.1'
 
     # ID used to uniquely identify this module
     GUID = '9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e'
@@ -50,7 +50,7 @@
             Tags = @('Progress', 'Logging', 'Reporting', 'Utilities')
             LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.2.0: Added Write-ExtractionSummary public summary renderer and raised minimum PowerShell version to 7.0 because the summary renderer depends on Core/FileSystem. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
+            ReleaseNotes = '1.2.1: Refactored Write-ExtractionSummary into focused helper functions to reduce cognitive complexity without behavior changes. 1.2.0: Added Write-ExtractionSummary public summary renderer and raised minimum PowerShell version to 7.0 because the summary renderer depends on Core/FileSystem. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
         }
     }
 }

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -21,7 +21,7 @@
     Description = 'Standardized progress reporting utilities for PowerShell scripts with logging integration.'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.0'
 
     # Functions to export from this module
     FunctionsToExport = @(
@@ -50,7 +50,7 @@
             Tags = @('Progress', 'Logging', 'Reporting', 'Utilities')
             LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.2.0: Added Write-ExtractionSummary public summary renderer. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
+            ReleaseNotes = '1.2.0: Added Write-ExtractionSummary public summary renderer and raised minimum PowerShell version to 7.0 because the summary renderer depends on Core/FileSystem. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
         }
     }
 }

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ProgressReporter.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.1'
+    ModuleVersion = '1.2.2'
 
     # ID used to uniquely identify this module
     GUID = '9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e'
@@ -50,7 +50,7 @@
             Tags = @('Progress', 'Logging', 'Reporting', 'Utilities')
             LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
             ProjectUri = 'https://github.com/manoj-bhaskaran/My-Scripts'
-            ReleaseNotes = '1.2.1: Refactored Write-ExtractionSummary into focused helper functions to reduce cognitive complexity without behavior changes. 1.2.0: Added Write-ExtractionSummary public summary renderer and raised minimum PowerShell version to 7.0 because the summary renderer depends on Core/FileSystem. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
+            ReleaseNotes = '1.2.2: Reduced duplicate new-code lines in Write-ExtractionSummary by deriving summary state from bound parameters. 1.2.1: Refactored Write-ExtractionSummary into focused helper functions to reduce cognitive complexity without behavior changes. 1.2.0: Added Write-ExtractionSummary public summary renderer and raised minimum PowerShell version to 7.0 because the summary renderer depends on Core/FileSystem. 1.1.0: Added Show-ProgressPhase (percentage-computing quiet-mode-aware progress wrapper). 1.0.1: Standardized module folder structure and loader.'
         }
     }
 }

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psm1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psm1
@@ -1,5 +1,10 @@
 # Module loader for ProgressReporter
 
+$fileSystemModule = Join-Path $PSScriptRoot '..\FileSystem\FileSystem.psm1'
+if (Test-Path -LiteralPath $fileSystemModule) {
+    Import-Module $fileSystemModule -Force
+}
+
 $privateDir = Join-Path $PSScriptRoot 'Private'
 if (Test-Path -LiteralPath $privateDir) {
     Get-ChildItem -Path $privateDir -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }

--- a/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
+++ b/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
@@ -1,42 +1,51 @@
 function New-ExtractionSummaryView {
     [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$SourceDirectory,
-        [Parameter(Mandatory)][string]$DestinationDirectory,
-        [Parameter(Mandatory)][string]$ExtractMode,
-        [Parameter(Mandatory)][string]$CollisionPolicy,
-        [Parameter(Mandatory)][int]$ZipCount,
-        [Parameter(Mandatory)][int]$ProcessedZips,
-        [Parameter(Mandatory)][int]$FilesExtracted,
-        [Parameter(Mandatory)][int64]$UncompressedBytes,
-        [Parameter(Mandatory)][int64]$CompressedBytes,
-        [Parameter(Mandatory)][pscustomobject]$MoveSummary,
-        [Parameter(Mandatory)][int]$ErrorCount,
-        [Parameter(Mandatory)][timespan]$Elapsed
-    )
+    param([Parameter(Mandatory)][pscustomobject]$SummaryState)
 
-    $compressionRatio = if ($CompressedBytes -gt 0) { "{0:N1}x" -f ($UncompressedBytes / [double]$CompressedBytes) } else { "n/a" }
+    $compressionRatio = if ($SummaryState.CompressedBytes -gt 0) {
+        "{0:N1}x" -f ($SummaryState.UncompressedBytes / [double]$SummaryState.CompressedBytes)
+    } else {
+        "n/a"
+    }
 
     [pscustomobject]@{
-        SrcDir          = $SourceDirectory
-        DestDir         = $DestinationDirectory
-        Mode            = $ExtractMode
-        Policy          = $CollisionPolicy
-        ZipsFound       = $ZipCount
-        ZipsDone        = $ProcessedZips
-        Files           = $FilesExtracted
-        Uncompressed    = (Format-Bytes $UncompressedBytes)
-        Compressed      = (Format-Bytes $CompressedBytes)
+        SrcDir          = $SummaryState.SourceDirectory
+        DestDir         = $SummaryState.DestinationDirectory
+        Mode            = $SummaryState.ExtractMode
+        Policy          = $SummaryState.CollisionPolicy
+        ZipsFound       = $SummaryState.ZipCount
+        ZipsDone        = $SummaryState.ProcessedZips
+        Files           = $SummaryState.FilesExtracted
+        Uncompressed    = (Format-Bytes $SummaryState.UncompressedBytes)
+        Compressed      = (Format-Bytes $SummaryState.CompressedBytes)
         Ratio           = $compressionRatio
-        ZipsMoved       = ($MoveSummary.Count)
-        MoveSkipped     = ($MoveSummary.Skipped)
-        MoveOverwritten = ($MoveSummary.Overwritten)
-        MoveRenamed     = ($MoveSummary.Renamed)
-        MovedBytes      = (Format-Bytes $MoveSummary.Bytes)
-        MovedTo         = ($MoveSummary.Destination)
-        Errors          = $ErrorCount
-        Duration        = ("{0:hh\:mm\:ss\.fff}" -f $Elapsed)
+        ZipsMoved       = ($SummaryState.MoveSummary.Count)
+        MoveSkipped     = ($SummaryState.MoveSummary.Skipped)
+        MoveOverwritten = ($SummaryState.MoveSummary.Overwritten)
+        MoveRenamed     = ($SummaryState.MoveSummary.Renamed)
+        MovedBytes      = (Format-Bytes $SummaryState.MoveSummary.Bytes)
+        MovedTo         = ($SummaryState.MoveSummary.Destination)
+        Errors          = $SummaryState.ErrorCount
+        Duration        = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
     }
+}
+
+function New-ExtractionSummaryState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$BoundParameters,
+        [Parameter(Mandatory)][int]$ErrorCount
+    )
+
+    $summaryState = [ordered]@{}
+    foreach ($name in $BoundParameters.Keys) {
+        if ($name -notin 'Errors', 'HostName', 'ConsoleWidth', 'PassThru') {
+            $summaryState[$name] = $BoundParameters[$name]
+        }
+    }
+
+    $summaryState['ErrorCount'] = $ErrorCount
+    [pscustomobject]$summaryState
 }
 
 function Get-ExtractionSummaryConsoleWidth {
@@ -162,19 +171,8 @@ function Write-ExtractionSummary {
     $isInteractive = $HostName -in ('ConsoleHost', 'Visual Studio Code Host')
 
     if ($isInteractive) {
-        $summaryView = New-ExtractionSummaryView `
-            -SourceDirectory $SourceDirectory `
-            -DestinationDirectory $DestinationDirectory `
-            -ExtractMode $ExtractMode `
-            -CollisionPolicy $CollisionPolicy `
-            -ZipCount $ZipCount `
-            -ProcessedZips $ProcessedZips `
-            -FilesExtracted $FilesExtracted `
-            -UncompressedBytes $UncompressedBytes `
-            -CompressedBytes $CompressedBytes `
-            -MoveSummary $MoveSummary `
-            -ErrorCount $Errors.Count `
-            -Elapsed $Elapsed
+        $summaryState = New-ExtractionSummaryState -BoundParameters $PSBoundParameters -ErrorCount $Errors.Count
+        $summaryView = New-ExtractionSummaryView -SummaryState $summaryState
 
         Write-ExtractionSummaryView -SummaryView $summaryView -ConsoleWidth $ConsoleWidth
         if ($PassThru) { $summaryView }

--- a/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
+++ b/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
@@ -1,3 +1,88 @@
+function New-ExtractionSummaryView {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDirectory,
+        [Parameter(Mandatory)][string]$DestinationDirectory,
+        [Parameter(Mandatory)][string]$ExtractMode,
+        [Parameter(Mandatory)][string]$CollisionPolicy,
+        [Parameter(Mandatory)][int]$ZipCount,
+        [Parameter(Mandatory)][int]$ProcessedZips,
+        [Parameter(Mandatory)][int]$FilesExtracted,
+        [Parameter(Mandatory)][int64]$UncompressedBytes,
+        [Parameter(Mandatory)][int64]$CompressedBytes,
+        [Parameter(Mandatory)][pscustomobject]$MoveSummary,
+        [Parameter(Mandatory)][int]$ErrorCount,
+        [Parameter(Mandatory)][timespan]$Elapsed
+    )
+
+    $compressionRatio = if ($CompressedBytes -gt 0) { "{0:N1}x" -f ($UncompressedBytes / [double]$CompressedBytes) } else { "n/a" }
+
+    [pscustomobject]@{
+        SrcDir          = $SourceDirectory
+        DestDir         = $DestinationDirectory
+        Mode            = $ExtractMode
+        Policy          = $CollisionPolicy
+        ZipsFound       = $ZipCount
+        ZipsDone        = $ProcessedZips
+        Files           = $FilesExtracted
+        Uncompressed    = (Format-Bytes $UncompressedBytes)
+        Compressed      = (Format-Bytes $CompressedBytes)
+        Ratio           = $compressionRatio
+        ZipsMoved       = ($MoveSummary.Count)
+        MoveSkipped     = ($MoveSummary.Skipped)
+        MoveOverwritten = ($MoveSummary.Overwritten)
+        MoveRenamed     = ($MoveSummary.Renamed)
+        MovedBytes      = (Format-Bytes $MoveSummary.Bytes)
+        MovedTo         = ($MoveSummary.Destination)
+        Errors          = $ErrorCount
+        Duration        = ("{0:hh\:mm\:ss\.fff}" -f $Elapsed)
+    }
+}
+
+function Get-ExtractionSummaryConsoleWidth {
+    [CmdletBinding()]
+    param([int]$ConsoleWidth)
+
+    if ($ConsoleWidth -gt 0) { return $ConsoleWidth }
+
+    $rawWidth = try { $Host.UI.RawUI.WindowSize.Width } catch { $null }
+    if ($null -ne $rawWidth) { return $rawWidth }
+
+    120
+}
+
+function Write-ExtractionSummaryView {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$SummaryView,
+        [Parameter(Mandatory)][int]$ConsoleWidth
+    )
+
+    Write-Output ""
+    Write-Output "==== Expand-ZipsAndClean Summary ===="
+
+    if ((Get-ExtractionSummaryConsoleWidth -ConsoleWidth $ConsoleWidth) -lt 120) {
+        $SummaryView | Format-List
+        return
+    }
+
+    $SummaryView | Format-Table -AutoSize
+}
+
+function Write-ExtractionSummaryErrors {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Errors,
+        [Parameter(Mandatory)][bool]$IsInteractive
+    )
+
+    if ($Errors.Count -eq 0) { return }
+
+    if ($IsInteractive) { Write-Output "" }
+    Write-Output "Notes / Errors:"
+    $Errors | ForEach-Object { Write-Output " - $_" }
+}
+
 <#
 .SYNOPSIS
     Writes the end-of-run extraction summary to the host.
@@ -77,47 +162,23 @@ function Write-ExtractionSummary {
     $isInteractive = $HostName -in ('ConsoleHost', 'Visual Studio Code Host')
 
     if ($isInteractive) {
-        $compressionRatio = if ($CompressedBytes -gt 0) { "{0:N1}x" -f ($UncompressedBytes / [double]$CompressedBytes) } else { "n/a" }
+        $summaryView = New-ExtractionSummaryView `
+            -SourceDirectory $SourceDirectory `
+            -DestinationDirectory $DestinationDirectory `
+            -ExtractMode $ExtractMode `
+            -CollisionPolicy $CollisionPolicy `
+            -ZipCount $ZipCount `
+            -ProcessedZips $ProcessedZips `
+            -FilesExtracted $FilesExtracted `
+            -UncompressedBytes $UncompressedBytes `
+            -CompressedBytes $CompressedBytes `
+            -MoveSummary $MoveSummary `
+            -ErrorCount $Errors.Count `
+            -Elapsed $Elapsed
 
-        $summaryView = [pscustomobject]@{
-            SrcDir          = $SourceDirectory
-            DestDir         = $DestinationDirectory
-            Mode            = $ExtractMode
-            Policy          = $CollisionPolicy
-            ZipsFound       = $ZipCount
-            ZipsDone        = $ProcessedZips
-            Files           = $FilesExtracted
-            Uncompressed    = (Format-Bytes $UncompressedBytes)
-            Compressed      = (Format-Bytes $CompressedBytes)
-            Ratio           = $compressionRatio
-            ZipsMoved       = ($MoveSummary.Count)
-            MoveSkipped     = ($MoveSummary.Skipped)
-            MoveOverwritten = ($MoveSummary.Overwritten)
-            MoveRenamed     = ($MoveSummary.Renamed)
-            MovedBytes      = (Format-Bytes $MoveSummary.Bytes)
-            MovedTo         = ($MoveSummary.Destination)
-            Errors          = ($Errors.Count)
-            Duration        = ("{0:hh\:mm\:ss\.fff}" -f $Elapsed)
-        }
-
-        Write-Output ""
-        Write-Output "==== Expand-ZipsAndClean Summary ===="
-
-        $rawWidth = try { $Host.UI.RawUI.WindowSize.Width } catch { $null }
-        $effectiveWidth = if ($ConsoleWidth -gt 0) { $ConsoleWidth } elseif ($null -ne $rawWidth) { $rawWidth } else { 120 }
-
-        if ($effectiveWidth -lt 120) {
-            $summaryView | Format-List
-        } else {
-            $summaryView | Format-Table -AutoSize
-        }
-
+        Write-ExtractionSummaryView -SummaryView $summaryView -ConsoleWidth $ConsoleWidth
         if ($PassThru) { $summaryView }
     }
 
-    if ($Errors.Count -gt 0) {
-        if ($isInteractive) { Write-Output "" }
-        Write-Output "Notes / Errors:"
-        $Errors | ForEach-Object { Write-Output " - $_" }
-    }
+    Write-ExtractionSummaryErrors -Errors $Errors -IsInteractive $isInteractive
 }

--- a/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
+++ b/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+    Writes the end-of-run extraction summary to the host.
+.DESCRIPTION
+    Formats and displays a summary table (or list on narrow consoles) of all
+    extraction, move, and error statistics collected during the run.
+
+    Behavior varies by host interactivity:
+    - Interactive hosts (ConsoleHost, Visual Studio Code Host): full output —
+      header, Format-Table/-List view, and error notes.
+    - Non-interactive hosts (scheduled tasks, redirected streams): the
+      formatted table is suppressed, but any accumulated errors are still
+      written to the success stream so failures are never silent in
+      automation logs.
+.PARAMETER SourceDirectory
+    Source directory passed to the script.
+.PARAMETER DestinationDirectory
+    Destination directory passed to the script.
+.PARAMETER ExtractMode
+    Extraction mode used (PerArchiveSubfolder or Flat).
+.PARAMETER CollisionPolicy
+    Collision policy used (Skip, Overwrite, or Rename).
+.PARAMETER ZipCount
+    Total number of zip files found.
+.PARAMETER ProcessedZips
+    Number of zip files successfully processed.
+.PARAMETER FilesExtracted
+    Total number of files extracted across all archives.
+.PARAMETER UncompressedBytes
+    Total uncompressed bytes extracted.
+.PARAMETER CompressedBytes
+    Total compressed (on-disk) bytes of the zip files processed.
+.PARAMETER MoveSummary
+    PSCustomObject returned by Move-ZipFilesToParent containing Count, Bytes,
+    Destination, Skipped, Overwritten, and Renamed.
+.PARAMETER Errors
+    List of non-fatal error messages accumulated during the run.
+.PARAMETER Elapsed
+    Total elapsed time for the run.
+.PARAMETER HostName
+    Name of the current host. Defaults to $Host.Name. Accepted as a parameter
+    so that tests can inject a synthetic value without spawning a new host.
+.PARAMETER ConsoleWidth
+    Override the detected console width. 0 (default) means auto-detect via
+    $Host.UI.RawUI.WindowSize.Width. Pass a positive value to force Format-Table
+    (>= 120) or Format-List (< 120) regardless of the actual terminal width.
+    Useful in tests and when piping output to a fixed-width formatter.
+.PARAMETER PassThru
+    Switch. When set, emits the summary PSCustomObject to the pipeline in addition
+    to writing it to the host. Intended for testing so callers can inspect the
+    computed fields without needing to intercept Format-Table/-List.
+.NOTES
+    Error notes are always emitted when errors exist, regardless of host type,
+    so that failures are never silently swallowed in scheduled tasks or
+    automation pipelines.
+#>
+function Write-ExtractionSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDirectory,
+        [Parameter(Mandatory)][string]$DestinationDirectory,
+        [Parameter(Mandatory)][string]$ExtractMode,
+        [Parameter(Mandatory)][string]$CollisionPolicy,
+        [Parameter(Mandatory)][int]$ZipCount,
+        [Parameter(Mandatory)][int]$ProcessedZips,
+        [Parameter(Mandatory)][int]$FilesExtracted,
+        [Parameter(Mandatory)][int64]$UncompressedBytes,
+        [Parameter(Mandatory)][int64]$CompressedBytes,
+        [Parameter(Mandatory)][pscustomobject]$MoveSummary,
+        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Errors,
+        [Parameter(Mandatory)][timespan]$Elapsed,
+        [string]$HostName = $Host.Name,
+        [int]$ConsoleWidth = 0,
+        [switch]$PassThru
+    )
+
+    $isInteractive = $HostName -in ('ConsoleHost', 'Visual Studio Code Host')
+
+    if ($isInteractive) {
+        $compressionRatio = if ($CompressedBytes -gt 0) { "{0:N1}x" -f ($UncompressedBytes / [double]$CompressedBytes) } else { "n/a" }
+
+        $summaryView = [pscustomobject]@{
+            SrcDir          = $SourceDirectory
+            DestDir         = $DestinationDirectory
+            Mode            = $ExtractMode
+            Policy          = $CollisionPolicy
+            ZipsFound       = $ZipCount
+            ZipsDone        = $ProcessedZips
+            Files           = $FilesExtracted
+            Uncompressed    = (Format-Bytes $UncompressedBytes)
+            Compressed      = (Format-Bytes $CompressedBytes)
+            Ratio           = $compressionRatio
+            ZipsMoved       = ($MoveSummary.Count)
+            MoveSkipped     = ($MoveSummary.Skipped)
+            MoveOverwritten = ($MoveSummary.Overwritten)
+            MoveRenamed     = ($MoveSummary.Renamed)
+            MovedBytes      = (Format-Bytes $MoveSummary.Bytes)
+            MovedTo         = ($MoveSummary.Destination)
+            Errors          = ($Errors.Count)
+            Duration        = ("{0:hh\:mm\:ss\.fff}" -f $Elapsed)
+        }
+
+        Write-Output ""
+        Write-Output "==== Expand-ZipsAndClean Summary ===="
+
+        $rawWidth = try { $Host.UI.RawUI.WindowSize.Width } catch { $null }
+        $effectiveWidth = if ($ConsoleWidth -gt 0) { $ConsoleWidth } elseif ($null -ne $rawWidth) { $rawWidth } else { 120 }
+
+        if ($effectiveWidth -lt 120) {
+            $summaryView | Format-List
+        } else {
+            $summaryView | Format-Table -AutoSize
+        }
+
+        if ($PassThru) { $summaryView }
+    }
+
+    if ($Errors.Count -gt 0) {
+        if ($isInteractive) { Write-Output "" }
+        Write-Output "Notes / Errors:"
+        $Errors | ForEach-Object { Write-Output " - $_" }
+    }
+}

--- a/src/powershell/modules/Core/Progress/README.md
+++ b/src/powershell/modules/Core/Progress/README.md
@@ -39,6 +39,19 @@ Show-Progress -Activity "Processing files" -PercentComplete 25 -Status "Validati
    ```
 
 ## Parameters
+- **Write-ExtractionSummary**
+  - `SourceDirectory` (string, required): Source directory displayed in the summary.
+  - `DestinationDirectory` (string, required): Destination directory displayed in the summary.
+  - `ExtractMode` (string, required): Extraction mode to report.
+  - `CollisionPolicy` (string, required): Collision policy to report.
+  - `ZipCount`, `ProcessedZips`, `FilesExtracted` (int, required): Archive and file counters.
+  - `UncompressedBytes`, `CompressedBytes` (int64, required): Byte counters used for formatted sizes and ratio.
+  - `MoveSummary` (pscustomobject, required): Zip move counters and destination.
+  - `Errors` (`List[string]`, required): Non-fatal error notes to emit.
+  - `Elapsed` (timespan, required): Run duration to display.
+  - `HostName` (string, default `$Host.Name`): Test-injection override for interactive detection.
+  - `ConsoleWidth` (int, default `0`): Test-injection override for table/list selection; widths below 120 use `Format-List`.
+  - `PassThru` (switch): Emits the computed summary object for callers/tests.
 - **Show-ProgressPhase**
   - `Activity` (string, required): Progress-bar activity label.
   - `Status` (string, required): Status message shown on the bar.
@@ -108,6 +121,20 @@ Import-Module "$PSScriptRoot/path/to/ProgressReporter.psm1"
 ```
 
 ## Functions
+
+### Write-ExtractionSummary
+
+Renders the `Expand-ZipsAndClean` end-of-run summary. Interactive hosts (`ConsoleHost` and `Visual Studio Code Host`) receive the header plus a formatted table or list depending on console width. Non-interactive hosts suppress the table but still emit accumulated error notes to the success stream for automation logs.
+
+**Example:**
+```powershell
+Write-ExtractionSummary `
+    -SourceDirectory $source -DestinationDirectory $destination `
+    -ExtractMode PerArchiveSubfolder -CollisionPolicy Rename `
+    -ZipCount $zipCount -ProcessedZips $processedZips -FilesExtracted $files `
+    -UncompressedBytes $uncompressed -CompressedBytes $compressed `
+    -MoveSummary $moveSummary -Errors $errors -Elapsed $stopwatch.Elapsed
+```
 
 ### Show-ProgressPhase
 
@@ -393,6 +420,13 @@ $tracker = New-ProgressTracker -Total 100000 -Activity "Processing" -UpdateFrequ
 This significantly reduces the performance impact of progress reporting.
 
 ## Version History
+
+### 1.2.0 (Unreleased)
+- Added `Write-ExtractionSummary` as a public summary renderer for `Expand-ZipsAndClean`.
+- Module manifest exports the new summary function and imports `Core/FileSystem` for `Format-Bytes`.
+
+### 1.1.0 (2026-05-29)
+- Added `Show-ProgressPhase` for quiet-mode-aware phase progress with percentage calculation.
 
 ### 1.0.0 (2025-11-20)
 - Initial release

--- a/src/powershell/modules/Core/Progress/README.md
+++ b/src/powershell/modules/Core/Progress/README.md
@@ -425,6 +425,9 @@ This significantly reduces the performance impact of progress reporting.
 
 ## Version History
 
+### 1.2.2 (Unreleased)
+- Reduced duplicated new-code lines in `Write-ExtractionSummary.ps1` by deriving internal summary state from bound parameters.
+
 ### 1.2.1 (Unreleased)
 - Refactored `Write-ExtractionSummary` into smaller internal helper functions to reduce Cognitive Complexity without behavior changes.
 

--- a/src/powershell/modules/Core/Progress/README.md
+++ b/src/powershell/modules/Core/Progress/README.md
@@ -4,6 +4,10 @@
 
 The ProgressReporter module provides standardized progress reporting utilities for PowerShell scripts. It offers consistent progress bar formatting, logging integration, and a tracker object for managing complex multi-stage operations.
 
+## Requirements
+
+- PowerShell 7.0 or newer. `Write-ExtractionSummary` imports shared byte formatting from `Core/FileSystem`, which is a PowerShell 7 module.
+
 ## Quick Start
 ```powershell
 Import-Module ProgressReporter
@@ -423,7 +427,7 @@ This significantly reduces the performance impact of progress reporting.
 
 ### 1.2.0 (Unreleased)
 - Added `Write-ExtractionSummary` as a public summary renderer for `Expand-ZipsAndClean`.
-- Module manifest exports the new summary function and imports `Core/FileSystem` for `Format-Bytes`.
+- Module manifest exports the new summary function, imports `Core/FileSystem` for `Format-Bytes`, and raises the minimum PowerShell version to 7.0.
 
 ### 1.1.0 (2026-05-29)
 - Added `Show-ProgressPhase` for quiet-mode-aware phase progress with percentage calculation.

--- a/src/powershell/modules/Core/Progress/README.md
+++ b/src/powershell/modules/Core/Progress/README.md
@@ -425,6 +425,9 @@ This significantly reduces the performance impact of progress reporting.
 
 ## Version History
 
+### 1.2.1 (Unreleased)
+- Refactored `Write-ExtractionSummary` into smaller internal helper functions to reduce Cognitive Complexity without behavior changes.
+
 ### 1.2.0 (Unreleased)
 - Added `Write-ExtractionSummary` as a public summary renderer for `Expand-ZipsAndClean`.
 - Module manifest exports the new summary function, imports `Core/FileSystem` for `Format-Bytes`, and raises the minimum PowerShell version to 7.0.

--- a/src/powershell/modules/FileManagement/ZipWorkflow/Public/Move-ZipFilesToParent.ps1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/Public/Move-ZipFilesToParent.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Moves .zip files from SourceDir to its parent folder with per-file progress.
+
+.PARAMETER SourceDir
+    The source directory containing .zip files to move.
+
+.PARAMETER QuietMode
+    Suppresses progress bar output when $true.
+
+.PARAMETER CollisionPolicy
+    Behavior when a zip with the same name already exists in the parent directory:
+      - Skip       : leave the existing parent zip untouched and do not move the source zip.
+      - Overwrite  : replace the existing parent zip with the source zip (Move-Item -Force).
+      - Rename     : move the source zip with a unique suffix (default, prior behavior).
+#>
+function Move-ZipFilesToParent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][bool]$QuietMode,
+        [ValidateSet('Skip', 'Overwrite', 'Rename')][string]$CollisionPolicy = 'Rename'
+    )
+
+    $parentItem = Get-Item -LiteralPath $SourceDir
+    $parent = $parentItem.Parent?.FullName
+    if (-not $parent) {
+        throw "Cannot move zip files: source directory '$SourceDir' is at drive root (no parent directory exists)"
+    }
+
+    if (-not [System.IO.Directory]::Exists($parent)) {
+        throw "Parent directory not found: $parent"
+    }
+
+    # Writability probe (skip if WhatIf)
+    if (-not $WhatIfPreference) {
+        $null = Test-DirectoryWritable -Path $parent -ThrowOnFailure
+    }
+
+    $zipsToMove = @(Get-ChildItem -LiteralPath $SourceDir -Filter *.zip -File)
+    $total = $zipsToMove.Count
+    $totalBytes = [int64](($zipsToMove | Measure-Object Length -Sum).Sum)
+
+    $idx = 0
+    $moved = 0
+    $bytes = [int64]0
+    $skipped = 0
+    $overwritten = 0
+    $renamed = 0
+
+    foreach ($zf in $zipsToMove) {
+        $idx++
+        # Include the current file's size in the display so the byte counter reflects
+        # the running total up to and including the file being processed (fixes the
+        # off-by-one where the caption previously showed only bytes from prior files).
+        Show-ProgressPhase -Activity "Moving zip files to parent" `
+            -Status "$idx / $total : $($zf.Name) ($(Format-Bytes $zf.Length))" `
+            -Current $idx -Total $total -QuietMode $QuietMode `
+            -CurrentOperation ("Moving: {0} of {1} bytes" -f (Format-Bytes ($bytes + $zf.Length)), (Format-Bytes $totalBytes))
+
+        $mt = Resolve-MoveTarget -Zip $zf -Parent $parent -CollisionPolicy $CollisionPolicy
+
+        if ($mt.PolicyTag -eq 'Skip') {
+            $skipped++
+            continue
+        }
+
+        Move-FileWithRetry -Source $zf.FullName -Destination $mt.TargetPath -Force:($mt.PolicyTag -eq 'Overwrite')
+        if ($mt.PolicyTag -eq 'Overwrite') { $overwritten++ }
+        elseif ($mt.PolicyTag -eq 'Rename') { $renamed++ }
+        $moved++
+        $bytes += $zf.Length
+    }
+
+    Show-ProgressPhase -Activity "Moving zip files to parent" -Status "Done" `
+        -Current $total -Total $total -QuietMode $QuietMode -Completed
+
+    [pscustomobject]@{ Count = $moved; Bytes = $bytes; Destination = $parent; Skipped = $skipped; Overwritten = $overwritten; Renamed = $renamed }
+}

--- a/src/powershell/modules/FileManagement/ZipWorkflow/Public/Move-ZipFilesToParent.ps1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/Public/Move-ZipFilesToParent.ps1
@@ -65,7 +65,7 @@ function Move-ZipFilesToParent {
             continue
         }
 
-        Move-FileWithRetry -Source $zf.FullName -Destination $mt.TargetPath -Force:($mt.PolicyTag -eq 'Overwrite')
+        $null = Move-FileWithRetry -Source $zf.FullName -Destination $mt.TargetPath -Force:($mt.PolicyTag -eq 'Overwrite')
         if ($mt.PolicyTag -eq 'Overwrite') { $overwritten++ }
         elseif ($mt.PolicyTag -eq 'Rename') { $renamed++ }
         $moved++

--- a/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
@@ -1,5 +1,17 @@
 #requires -Version 7.0
 
+$coreModules = @(
+    '..\..\Core\FileSystem\FileSystem.psm1',
+    '..\..\Core\Progress\ProgressReporter.psm1',
+    '..\..\Core\FileOperations\FileOperations.psm1'
+)
+foreach ($relativeModulePath in $coreModules) {
+    $modulePath = Join-Path $PSScriptRoot $relativeModulePath
+    if (Test-Path -LiteralPath $modulePath) {
+        Import-Module $modulePath -Force
+    }
+}
+
 # Provide no-op logging fallback for helper-load/test contexts where the
 # logging framework is not imported into the same scope as this module.
 if (-not (Get-Command -Name Write-LogDebug -ErrorAction SilentlyContinue)) {

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -2,33 +2,7 @@ Set-StrictMode -Version Latest
 
 Describe 'Move-ZipFilesToParent' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Progress\ProgressReporter.psm1') -Force
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-
-        function Write-LogDebug { param([string]$Message) }
-        function Move-FileWithRetry {
-            param([string]$Source, [string]$Destination, [switch]$Force)
-            Move-Item -LiteralPath $Source -Destination $Destination -Force:$Force
-        }
-        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'moves zip files from source to parent directory' {
@@ -39,7 +13,7 @@ Describe 'Move-ZipFilesToParent' {
         $zipPath = Join-Path $sourceDir 'test.zip'
         Set-Content -LiteralPath $zipPath -Value 'dummy zip content' -NoNewline
 
-        $result = Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true
+        $result = ZipWorkflow\Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true
 
         $result.Count | Should -Be 1
         $result.Bytes | Should -BeGreaterThan 0
@@ -50,12 +24,11 @@ Describe 'Move-ZipFilesToParent' {
     }
 
     It 'throws clear error for drive root source directory' {
-        # Mock Get-Item to simulate a drive root (no parent directory)
-        Mock Get-Item {
+        Mock Get-Item -ModuleName ZipWorkflow {
             [pscustomobject]@{ Parent = $null; FullName = 'C:\' }
         }
 
-        { Move-ZipFilesToParent -SourceDir 'C:\' -QuietMode $true } | Should -Throw "*drive root*"
+        { ZipWorkflow\Move-ZipFilesToParent -SourceDir 'C:\' -QuietMode $true } | Should -Throw '*drive root*'
     }
 
     It 'Rename policy: keeps existing parent zip and moves source zip under a unique name on collision' {
@@ -68,123 +41,21 @@ Describe 'Move-ZipFilesToParent' {
         Set-Content -LiteralPath $srcZip    -Value 'new-content'      -NoNewline
         Set-Content -LiteralPath $parentZip -Value 'original-content' -NoNewline
 
-        $result = Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true -CollisionPolicy Rename
+        $result = ZipWorkflow\Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true -CollisionPolicy Rename
 
         $result.Count   | Should -Be 1
         $result.Renamed | Should -Be 1
 
-        # Source zip must be gone; original parent zip must be intact
         [System.IO.File]::Exists($srcZip) | Should -BeFalse
         (Get-Content -LiteralPath $parentZip -Raw) | Should -Be 'original-content'
 
-        # A second zip with a unique name must exist in the parent
         $parentZips = @(Get-ChildItem -LiteralPath $parentDir -Filter '*.zip' -File)
         $parentZips.Count | Should -Be 2
     }
-
-}
-
-Describe 'Write-ExtractionSummary' {
-    BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd   = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-
-        function Write-LogDebug { param([string]$Message) }
-        . ([ScriptBlock]::Create($helpersWithUsing))
-
-        $script:defaultMoveSummary = [pscustomobject]@{
-            Count = 3; Bytes = [int64]5000; Destination = 'C:\parent'
-            Skipped = 0; Overwritten = 0; Renamed = 1
-        }
-        $script:emptyErrors = [System.Collections.Generic.List[string]]::new()
-        $script:testElapsed = [timespan]::FromSeconds(2.5)
-    }
-
-    It 'emits interactive summary header and view payload' {
-        Mock Format-Table { }
-        Mock Format-List  { }
-
-        $allOutput = @(Write-ExtractionSummary `
-            -SourceDirectory 'C:\mysrc' -DestinationDirectory 'C:\mydest' `
-            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 7 -ProcessedZips 6 -FilesExtracted 30 `
-            -UncompressedBytes ([int64]2000000) -CompressedBytes ([int64]600000) `
-            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
-            -Elapsed ([timespan]::FromSeconds(10)) -HostName 'ConsoleHost' -PassThru)
-
-        $allOutput | Should -Contain '==== Expand-ZipsAndClean Summary ===='
-        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
-
-        $view             | Should -Not -BeNullOrEmpty
-        $view.SrcDir      | Should -Be 'C:\mysrc'
-        $view.DestDir     | Should -Be 'C:\mydest'
-        $view.ZipsFound   | Should -Be 7
-        $view.ZipsDone    | Should -Be 6
-        $view.Files       | Should -Be 30
-        $view.Ratio       | Should -Be '3.3x'
-        $view.Duration    | Should -BeLike '00:00:10*'
-    }
-
-    It 'suppresses summary table and header when non-interactive and no errors' {
-        Mock Format-Table { }
-        Mock Format-List  { }
-
-        $output = @(Write-ExtractionSummary `
-            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
-            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 5 -ProcessedZips 5 -FilesExtracted 20 `
-            -UncompressedBytes ([int64]1000000) -CompressedBytes ([int64]300000) `
-            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
-            -Elapsed $script:testElapsed -HostName 'DefaultHost')
-
-        $output.Count   | Should -Be 0
-        Should -Invoke Format-Table -Times 0
-        Should -Invoke Format-List  -Times 0
-    }
-
-    It 'emits error notes even when host is non-interactive' {
-        $errList = [System.Collections.Generic.List[string]]::new()
-        $errList.Add('Archive is corrupt')
-        Mock Format-Table { }
-        Mock Format-List  { }
-
-        $output = @(Write-ExtractionSummary `
-            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
-            -ExtractMode 'Flat' -CollisionPolicy 'Skip' `
-            -ZipCount 1 -ProcessedZips 0 -FilesExtracted 0 `
-            -UncompressedBytes ([int64]0) -CompressedBytes ([int64]0) `
-            -MoveSummary $script:defaultMoveSummary -Errors $errList `
-            -Elapsed $script:testElapsed -HostName 'DefaultHost')
-
-        Should -Invoke Format-Table -Times 0
-        Should -Invoke Format-List  -Times 0
-        ($output | Where-Object { $_ -like '*Notes / Errors*' }) | Should -Not -BeNullOrEmpty
-        ($output | Where-Object { $_ -like '* - Archive is corrupt' }) | Should -Not -BeNullOrEmpty
-    }
-
 }
 
 Describe 'Invoke-ZipExtractions — wrapper delegation' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipExtraction\ZipExtraction.psm1') -Force
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
     }
@@ -196,7 +67,7 @@ Describe 'Invoke-ZipExtractions — wrapper delegation' {
         New-Item -ItemType Directory -Path $destDir   -Force | Out-Null
 
         $errorList = [System.Collections.Generic.List[string]]::new()
-        $result = Invoke-ZipExtractions `
+        $result = ZipExtraction\Invoke-ZipExtractions `
             -SourceDir      $sourceDir `
             -DestinationDir $destDir `
             -Mode           'PerArchiveSubfolder' `
@@ -214,89 +85,42 @@ Describe 'Invoke-ZipExtractions — wrapper delegation' {
 
 Describe 'Test-ScriptPreconditions' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd   = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-
-        function Write-LogDebug { param([string]$Message) }
-        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'throws when source and destination are the same path' {
-        # Get-FullPath returns the same (possibly mangled) string for both arguments,
-        # so the equality check always fires before any path-containment logic.
-        Mock Get-FullPath { param([string]$Path) $Path }
+        Mock Get-FullPath -ModuleName ZipWorkflow { param([string]$Path) $Path }
         $sep = [System.IO.Path]::DirectorySeparatorChar
         $dir = "${sep}precond-same"
 
-        { Test-ScriptPreconditions -SourceDir $dir -DestinationDir $dir } |
-            Should -Throw "*Source and destination cannot be the same*"
+        { ZipWorkflow\Test-ScriptPreconditions -SourceDir $dir -DestinationDir $dir } |
+            Should -Throw '*Source and destination cannot be the same*'
     }
 
     It 'throws when destination is inside the source directory' {
-        # Get-FullPath converts '/' to '\' before resolving, which breaks containment
-        # detection on Linux (Add-TrailingSeparator then adds '/' making StartsWith fail).
-        # Mock it as an identity so Test-PathContainment sees native-separator paths.
-        Mock Get-FullPath { param([string]$Path) $Path }
+        Mock Get-FullPath -ModuleName ZipWorkflow { param([string]$Path) $Path }
         $sep  = [System.IO.Path]::DirectorySeparatorChar
         $src  = "${sep}precond-src"
         $dest = "${sep}precond-src${sep}inner"
 
-        { Test-ScriptPreconditions -SourceDir $src -DestinationDir $dest } |
-            Should -Throw "*Destination cannot be inside the source*"
+        { ZipWorkflow\Test-ScriptPreconditions -SourceDir $src -DestinationDir $dest } |
+            Should -Throw '*Destination cannot be inside the source*'
     }
 
     It 'throws when source is inside the destination directory' {
-        Mock Get-FullPath { param([string]$Path) $Path }
+        Mock Get-FullPath -ModuleName ZipWorkflow { param([string]$Path) $Path }
         $sep  = [System.IO.Path]::DirectorySeparatorChar
         $dest = "${sep}precond-dest"
         $src  = "${sep}precond-dest${sep}inner"
 
-        { Test-ScriptPreconditions -SourceDir $src -DestinationDir $dest } |
-            Should -Throw "*Source cannot be inside the destination*"
+        { ZipWorkflow\Test-ScriptPreconditions -SourceDir $src -DestinationDir $dest } |
+            Should -Throw '*Source cannot be inside the destination*'
     }
 }
 
 Describe 'Resolve-MoveTarget' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
-        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
-        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
-
-        $helpersStart = $scriptText.IndexOf('#region Helpers')
-        $helpersEnd   = $scriptText.IndexOf('#endregion Helpers')
-        if ($helpersStart -lt 0 -or $helpersEnd -lt 0) {
-            throw 'Failed to locate helpers region in Expand-ZipsAndClean.ps1'
-        }
-
-        $helpers = $scriptText.Substring($helpersStart, $helpersEnd - $helpersStart)
-        $usingLines = ($scriptText -split "`n" |
-            Where-Object { $_ -match '^\s*using\s+namespace\s+' }) -join "`n"
-        $helpersWithUsing = $usingLines + "`n" + $helpers
-
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1') -Force
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\Zip\Zip.psm1') -Force
         Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-
-        function Write-LogDebug { param([string]$Message) }
-        . ([ScriptBlock]::Create($helpersWithUsing))
     }
 
     It 'returns PolicyTag None and canonical TargetPath when no collision' {
@@ -306,7 +130,7 @@ Describe 'Resolve-MoveTarget' {
         Set-Content -LiteralPath $zipPath -Value 'x' -NoNewline
         $zip = Get-Item -LiteralPath $zipPath
 
-        $result = Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Rename'
+        $result = ZipWorkflow\Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Rename'
 
         $result.PolicyTag  | Should -Be 'None'
         $result.TargetPath | Should -Be (Join-Path $parentDir 'rmt-no-coll-src.zip')
@@ -318,11 +142,10 @@ Describe 'Resolve-MoveTarget' {
         Set-Content -LiteralPath (Join-Path $parentDir 'dup.zip') -Value 'existing' -NoNewline
         $zipPath = Join-Path $TestDrive 'rmt-skip-src.zip'
         Set-Content -LiteralPath $zipPath -Value 'new' -NoNewline
-        # Rename to collide with the parent file
         Rename-Item -LiteralPath $zipPath -NewName 'dup.zip'
         $zip = Get-Item -LiteralPath (Join-Path $TestDrive 'dup.zip')
 
-        $result = Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Skip'
+        $result = ZipWorkflow\Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Skip'
 
         $result.PolicyTag  | Should -Be 'Skip'
         $result.TargetPath | Should -Be (Join-Path $parentDir 'dup.zip')
@@ -337,7 +160,7 @@ Describe 'Resolve-MoveTarget' {
         Rename-Item -LiteralPath $zipPath -NewName 'ow.zip'
         $zip = Get-Item -LiteralPath (Join-Path $TestDrive 'ow.zip')
 
-        $result = Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Overwrite'
+        $result = ZipWorkflow\Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Overwrite'
 
         $result.PolicyTag  | Should -Be 'Overwrite'
         $result.TargetPath | Should -Be (Join-Path $parentDir 'ow.zip')
@@ -352,10 +175,24 @@ Describe 'Resolve-MoveTarget' {
         Rename-Item -LiteralPath $zipPath -NewName 'rn.zip'
         $zip = Get-Item -LiteralPath (Join-Path $TestDrive 'rn.zip')
 
-        $result = Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Rename'
+        $result = ZipWorkflow\Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy 'Rename'
 
         $result.PolicyTag  | Should -Be 'Rename'
         $result.TargetPath | Should -Not -Be (Join-Path $parentDir 'rn.zip')
         $result.TargetPath | Should -BeLike (Join-Path $parentDir 'rn*')
+    }
+}
+
+Describe 'Expand-ZipsAndClean script structure' {
+    It 'contains no script-local helper function definitions' {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref]$tokens, [ref]$parseErrors)
+
+        $parseErrors | Should -BeNullOrEmpty
+        @($ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)).Count |
+            Should -Be 0
     }
 }

--- a/tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1
+++ b/tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1
@@ -1,0 +1,92 @@
+Set-StrictMode -Version Latest
+
+Describe 'Write-ExtractionSummary' {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..\..\..\..\..\src\powershell\modules\Core\Progress\ProgressReporter.psm1') -Force
+
+        $script:defaultMoveSummary = [pscustomobject]@{
+            Count = 3; Bytes = [int64]5000; Destination = 'C:\parent'
+            Skipped = 0; Overwritten = 0; Renamed = 1
+        }
+        $script:emptyErrors = [System.Collections.Generic.List[string]]::new()
+        $script:testElapsed = [timespan]::FromSeconds(2.5)
+    }
+
+    It 'emits interactive summary header and view payload' {
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        $allOutput = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\mysrc' -DestinationDirectory 'C:\mydest' `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 7 -ProcessedZips 6 -FilesExtracted 30 `
+            -UncompressedBytes ([int64]2000000) -CompressedBytes ([int64]600000) `
+            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
+            -Elapsed ([timespan]::FromSeconds(10)) -HostName 'ConsoleHost' -PassThru)
+
+        $allOutput | Should -Contain '==== Expand-ZipsAndClean Summary ===='
+        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
+
+        $view             | Should -Not -BeNullOrEmpty
+        $view.SrcDir      | Should -Be 'C:\mysrc'
+        $view.DestDir     | Should -Be 'C:\mydest'
+        $view.ZipsFound   | Should -Be 7
+        $view.ZipsDone    | Should -Be 6
+        $view.Files       | Should -Be 30
+        $view.Ratio       | Should -Be '3.3x'
+        $view.Duration    | Should -BeLike '00:00:10*'
+    }
+
+    It 'suppresses summary table and header when non-interactive and no errors' {
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        $output = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 5 -ProcessedZips 5 -FilesExtracted 20 `
+            -UncompressedBytes ([int64]1000000) -CompressedBytes ([int64]300000) `
+            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
+            -Elapsed $script:testElapsed -HostName 'DefaultHost')
+
+        $output.Count   | Should -Be 0
+        Should -Invoke Format-Table -ModuleName ProgressReporter -Times 0
+        Should -Invoke Format-List -ModuleName ProgressReporter -Times 0
+    }
+
+    It 'emits error notes even when host is non-interactive' {
+        $errList = [System.Collections.Generic.List[string]]::new()
+        $errList.Add('Archive is corrupt')
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        $output = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'Flat' -CollisionPolicy 'Skip' `
+            -ZipCount 1 -ProcessedZips 0 -FilesExtracted 0 `
+            -UncompressedBytes ([int64]0) -CompressedBytes ([int64]0) `
+            -MoveSummary $script:defaultMoveSummary -Errors $errList `
+            -Elapsed $script:testElapsed -HostName 'DefaultHost')
+
+        Should -Invoke Format-Table -ModuleName ProgressReporter -Times 0
+        Should -Invoke Format-List -ModuleName ProgressReporter -Times 0
+        ($output | Where-Object { $_ -like '*Notes / Errors*' }) | Should -Not -BeNullOrEmpty
+        ($output | Where-Object { $_ -like '* - Archive is corrupt' }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'uses Format-List for narrow interactive consoles' {
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'Flat' -CollisionPolicy 'Rename' `
+            -ZipCount 1 -ProcessedZips 1 -FilesExtracted 1 `
+            -UncompressedBytes ([int64]1000) -CompressedBytes ([int64]0) `
+            -MoveSummary $script:defaultMoveSummary -Errors $script:emptyErrors `
+            -Elapsed $script:testElapsed -HostName 'ConsoleHost' -ConsoleWidth 80
+
+        Should -Invoke Format-List -ModuleName ProgressReporter -Times 1
+        Should -Invoke Format-Table -ModuleName ProgressReporter -Times 0
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize presentation logic by extracting the end-of-run summary renderer out of the script and into the shared Progress module so multiple callers can reuse consistent formatting and byte-formatting logic.
- Reduce script surface area by removing inlined helper implementations from `Expand-ZipsAndClean.ps1` so the script becomes a thin orchestrator that delegates work to well-scoped modules.
- Promote zip-move workflow ownership into a module so move/collision logic is module-owned and testable outside the top-level script.

### Description
- Moved `Write-ExtractionSummary` into `src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1` and exported it from `ProgressReporter.psm1`, preserving interactive header/table vs list selection, `PassThru`, compression-ratio formatting, and non-interactive error-note emission.
- Promoted `Move-ZipFilesToParent` into `src/powershell/modules/FileManagement/ZipWorkflow/Public/Move-ZipFilesToParent.ps1` and updated `ZipWorkflow.psm1` to import required core modules for helper delegation and test-load safety.
- Slimmed `src/powershell/file-management/Expand-ZipsAndClean.ps1` to a thin orchestrator that imports modules and calls `ZipExtraction\<...>`, `ZipWorkflow\<...>`, `FileSystem\<...>` and `ProgressReporter\<Write-ExtractionSummary>`; bumped script `Version` to `2.6.13`.
- Bumped `Core/Progress` manifest to `1.2.0`, added `Write-ExtractionSummary` to `FunctionsToExport`, imported `Core/FileSystem` in the module loader for `Format-Bytes` reuse, and updated CHANGELOGs and README entries to reflect the refactor and SemVer changes.
- Added Pester coverage files and reworked existing helper-focused tests: moved summary tests to `tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1` and added a script-structure assertion to `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` that asserts no script-local function definitions remain.

### Testing
- Ran `git diff --check` and repository diffs to validate no whitespace/merge markers; the check passed with no errors reported.
- Verified there are no script-local function definitions in `Expand-ZipsAndClean.ps1` using `rg` and a quick AST-based assertion (the test was added to the Pester suite); the repository now reports "No script-local function definitions found." for the script.
- Attempted to run the new Pester tests via `pwsh`/`Invoke-Pester` but `pwsh` is not installed in the container so Pester execution was not performed (tests were added and committed but not executed here).
- Committed the refactor (commit message: `refactor(powershell): move extraction summary to progress module`) and staged updated CHANGELOG/README/manifest entries reflecting the version bumps (`Expand-ZipsAndClean` → `2.6.13`, `Core/Progress` → `1.2.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d8fbd0bc832587644caa0adc38bd)