### PR TITLE
fix(powershell): fail fast on Expand-ZipsAndClean imports

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.15 — 2026-05-30
+
+### Fixed
+
+- Added `-ErrorAction Stop` to all seven `Expand-ZipsAndClean.ps1` startup `Import-Module` calls so a missing or broken module fails immediately before extraction work begins, instead of surfacing later as a `ProgressReporter\Write-ExtractionSummary` module-load error at the summary step.
+- Kept the existing `ZipExtraction` command-source guard as an additional consistency check after terminating imports.
+- Hardened the related `ProgressReporter` and `ZipWorkflow` module loaders so their internal dependency imports also fail fast.
+
+### Tests
+
+- Added script-structure coverage to require terminating startup imports on every top-level `Expand-ZipsAndClean.ps1` module dependency.
+
+---
+
 ## 2.6.14 — 2026-05-29
 
 ### Fixed

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.14
+    Version  : 2.6.15
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)
@@ -174,13 +174,13 @@ param(
 )
 
 # Import logging framework
-Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\Core\FileSystem\FileSystem.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\Core\Zip\Zip.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\Core\Progress\ProgressReporter.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\Core\FileOperations\FileOperations.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1" -Force
-Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1" -Force
+Import-Module "$PSScriptRoot\..\modules\Core\Logging\PowerShellLoggingFramework.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\Core\FileSystem\FileSystem.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\Core\Zip\Zip.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\Core\Progress\ProgressReporter.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\Core\FileOperations\FileOperations.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1" -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1" -Force -ErrorAction Stop
 
 $_zipExtractionCmd = Get-Command Invoke-ZipExtractions -ErrorAction SilentlyContinue
 if (-not $_zipExtractionCmd -or $_zipExtractionCmd.Source -ne 'ZipExtraction') {

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean fast-fail module import fix (issue #1188)** (2026-05-30)
+  - Added terminating `-ErrorAction Stop` handling to the script's startup module imports so dependency failures stop before extraction work begins and no longer appear as a late `ProgressReporter\Write-ExtractionSummary` summary-step error.
+  - Hardened `ProgressReporter` and `ZipWorkflow` dependency imports for consistent fail-fast module loading.
+  - Version bump: `2.6.15` (patch — module-load robustness bug fix).
+
 - **Expand-ZipsAndClean ZipWorkflow move output fix** (2026-05-29)
   - Suppressed `Move-FileWithRetry`'s boolean success output inside `ZipWorkflow\Move-ZipFilesToParent` so callers receive only the move-summary object.
   - Version bump: `2.6.14` (patch — output contract bug fix).

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG — Core/Progress (ProgressReporter)
 
+## 1.2.3 — Unreleased
+
+### Fixed
+
+- `ProgressReporter.psm1`: imports `Core/FileSystem` with `-ErrorAction Stop` so missing or broken dependency failures are terminating and surface at import time instead of allowing a partially loaded summary module.
+- `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.2.2` to `1.2.3` (PATCH — module-load robustness fix).
+
 ## 1.2.2 — Unreleased
 
 ### Changed

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ProgressReporter.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.2'
+    ModuleVersion = '1.2.3'
 
     # ID used to uniquely identify this module
     GUID = '9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e'

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psm1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psm1
@@ -1,9 +1,10 @@
 # Module loader for ProgressReporter
 
 $fileSystemModule = Join-Path $PSScriptRoot '..\FileSystem\FileSystem.psm1'
-if (Test-Path -LiteralPath $fileSystemModule) {
-    Import-Module $fileSystemModule -Force
+if (-not (Test-Path -LiteralPath $fileSystemModule)) {
+    throw "Required module dependency not found: $fileSystemModule"
 }
+Import-Module $fileSystemModule -Force -ErrorAction Stop
 
 $privateDir = Join-Path $PSScriptRoot 'Private'
 if (Test-Path -LiteralPath $privateDir) {

--- a/src/powershell/modules/Core/Progress/README.md
+++ b/src/powershell/modules/Core/Progress/README.md
@@ -425,6 +425,9 @@ This significantly reduces the performance impact of progress reporting.
 
 ## Version History
 
+### 1.2.3 (Unreleased)
+- Treat the internal `Core/FileSystem` dependency import as terminating so missing or broken dependencies fail fast during module load.
+
 ### 1.2.2 (Unreleased)
 - Reduced duplicated new-code lines in `Write-ExtractionSummary.ps1` by deriving internal summary state from bound parameters.
 

--- a/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
@@ -7,9 +7,10 @@ $coreModules = @(
 )
 foreach ($relativeModulePath in $coreModules) {
     $modulePath = Join-Path $PSScriptRoot $relativeModulePath
-    if (Test-Path -LiteralPath $modulePath) {
-        Import-Module $modulePath -Force
+    if (-not (Test-Path -LiteralPath $modulePath)) {
+        throw "Required module dependency not found: $modulePath"
     }
+    Import-Module $modulePath -Force -ErrorAction Stop
 }
 
 # Provide no-op logging fallback for helper-load/test contexts where the

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -184,6 +184,31 @@ Describe 'Resolve-MoveTarget' {
 }
 
 Describe 'Expand-ZipsAndClean script structure' {
+    It 'uses terminating imports for all startup modules before workflow execution' {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref]$tokens, [ref]$parseErrors)
+
+        $parseErrors | Should -BeNullOrEmpty
+
+        $importCommands = @($ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq 'Import-Module'
+        }, $true))
+
+        $startupImports = @($importCommands | Where-Object {
+            $_.Extent.Text -like '*$PSScriptRoot*..*modules*'
+        })
+
+        $startupImports.Count | Should -Be 7
+        foreach ($import in $startupImports) {
+            $import.Extent.Text | Should -Match '(?i)-ErrorAction\s+Stop'
+        }
+    }
+
     It 'contains no script-local helper function definitions' {
         $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
         $scriptText = Get-Content -LiteralPath $scriptPath -Raw


### PR DESCRIPTION
### Motivation

- Prevent a late `ProgressReporter\Write-ExtractionSummary` failure caused by non-terminating `Import-Module` calls during `Expand-ZipsAndClean.ps1` startup by making dependency-load failures fail fast.
- Make module loaders deterministic in helper/test load contexts so missing or broken internal module dependencies surface at import time instead of during end-of-run summary rendering.

### Description

- Updated `src/powershell/file-management/Expand-ZipsAndClean.ps1` to add `-ErrorAction Stop` to all seven startup `Import-Module` calls and bumped the script `Version` to `2.6.15` (patch — module-load robustness fix). 
- Hardened module loaders: `src/powershell/modules/Core/Progress/ProgressReporter.psm1` now throws if its `Core/FileSystem` dependency is missing and imports it with `-ErrorAction Stop`, and `src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1` now throws for missing core dependencies and imports them with `-ErrorAction Stop`.
- Bumped `ProgressReporter` manifest `ModuleVersion` to `1.2.3` and added corresponding `CHANGELOG` / `README` entries documenting the module-load robustness fix.
- Added a Pester structure test in `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` that parses the script AST and asserts all top-level `Expand-ZipsAndClean.ps1` startup `Import-Module` calls include a terminating `-ErrorAction Stop` flag.

### Testing

- Performed static verification with a Python check that asserts all seven startup `Import-Module` lines in `Expand-ZipsAndClean.ps1` include `-ErrorAction Stop`, the script `Version` is `2.6.15`, the `ProgressReporter` manifest version is `1.2.3`, and the module loader changes are present, and these checks passed.
- Ran `git diff --check` to validate no whitespace/merge markers and it reported no blocking issues.
- Attempted to run the PowerShell Pester suite (`Invoke-Pester`) to execute the added structural test, but `pwsh` is not available in the environment so the Pester run was not executed (test added and ready to run in PS environments).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af4dadfc4832591deb84fc7620eb5)