### PR TITLE
fix(expand-zips): guard ZipWorkflow dependency imports

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.18 — 2026-05-30 *(patch — import guard test fix)*
+
+### Fixed
+
+- Used a platform-appropriate path comparer for `ZipWorkflow` dependency path checks
+  (case-insensitive on Windows, case-sensitive elsewhere) before deciding whether an
+  already-loaded same-name module is the repository-local dependency.
+
+### Tests
+
+- Corrected the path-aware import-guard regression tests to verify behavior through
+  `ZipWorkflow` commands instead of expecting nested dependency imports to appear in
+  the caller's global module table.
+
 ## 2.6.17 — 2026-05-30 *(patch — path-aware import guard)*
 
 ### Fixed

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.17 — 2026-05-30 *(patch — path-aware import guard)*
+
+### Fixed
+
+- Matched `ZipWorkflow`'s already-loaded dependency guard by resolved module path, not just
+  module name. Same-name modules loaded from other locations no longer cause repository-local
+  `FileSystem`, `ProgressReporter`, or `FileOperations` dependencies to be skipped.
+
+### Tests
+
+- Added regression coverage for same-name external `FileSystem` modules so `ZipWorkflow`
+  still loads the repository-local dependency.
+
 ## 2.6.16 — 2026-05-30 *(patch — ZipWorkflow import guard)*
 
 ### Fixed

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.16 — 2026-05-30 *(patch — ZipWorkflow import guard)*
+
+### Fixed
+
+- Guarded `ZipWorkflow` dependency imports so already-loaded core modules are reused instead
+  of being force-unloaded and reimported. This preserves `ProgressReporter` through the full
+  `Expand-ZipsAndClean.ps1` startup load sequence and prevents the summary-step
+  `ProgressReporter\Write-ExtractionSummary` module-load failure.
+
+### Tests
+
+- Added regression coverage for the full startup import sequence, the module-qualified
+  summary call, and standalone `ZipWorkflow` loading when `ProgressReporter` is not preloaded.
+
 ## 2.6.15 — 2026-05-30 *(patch — startup robustness)*
 
 ### Fixed

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.15
+    Version  : 2.6.16
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.16
+    Version  : 2.6.17
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.17
+    Version  : 2.6.18
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean path-aware ZipWorkflow import guard fix (issue #1191)** (2026-05-30)
+  - Tightened the `ZipWorkflow` dependency guard so it only skips an import when the loaded module path matches the repository-local dependency path.
+  - Added regression coverage for a same-name external `FileSystem` module to ensure repository-local dependencies are still loaded.
+  - Version bump: `2.6.17` (patch — module-load regression fix).
+
 - **Expand-ZipsAndClean ZipWorkflow import guard fix (issue #1191)** (2026-05-30)
   - Changed `ZipWorkflow` to reuse already-loaded core modules instead of force-reimporting them, preventing `ProgressReporter` from being unloaded before the final summary call.
   - Added regression coverage for the full startup import sequence, `ProgressReporter\Write-ExtractionSummary`, and standalone `ZipWorkflow` loading.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean ZipWorkflow import guard fix (issue #1191)** (2026-05-30)
+  - Changed `ZipWorkflow` to reuse already-loaded core modules instead of force-reimporting them, preventing `ProgressReporter` from being unloaded before the final summary call.
+  - Added regression coverage for the full startup import sequence, `ProgressReporter\Write-ExtractionSummary`, and standalone `ZipWorkflow` loading.
+  - Version bump: `2.6.16` (patch — module-load regression fix).
+
 - **Expand-ZipsAndClean fast-fail module import fix (issue #1188)** (2026-05-30)
   - Added terminating `-ErrorAction Stop` handling to the script's startup module imports so dependency failures stop before extraction work begins and no longer appear as a late `ProgressReporter\Write-ExtractionSummary` summary-step error.
   - Hardened `ProgressReporter` and `ZipWorkflow` dependency imports for consistent fail-fast module loading.

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean path-aware import guard test fix (issue #1191)** (2026-05-30)
+  - Used a platform-appropriate path comparer for `ZipWorkflow` dependency path checks before skipping already-loaded same-name modules.
+  - Corrected regression tests to validate nested dependency behavior through `ZipWorkflow` commands rather than global module visibility.
+  - Version bump: `2.6.18` (patch — module-load regression/test fix).
+
 - **Expand-ZipsAndClean path-aware ZipWorkflow import guard fix (issue #1191)** (2026-05-30)
   - Tightened the `ZipWorkflow` dependency guard so it only skips an import when the loaded module path matches the repository-local dependency path.
   - Added regression coverage for a same-name external `FileSystem` module to ensure repository-local dependencies are still loaded.

--- a/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
@@ -5,6 +5,12 @@ $coreModules = @(
     '..\..\Core\Progress\ProgressReporter.psm1',
     '..\..\Core\FileOperations\FileOperations.psm1'
 )
+$modulePathComparer = if ($IsWindows) {
+    [System.StringComparer]::OrdinalIgnoreCase
+} else {
+    [System.StringComparer]::Ordinal
+}
+
 foreach ($relativeModulePath in $coreModules) {
     $modulePath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $relativeModulePath))
     $moduleName = [System.IO.Path]::GetFileNameWithoutExtension(($relativeModulePath -split '[\\/]' | Select-Object -Last 1))
@@ -14,7 +20,7 @@ foreach ($relativeModulePath in $coreModules) {
     }
 
     $loadedModule = Get-Module -Name $moduleName | Where-Object {
-        $_.Path -and [System.StringComparer]::OrdinalIgnoreCase.Equals(
+        $_.Path -and $modulePathComparer.Equals(
             [System.IO.Path]::GetFullPath($_.Path),
             $modulePath
         )

--- a/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
@@ -7,10 +7,17 @@ $coreModules = @(
 )
 foreach ($relativeModulePath in $coreModules) {
     $modulePath = Join-Path $PSScriptRoot $relativeModulePath
+    $moduleName = [System.IO.Path]::GetFileNameWithoutExtension(($relativeModulePath -split '[\\/]' | Select-Object -Last 1))
+
+    if (Get-Module -Name $moduleName) {
+        continue
+    }
+
     if (-not (Test-Path -LiteralPath $modulePath)) {
         throw "Required module dependency not found: $modulePath"
     }
-    Import-Module $modulePath -Force -ErrorAction Stop
+
+    Import-Module $modulePath -ErrorAction Stop
 }
 
 # Provide no-op logging fallback for helper-load/test contexts where the

--- a/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
+++ b/src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1
@@ -6,18 +6,25 @@ $coreModules = @(
     '..\..\Core\FileOperations\FileOperations.psm1'
 )
 foreach ($relativeModulePath in $coreModules) {
-    $modulePath = Join-Path $PSScriptRoot $relativeModulePath
+    $modulePath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $relativeModulePath))
     $moduleName = [System.IO.Path]::GetFileNameWithoutExtension(($relativeModulePath -split '[\\/]' | Select-Object -Last 1))
-
-    if (Get-Module -Name $moduleName) {
-        continue
-    }
 
     if (-not (Test-Path -LiteralPath $modulePath)) {
         throw "Required module dependency not found: $modulePath"
     }
 
-    Import-Module $modulePath -ErrorAction Stop
+    $loadedModule = Get-Module -Name $moduleName | Where-Object {
+        $_.Path -and [System.StringComparer]::OrdinalIgnoreCase.Equals(
+            [System.IO.Path]::GetFullPath($_.Path),
+            $modulePath
+        )
+    } | Select-Object -First 1
+
+    if ($loadedModule) {
+        continue
+    }
+
+    Import-Module $modulePath -Force -ErrorAction Stop
 }
 
 # Provide no-op logging fallback for helper-load/test contexts where the

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -222,13 +222,14 @@ Describe 'Expand-ZipsAndClean script structure' {
     }
 
 
-    It 'does not force-reimport ZipWorkflow core dependencies' {
+    It 'uses a path-aware guard before force-importing ZipWorkflow core dependencies' {
         $modulePath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
         $moduleText = Get-Content -LiteralPath $modulePath -Raw
 
         $moduleText | Should -Match 'Get-Module -Name \$moduleName'
-        $moduleText | Should -Not -Match 'Import-Module \$modulePath -Force'
-        $moduleText | Should -Match 'Import-Module \$modulePath -ErrorAction Stop'
+        $moduleText | Should -Match '\\$_.Path'
+        $moduleText | Should -Match 'OrdinalIgnoreCase\.Equals'
+        $moduleText | Should -Match 'Import-Module \$modulePath -Force -ErrorAction Stop'
     }
 }
 
@@ -284,5 +285,24 @@ Describe 'Expand-ZipsAndClean module load sequence' {
 
         Get-Module -Name ZipWorkflow | Should -Not -BeNullOrEmpty
         Get-Module -Name ProgressReporter | Should -Not -BeNullOrEmpty
+    }
+
+
+    It 'does not skip repository-local dependencies when another module with the same name is loaded' {
+        $foreignDir = Join-Path $TestDrive 'foreign-modules'
+        New-Item -ItemType Directory -Path $foreignDir -Force | Out-Null
+        $foreignFileSystemPath = Join-Path $foreignDir 'FileSystem.psm1'
+        Set-Content -LiteralPath $foreignFileSystemPath -Value 'function Get-FullPath { param([string]$Path) "foreign:$Path" }' -NoNewline
+
+        Import-Module $foreignFileSystemPath -Force -ErrorAction Stop
+        [System.IO.Path]::GetFullPath((Get-Module -Name FileSystem).Path) | Should -Be ([System.IO.Path]::GetFullPath($foreignFileSystemPath))
+
+        $zipWorkflowPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
+        $repoFileSystemPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1'
+
+        Import-Module $zipWorkflowPath -Force -ErrorAction Stop
+
+        $loadedFileSystemPaths = @(Get-Module -Name FileSystem | ForEach-Object { [System.IO.Path]::GetFullPath($_.Path) })
+        $loadedFileSystemPaths | Should -Contain ([System.IO.Path]::GetFullPath($repoFileSystemPath))
     }
 }

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -220,4 +220,69 @@ Describe 'Expand-ZipsAndClean script structure' {
         @($ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)).Count |
             Should -Be 0
     }
+
+
+    It 'does not force-reimport ZipWorkflow core dependencies' {
+        $modulePath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
+        $moduleText = Get-Content -LiteralPath $modulePath -Raw
+
+        $moduleText | Should -Match 'Get-Module -Name \$moduleName'
+        $moduleText | Should -Not -Match 'Import-Module \$modulePath -Force'
+        $moduleText | Should -Match 'Import-Module \$modulePath -ErrorAction Stop'
+    }
+}
+
+Describe 'Expand-ZipsAndClean module load sequence' {
+    BeforeEach {
+        'ZipWorkflow', 'ZipExtraction', 'FileOperations', 'ProgressReporter', 'Zip', 'FileSystem', 'PowerShellLoggingFramework' |
+            ForEach-Object { Remove-Module -Name $_ -Force -ErrorAction SilentlyContinue }
+    }
+
+    AfterEach {
+        'ZipWorkflow', 'ZipExtraction', 'FileOperations', 'ProgressReporter', 'Zip', 'FileSystem', 'PowerShellLoggingFramework' |
+            ForEach-Object { Remove-Module -Name $_ -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'keeps ProgressReporter loaded after the full startup import sequence' {
+        $scriptRoot = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management'
+
+        Import-Module (Join-Path $scriptRoot '..\modules\Core\Logging\PowerShellLoggingFramework.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\Core\FileSystem\FileSystem.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\Core\Zip\Zip.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\Core\Progress\ProgressReporter.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\Core\FileOperations\FileOperations.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\FileManagement\ZipExtraction\ZipExtraction.psm1') -Force -ErrorAction Stop
+        Import-Module (Join-Path $scriptRoot '..\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force -ErrorAction Stop
+
+        Get-Module -Name ProgressReporter | Should -Not -BeNullOrEmpty
+
+        $errors = [System.Collections.Generic.List[string]]::new()
+        {
+            ProgressReporter\Write-ExtractionSummary `
+                -SourceDirectory $TestDrive `
+                -DestinationDirectory $TestDrive `
+                -ExtractMode 'PerArchiveSubfolder' `
+                -CollisionPolicy 'Rename' `
+                -ZipCount 0 `
+                -ProcessedZips 0 `
+                -FilesExtracted 0 `
+                -UncompressedBytes 0 `
+                -CompressedBytes 0 `
+                -MoveSummary ([pscustomobject]@{ Count = 0; Bytes = 0; Destination = $TestDrive; Skipped = 0; Overwritten = 0; Renamed = 0 }) `
+                -Errors $errors `
+                -Elapsed ([timespan]::Zero) `
+                -HostName 'ServerRemoteHost'
+        } | Should -Not -Throw
+    }
+
+    It 'loads ZipWorkflow standalone and imports ProgressReporter when it was not already loaded' {
+        $zipWorkflowPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
+
+        Get-Module -Name ProgressReporter | Should -BeNullOrEmpty
+
+        Import-Module $zipWorkflowPath -Force -ErrorAction Stop
+
+        Get-Module -Name ZipWorkflow | Should -Not -BeNullOrEmpty
+        Get-Module -Name ProgressReporter | Should -Not -BeNullOrEmpty
+    }
 }

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -227,8 +227,9 @@ Describe 'Expand-ZipsAndClean script structure' {
         $moduleText = Get-Content -LiteralPath $modulePath -Raw
 
         $moduleText | Should -Match 'Get-Module -Name \$moduleName'
-        $moduleText | Should -Match '\\$_.Path'
-        $moduleText | Should -Match 'OrdinalIgnoreCase\.Equals'
+        $moduleText | Should -Match '\$_.Path -and \$modulePathComparer\.Equals'
+        $moduleText | Should -Match '\[System.StringComparer\]::OrdinalIgnoreCase'
+        $moduleText | Should -Match '\[System.StringComparer\]::Ordinal'
         $moduleText | Should -Match 'Import-Module \$modulePath -Force -ErrorAction Stop'
     }
 }
@@ -276,15 +277,17 @@ Describe 'Expand-ZipsAndClean module load sequence' {
         } | Should -Not -Throw
     }
 
-    It 'loads ZipWorkflow standalone and imports ProgressReporter when it was not already loaded' {
+    It 'loads ZipWorkflow standalone with nested ProgressReporter helpers available' {
         $zipWorkflowPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
+        $sourceDir = Join-Path $TestDrive 'standalone-empty-src'
+        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
 
         Get-Module -Name ProgressReporter | Should -BeNullOrEmpty
 
         Import-Module $zipWorkflowPath -Force -ErrorAction Stop
 
         Get-Module -Name ZipWorkflow | Should -Not -BeNullOrEmpty
-        Get-Module -Name ProgressReporter | Should -Not -BeNullOrEmpty
+        { ZipWorkflow\Move-ZipFilesToParent -SourceDir $sourceDir -QuietMode $true } | Should -Not -Throw
     }
 
 
@@ -292,17 +295,23 @@ Describe 'Expand-ZipsAndClean module load sequence' {
         $foreignDir = Join-Path $TestDrive 'foreign-modules'
         New-Item -ItemType Directory -Path $foreignDir -Force | Out-Null
         $foreignFileSystemPath = Join-Path $foreignDir 'FileSystem.psm1'
-        Set-Content -LiteralPath $foreignFileSystemPath -Value 'function Get-FullPath { param([string]$Path) "foreign:$Path" }' -NoNewline
+        Set-Content -LiteralPath $foreignFileSystemPath -Value 'function Resolve-UniquePath { param([string]$Path) "foreign:$Path" }' -NoNewline
 
         Import-Module $foreignFileSystemPath -Force -ErrorAction Stop
         [System.IO.Path]::GetFullPath((Get-Module -Name FileSystem).Path) | Should -Be ([System.IO.Path]::GetFullPath($foreignFileSystemPath))
 
         $zipWorkflowPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1'
-        $repoFileSystemPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\Core\FileSystem\FileSystem.psm1'
-
         Import-Module $zipWorkflowPath -Force -ErrorAction Stop
 
-        $loadedFileSystemPaths = @(Get-Module -Name FileSystem | ForEach-Object { [System.IO.Path]::GetFullPath($_.Path) })
-        $loadedFileSystemPaths | Should -Contain ([System.IO.Path]::GetFullPath($repoFileSystemPath))
+        $parentDir = Join-Path $TestDrive 'collision-parent'
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+        $zipPath = Join-Path $parentDir 'dup.zip'
+        Set-Content -LiteralPath $zipPath -Value 'existing' -NoNewline
+        $zip = Get-Item -LiteralPath $zipPath
+
+        $result = ZipWorkflow\Resolve-MoveTarget -Zip $zip -Parent $parentDir -CollisionPolicy Rename
+
+        $result.TargetPath | Should -Not -Be "foreign:$zipPath"
+        $result.TargetPath | Should -BeLike (Join-Path $parentDir 'dup_*.zip')
     }
 }


### PR DESCRIPTION
### Motivation
- The `ZipWorkflow` module was unconditionally reimporting core modules (`Import-Module -Force`) which could unload an already-loaded `ProgressReporter` and cause a late `ProgressReporter\Write-ExtractionSummary` load failure during `Expand-ZipsAndClean` startup.

### Description
- Update `src/powershell/modules/FileManagement/ZipWorkflow/ZipWorkflow.psm1` to compute `moduleName` from the relative path, skip importing when the module is already loaded, and remove the `-Force` flag while keeping `-ErrorAction Stop` for fail-fast behavior.
- Bump the script `Version` in `src/powershell/file-management/Expand-ZipsAndClean.ps1` to `2.6.16` and add a `2.6.16` entry to `src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md` and a README note documenting the fix for issue #1191.
- Add Pester regression coverage in `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` that asserts the module no longer force-reimports core dependencies, that the full startup import sequence preserves `ProgressReporter`, that `ProgressReporter\Write-ExtractionSummary` does not throw, and that `ZipWorkflow` can standalone-import `ProgressReporter` when needed.

### Testing
- Ran static `python3` assertion checks validating the version bump, import-line patterns in the script and module, and changelog/README updates, and they passed.
- Ran `git diff --check` for whitespace/errors which passed.
- Attempted to run Pester (`pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1' -CI"`) but PowerShell/Core (`pwsh`) is not installed in the execution environment so the Pester test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0d1d3bdc83259e6c16beb23ef5ac)