### PR TITLE
Fix ProgressReporter module loading to preserve FileSystem scope

### DIFF
--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG — Core/Progress (ProgressReporter)
 
+## 1.2.4 — Unreleased
+
+### Fixed
+
+- `ProgressReporter.psm1`: no longer performs an unconditional `Import-Module -Force` of
+  `Core/FileSystem` from inside its own module session state. Because `-Force` first
+  removes the already-loaded FileSystem module and then re-imports it privately into the
+  caller module, the previous code stripped FileSystem's functions (`Get-FullPath`,
+  `Get-SafeName`, etc.) from the global/caller scope and from every other module's view.
+  This caused `Expand-ZipsAndClean.ps1` to fail every extraction with "The term
+  'Get-FullPath' is not recognized" and to abort with the fatal "The module 'FileSystem'
+  could not be loaded." The loader now skips the import when a FileSystem module from the
+  same path is already loaded (mirroring the guard in `ZipWorkflow.psm1`), keeping
+  FileSystem shared across the session.
+- `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.2.3` to `1.2.4` (PATCH —
+  module-load robustness fix).
+
 ## 1.2.3 — Unreleased
 
 ### Fixed

--- a/src/powershell/modules/Core/Progress/CHANGELOG.md
+++ b/src/powershell/modules/Core/Progress/CHANGELOG.md
@@ -14,6 +14,11 @@
   could not be loaded." The loader now skips the import when a FileSystem module from the
   same path is already loaded (mirroring the guard in `ZipWorkflow.psm1`), keeping
   FileSystem shared across the session.
+- `ProgressReporter.psm1`: build the FileSystem dependency path from discrete `Join-Path`
+  segments instead of an embedded-separator literal. `[System.IO.Path]::GetFullPath()` does
+  not normalize `\` on Linux/macOS, so a `'..\FileSystem\FileSystem.psm1'` literal could
+  resolve to a mangled path and make the already-loaded guard miss a matching module,
+  falling back to the destructive `-Force` re-import the guard is meant to prevent.
 - `ProgressReporter.psd1`: `ModuleVersion` bumped from `1.2.3` to `1.2.4` (PATCH —
   module-load robustness fix).
 

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psd1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ProgressReporter.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.3'
+    ModuleVersion = '1.2.4'
 
     # ID used to uniquely identify this module
     GUID = '9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e'

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psm1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psm1
@@ -1,10 +1,26 @@
 # Module loader for ProgressReporter
 
-$fileSystemModule = Join-Path $PSScriptRoot '..\FileSystem\FileSystem.psm1'
+$fileSystemModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\FileSystem\FileSystem.psm1'))
 if (-not (Test-Path -LiteralPath $fileSystemModule)) {
     throw "Required module dependency not found: $fileSystemModule"
 }
-Import-Module $fileSystemModule -Force -ErrorAction Stop
+
+# Only import FileSystem when it is not already loaded from the same path. A blind
+# `Import-Module -Force` from inside this module's session state would Remove-Module the
+# existing (caller/global-scoped) FileSystem and re-import it privately into this module,
+# stripping its functions (Get-FullPath, etc.) from every other module's view and from the
+# caller's scope. Skipping when already present keeps FileSystem shared across the session.
+$modulePathComparer = if ($IsWindows) {
+    [System.StringComparer]::OrdinalIgnoreCase
+} else {
+    [System.StringComparer]::Ordinal
+}
+$loadedFileSystem = Get-Module -Name 'FileSystem' | Where-Object {
+    $_.Path -and $modulePathComparer.Equals([System.IO.Path]::GetFullPath($_.Path), $fileSystemModule)
+} | Select-Object -First 1
+if (-not $loadedFileSystem) {
+    Import-Module $fileSystemModule -Force -ErrorAction Stop
+}
 
 $privateDir = Join-Path $PSScriptRoot 'Private'
 if (Test-Path -LiteralPath $privateDir) {

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psm1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psm1
@@ -1,6 +1,11 @@
 # Module loader for ProgressReporter
 
-$fileSystemModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\FileSystem\FileSystem.psm1'))
+# Build the dependency path from discrete segments (no embedded '\' / '/') so it resolves
+# correctly on every platform. An embedded-separator literal like '..\FileSystem\...' is not
+# normalized by [System.IO.Path]::GetFullPath() on Linux/macOS (where '\' is an ordinary
+# filename character), which would leave a mangled path and make the guard below miss an
+# already-loaded FileSystem module.
+$fileSystemModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..' 'FileSystem' 'FileSystem.psm1'))
 if (-not (Test-Path -LiteralPath $fileSystemModule)) {
     throw "Required module dependency not found: $fileSystemModule"
 }

--- a/src/powershell/modules/Core/Progress/ProgressReporter.psm1
+++ b/src/powershell/modules/Core/Progress/ProgressReporter.psm1
@@ -20,9 +20,12 @@ $modulePathComparer = if ($IsWindows) {
 } else {
     [System.StringComparer]::Ordinal
 }
-$loadedFileSystem = Get-Module -Name 'FileSystem' | Where-Object {
-    $_.Path -and $modulePathComparer.Equals([System.IO.Path]::GetFullPath($_.Path), $fileSystemModule)
-} | Select-Object -First 1
+$loadedFileSystem =
+    Get-Module -Name 'FileSystem' |
+    Where-Object {
+        $_.Path -and $modulePathComparer.Equals([System.IO.Path]::GetFullPath($_.Path), $fileSystemModule)
+    } |
+    Select-Object -First 1
 if (-not $loadedFileSystem) {
     Import-Module $fileSystemModule -Force -ErrorAction Stop
 }


### PR DESCRIPTION
## Summary
Fixed a critical module loading issue in ProgressReporter where an unconditional `Import-Module -Force` was stripping FileSystem functions from the global scope and other modules, causing downstream failures in scripts like `Expand-ZipsAndClean.ps1`.

## Key Changes
- **ProgressReporter.psm1**: Replaced unconditional `Import-Module -Force` with conditional logic that checks if FileSystem is already loaded from the same path before importing
  - Added platform-aware path comparison (case-insensitive on Windows, case-sensitive on Unix)
  - Uses `Get-Module` to detect existing FileSystem module and skips import if already present
  - Preserves FileSystem as a shared module across the session instead of re-importing it privately
  - Mirrors the guard pattern already used in `ZipWorkflow.psm1`

- **ProgressReporter.psd1**: Bumped `ModuleVersion` from `1.2.3` to `1.2.4` (PATCH version)

- **CHANGELOG.md**: Documented the fix with details on the root cause and solution

## Implementation Details
The previous code would remove the already-loaded FileSystem module and re-import it privately into ProgressReporter's session state, making its functions (like `Get-FullPath`, `Get-SafeName`) invisible to the caller and other modules. The fix uses a conditional import guard that:
1. Normalizes the FileSystem module path using `[System.IO.Path]::GetFullPath()`
2. Checks if a FileSystem module from that exact path is already loaded
3. Only imports if not already present, keeping the module shared across the session

https://claude.ai/code/session_01RA7BdxfeWtLf8N5CamwUf8