### PR TITLE
fix(videoscreenshot): avoid VLC pipe-buffer deadlock

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,13 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-05-31
+### Fixed
+- **VLC stdout/stderr pipe-buffer deadlock**: long-running VLC sessions no longer redirect stdout/stderr pipes. VLC now writes diagnostics to a `.vlc_log_<RunGuid>.txt` sidecar under `SaveFolder`, with startup-failure errors reading from that logfile instead of unread stderr.
+
+### Added
+- **`Vlc.LogVerbosity`** (default `1`) in `Get-DefaultConfig` to tune VLC sidecar logging verbosity (`0`-`2`, where `0` also passes `--quiet`).
+
 ## [3.2.0] - 2026-05-29
 ### Added
 - **Opt-in video pre-flight skip**: `Start-VideoBatch -VerifyVideos` (aliases `-PreflightProbe`, `-SkipUnplayable`) now runs `Test-VideoPlayable` before launching the main VLC capture session. Videos that fail the probe are logged as `Skipped`/`NotPlayable` in the processed log so resume runs do not retry them.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -103,6 +103,27 @@ function Get-DefaultConfig {
         GdiCaptureDefaultSeconds        = 10
 
         # =========================
+        # VLC process logging
+        # =========================
+
+        Vlc                             = @{
+            # VLC writes its own diagnostics to a sidecar file instead of this
+            # module redirecting stdout/stderr pipes. Keep the default modest to
+            # avoid large logs during batch runs. Valid range: 0-2 (0 also adds
+            # --quiet; 1 is VLC's normal warning/info balance; 2 is verbose).
+            LogVerbosity = 1
+
+            Scene        = @{
+                Format   = 'png'
+                BaseArgs = @('--intf', 'dummy', '--video-filter=scene')
+            }
+
+            Gdi          = @{
+                Args = @('--qt-minimal-view')
+            }
+        }
+
+        # =========================
         # Python / Cropper preflight
         # =========================
 

--- a/src/powershell/modules/Media/Videoscreenshot/Private/New-RunContext.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/New-RunContext.ps1
@@ -52,5 +52,6 @@ function New-VideoRunContext {
         SaveFolder      = $SaveFolder
         RunGuid         = $RunGuid
         PidRegistryPath = $null
+        VlcLogPath      = $null
     }
 }

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Vlc.Process.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Vlc.Process.ps1
@@ -8,8 +8,9 @@ EXPECTED Context.Config SHAPE (used for configurability; all optional):
     StopVlcWaitMs  = 5000
     WaitProcessTimeoutSeconds = 3
     Vlc = @{
-      BaseArgs  = @('--no-qt-privacy-ask','--no-video-title-show','--no-loop','--no-repeat','--rate','1','--play-and-exit')
-      ExtraArgs = @()
+      BaseArgs     = @('--no-qt-privacy-ask','--no-video-title-show','--no-loop','--no-repeat','--rate','1','--play-and-exit')
+      ExtraArgs    = @()
+      LogVerbosity = 1
       Scene = @{
         Format   = 'png'             # default snapshot format
         BaseArgs = @('--intf','dummy','--video-filter=scene')
@@ -149,6 +150,38 @@ function Get-VlcArgsSnapshot {
 
 <#
 .SYNOPSIS
+  Build VLC file-logging arguments for the current run.
+.DESCRIPTION
+  Directs VLC diagnostics to a sidecar file instead of redirected process pipes,
+  preventing stdout/stderr pipe-buffer deadlocks during verbose decoding.
+.PARAMETER Context
+  Run context; optional .VlcLogPath enables sidecar logging and
+  Config.Vlc.LogVerbosity controls VLC verbosity (0-2, default 1).
+.OUTPUTS
+  string[] of VLC logging arguments, or an empty array when no log path is configured.
+#>
+function Get-VlcFileLoggingArgs {
+    param(
+        [Parameter(Mandatory)][psobject]$Context
+    )
+
+    if (-not $Context -or [string]::IsNullOrWhiteSpace([string]$Context.VlcLogPath)) {
+        return @()
+    }
+
+    $verbosity = 1
+    if ($Context.Config -and $Context.Config.Vlc -and $null -ne $Context.Config.Vlc.LogVerbosity) {
+        try { $verbosity = [int]$Context.Config.Vlc.LogVerbosity } catch { $verbosity = 1 }
+    }
+    $verbosity = [Math]::Min(2, [Math]::Max(0, $verbosity))
+
+    $args = @('--file-logging', '--logfile', [string]$Context.VlcLogPath, '--verbose', "$verbosity")
+    if ($verbosity -eq 0) { $args += '--quiet' }
+    return $args
+}
+
+<#
+.SYNOPSIS
   Validate required configuration keys on the run context.
 .DESCRIPTION
   Ensures Context.Config and core timing knobs exist and are sane before using them.
@@ -174,8 +207,8 @@ function Test-VideoConfig {
 .SYNOPSIS
   Start a VLC process with the provided arguments and basic startup validation.
 .DESCRIPTION
-  Launches VLC headlessly with stdout/stderr redirected. Collects early output
-  for diagnostics and respects a startup timeout watchdog.
+  Launches VLC headlessly without redirecting stdout/stderr. VLC diagnostics
+  are written to the configured sidecar logfile for startup-failure diagnostics.
 .PARAMETER Context
   Run context object; expected to contain Config timing knobs.
 .PARAMETER Arguments
@@ -194,20 +227,20 @@ function Start-VlcProcess {
     )
     $psi = [Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = if (-not [string]::IsNullOrWhiteSpace($VlcExe)) { $VlcExe } else { 'vlc.exe' }
+    $effectiveArguments = @($Arguments) + (Get-VlcFileLoggingArgs -Context $Context)
     # Prefer .Arguments string for WinPS 5.1 compatibility (ArgumentList may be unavailable)
-    $quotedArgs = $Arguments | ForEach-Object { '"{0}"' -f ($_.Replace('"', '""')) }
+    $quotedArgs = $effectiveArguments | ForEach-Object { '"{0}"' -f ($_.Replace('"', '""')) }
     $psi.Arguments = [string]::Join(' ', $quotedArgs)
     $psi.UseShellExecute = $false
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError = $true
+    $psi.RedirectStandardOutput = $false
+    $psi.RedirectStandardError = $false
     $psi.CreateNoWindow = $true
 
     $p = [Diagnostics.Process]::new()
     $p.StartInfo = $psi
-    # IMPORTANT (Robustness): Do not attach ScriptBlock event handlers for stdout/stderr.
-    # They execute on ThreadPool threads without a PowerShell runspace and will crash with:
-    # "There is no Runspace available to run scripts in this thread."
-    # We still redirect streams, but avoid async handlers; on startup failure we read stderr synchronously.
+    # IMPORTANT (Robustness): Do not attach ScriptBlock event handlers or redirect stdout/stderr.
+    # VLC writes diagnostics to a sidecar logfile instead, avoiding finite OS pipe-buffer deadlocks
+    # and the ThreadPool runspace crash caused by PowerShell stream handlers.
     $null = ($p.EnableRaisingEvents = $true)
     Write-Debug ("TRACE Start-VlcProcess: EnableRaisingEvents={0}" -f $p.EnableRaisingEvents)
 
@@ -225,12 +258,16 @@ function Start-VlcProcess {
         Start-Sleep -Milliseconds $Context.Config.PollIntervalMs
     }
     if ($p.HasExited -and $p.ExitCode -ne 0) {
-        # Safe: streams are closed after process exit; read synchronously for diagnostics.
-        $stderrText = ''
-        try { $stderrText = $p.StandardError.ReadToEnd() } catch {
-            # Stream may already be disposed or not available
+        $logText = ''
+        if (-not [string]::IsNullOrWhiteSpace([string]$Context.VlcLogPath) -and (Test-Path -LiteralPath $Context.VlcLogPath -PathType Leaf)) {
+            try { $logText = Get-Content -LiteralPath $Context.VlcLogPath -Raw -ErrorAction Stop } catch {
+                $logText = "<unable to read VLC logfile: $($_.Exception.Message)>"
+            }
         }
-        throw ("VLC startup failed (ExitCode={0}). stderr: {1}" -f $p.ExitCode, ($stderrText ?? ''))
+        if ([string]::IsNullOrWhiteSpace($logText)) {
+            $logText = '<VLC logfile empty or unavailable; stdout/stderr pipes are not redirected>'
+        }
+        throw ("VLC startup failed (ExitCode={0}). VLC log: {1}" -f $p.ExitCode, $logText)
     }
     Write-Debug ("TRACE Start-VlcProcess: leaving; returning Process Id={0}" -f $p.Id)
     return $p

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Vlc.Process.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Vlc.Process.ps1
@@ -175,9 +175,9 @@ function Get-VlcFileLoggingArgs {
     }
     $verbosity = [Math]::Min(2, [Math]::Max(0, $verbosity))
 
-    $args = @('--file-logging', '--logfile', [string]$Context.VlcLogPath, '--verbose', "$verbosity")
-    if ($verbosity -eq 0) { $args += '--quiet' }
-    return $args
+    $loggingArgs = @('--file-logging', '--logfile', [string]$Context.VlcLogPath, '--verbose', "$verbosity")
+    if ($verbosity -eq 0) { $loggingArgs += '--quiet' }
+    return $loggingArgs
 }
 
 <#

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -283,6 +283,23 @@ function Start-VideoBatch {
     $pidFile = Initialize-PidRegistry -Context $context -SaveFolder $SaveFolder -RunGuid $runGuid
     Write-Debug "PID registry: $pidFile"
 
+    # Initialize VLC's own sidecar logfile. This avoids redirecting stdout/stderr
+    # pipes for the long-running process, which can deadlock when VLC is chatty.
+    $vlcLogFile = Join-Path $SaveFolder ".vlc_log_$runGuid.txt"
+    try {
+        if (Test-Path -LiteralPath $vlcLogFile -PathType Leaf) {
+            Remove-Item -LiteralPath $vlcLogFile -Force -ErrorAction Stop
+        }
+        New-Item -ItemType File -Path $vlcLogFile -Force -ErrorAction Stop | Out-Null
+        $context | Add-Member -NotePropertyName VlcLogPath -NotePropertyValue $vlcLogFile -Force
+        Write-Debug "VLC sidecar log: $vlcLogFile"
+    }
+    catch {
+        Write-Message -Level Warn -Message ("Unable to initialize VLC sidecar logfile '{0}': {1}. Continuing without VLC file logging." -f $vlcLogFile, $_.Exception.Message)
+        $context | Add-Member -NotePropertyName VlcLogPath -NotePropertyValue $null -Force
+        $vlcLogFile = $null
+    }
+
     # Discover videos (configurable extension set via param or config)
     $exts = if ($IncludeExtensions -and $IncludeExtensions.Count -gt 0) { $IncludeExtensions } else { $context.Config.VideoExtensions }
     $patterns = $exts | ForEach-Object {
@@ -293,11 +310,18 @@ function Start-VideoBatch {
     $videos = Get-ChildItem -Path (Join-Path $SourceFolder '*') -Recurse -File -Include $patterns
     if (-not $videos) {
         Write-Message -Level Warn -Message "No videos found under $SourceFolder."
+        if ($pidFile -and (Test-Path -LiteralPath $pidFile)) {
+            Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+        }
+        if ($vlcLogFile -and (Test-Path -LiteralPath $vlcLogFile)) {
+            Remove-Item -LiteralPath $vlcLogFile -Force -ErrorAction SilentlyContinue
+        }
         return
     }
 
     $processedCount = 0
     $attemptedCount = 0
+    $retainVlcLog = $false
 
     foreach ($video in $videos) {
         if ($VideoLimit -gt 0 -and $attemptedCount -ge $VideoLimit) { break }
@@ -395,6 +419,7 @@ function Start-VideoBatch {
         }
         catch {
             $processingFailed = $true
+            $retainVlcLog = $true
             $processingError = $_.Exception.Message
             Write-Message -Level Error -Message ("Processing failed for: {0} — {1}" -f $video.FullName, $processingError)
         }
@@ -502,6 +527,23 @@ function Start-VideoBatch {
         }
         catch {
             Write-Message -Level Warn -Message ("Failed to remove PID registry file '{0}': {1}" -f $pidFile, $_.Exception.Message)
+        }
+    }
+
+    # Clean VLC's sidecar logfile on successful runs; retain it deterministically
+    # when processing failed so startup/decoder diagnostics remain available.
+    if ($vlcLogFile -and (Test-Path -LiteralPath $vlcLogFile)) {
+        if ($retainVlcLog) {
+            Write-Message -Level Warn -Message ("Retaining VLC sidecar log after failure: {0}" -f $vlcLogFile)
+        }
+        else {
+            try {
+                Remove-Item -LiteralPath $vlcLogFile -Force -ErrorAction Stop
+                Write-Debug "Cleaned up VLC sidecar log: $vlcLogFile"
+            }
+            catch {
+                Write-Message -Level Warn -Message ("Failed to remove VLC sidecar log '{0}': {1}" -f $vlcLogFile, $_.Exception.Message)
+            }
         }
     }
 

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -319,9 +319,14 @@ On Windows (example):
   via `-ProcessedLogPath`. `Start-VideoBatch` honors `-ResumeFile` by skipping items up to that file.
 - **Crash: “There is no Runspace available to run scripts in this thread.”**
   This was caused by emitting PowerShell debug output from background stream handlers.
-  Fixed in the next patch release; update to the latest version. As a temporary workaround,
-  run without `-Debug`. Note that, by design, VLC’s stdout/stderr are still captured for errors,
-  but per-line live output from VLC is no longer shown when `-Debug` is used.
+  Fixed in earlier patch releases; update to the latest version.
+- **VLC hangs or stalls after producing a few frames.**
+  VLC stdout/stderr are not redirected by the module. Instead, VLC writes diagnostics to a
+  hidden sidecar logfile named `.vlc_log_<RunGuid>.txt` in `SaveFolder`, so verbose decoder
+  output cannot fill an unread pipe and deadlock the process. The sidecar is deleted after
+  successful runs and retained after processing failures for diagnosis. Tune `Vlc.LogVerbosity`
+  in `Get-DefaultConfig` (`0`-`2`, default `1`; `0` also passes `--quiet`) if the VLC log is
+  too noisy or too sparse.
 
 ### GDI-specific tips
 - Prefer the Primary display; multi-monitor/VM environments may vary in behavior.
@@ -359,5 +364,6 @@ Key config knobs (in `Get-DefaultConfig`, `Private/Config.ps1`):
 | `SnapshotIdleTimeoutSeconds` | `20` | Seconds without a new frame before the session is abandoned. Set to `0` to disable. |
 | `SnapshotIdleWarmUpSeconds` | `10` | Seconds at session start during which idle detection is suppressed (allows slow-starting sources their first frame). |
 | `SnapshotFallbackTimeoutSeconds` | `300` | Last-resort cap used only when duration detection fails. |
+| `Vlc.LogVerbosity` | `1` | VLC sidecar logfile verbosity (`0`-`2`); `0` also passes `--quiet`. |
 
 A `WARNING` log line is emitted when idle-break fires so the problem video is visible in the run log.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.0'
+  ModuleVersion     = '3.2.1'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.0: Optional VerifyVideos/PreflightProbe pre-flight now skips unplayable videos before the main VLC session, logs them as Skipped/NotPlayable for resume, and bounds Test-VideoPlayable with VideoProbeTimeoutSeconds plus force-kill on timeout.'
+      ReleaseNotes = '3.2.1: VLC capture now logs diagnostics to a .vlc_log_<RunGuid>.txt sidecar instead of redirecting stdout/stderr pipes, preventing pipe-buffer deadlocks while preserving startup-failure diagnostics.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
@@ -31,7 +31,10 @@ BeforeAll {
 
         [pscustomobject]@{
             FilePath    = $path
-            Arguments   = @()
+            # Start-VlcProcess requires a non-empty argument array; the fake
+            # native command intentionally ignores this placeholder and any
+            # appended VLC logging flags.
+            Arguments   = @('--ignored-test-arg')
             CleanupPath = $dir
         }
     }

--- a/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
@@ -64,19 +64,19 @@ Describe 'Get-VlcFileLoggingArgs' {
         $logPath = Join-Path ([System.IO.Path]::GetTempPath()) 'vlc-sidecar-test.txt'
         $context = Script:New-TestContext -VlcLogPath $logPath -LogVerbosity 2
 
-        $args = Get-VlcFileLoggingArgs -Context $context
+        $loggingArgs = Get-VlcFileLoggingArgs -Context $context
 
-        $args | Should -Be @('--file-logging', '--logfile', $logPath, '--verbose', '2')
+        $loggingArgs | Should -Be @('--file-logging', '--logfile', $logPath, '--verbose', '2')
     }
 
     It 'adds --quiet when verbosity is zero' {
         $context = Script:New-TestContext -LogVerbosity 0
 
-        $args = Get-VlcFileLoggingArgs -Context $context
+        $loggingArgs = Get-VlcFileLoggingArgs -Context $context
 
-        $args | Should -Contain '--quiet'
-        $args | Should -Contain '--verbose'
-        $args | Should -Contain '0'
+        $loggingArgs | Should -Contain '--quiet'
+        $loggingArgs | Should -Contain '--verbose'
+        $loggingArgs | Should -Contain '0'
     }
 }
 

--- a/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
@@ -1,0 +1,90 @@
+<#
+.SYNOPSIS
+Pester tests for VLC process launch and sidecar file logging.
+#>
+
+BeforeAll {
+    $script:VlcProcessPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Vlc.Process.ps1'
+    if (-not (Test-Path -LiteralPath $script:VlcProcessPath)) {
+        throw "Required file not found: $script:VlcProcessPath"
+    }
+
+    . $script:VlcProcessPath
+
+    $pwsh = Get-Command -Name 'pwsh' -ErrorAction SilentlyContinue
+    if (-not $pwsh) { $pwsh = Get-Command -Name 'powershell' -ErrorAction SilentlyContinue }
+    if (-not $pwsh) { throw 'No PowerShell executable found; cannot run process tests.' }
+    $script:PwshExe = $pwsh.Source
+
+    function Script:New-TestContext {
+        param(
+            [string]$VlcLogPath = (Join-Path ([System.IO.Path]::GetTempPath()) ("vlc-log-{0}.txt" -f [System.Guid]::NewGuid().ToString('N'))),
+            [int]$LogVerbosity = 1
+        )
+
+        [pscustomobject]@{
+            Config     = @{
+                PollIntervalMs            = 10
+                StopVlcWaitMs             = 100
+                WaitProcessTimeoutSeconds = 1
+                Vlc                       = @{
+                    LogVerbosity = $LogVerbosity
+                }
+            }
+            VlcLogPath = $VlcLogPath
+        }
+    }
+}
+
+Describe 'Get-VlcFileLoggingArgs' {
+    It 'builds VLC sidecar logfile arguments at the configured verbosity' {
+        $logPath = Join-Path ([System.IO.Path]::GetTempPath()) 'vlc-sidecar-test.txt'
+        $context = Script:New-TestContext -VlcLogPath $logPath -LogVerbosity 2
+
+        $args = Get-VlcFileLoggingArgs -Context $context
+
+        $args | Should -Be @('--file-logging', '--logfile', $logPath, '--verbose', '2')
+    }
+
+    It 'adds --quiet when verbosity is zero' {
+        $context = Script:New-TestContext -LogVerbosity 0
+
+        $args = Get-VlcFileLoggingArgs -Context $context
+
+        $args | Should -Contain '--quiet'
+        $args | Should -Contain '--verbose'
+        $args | Should -Contain '0'
+    }
+}
+
+Describe 'Start-VlcProcess' {
+    It 'does not redirect stdout or stderr and appends VLC file logging arguments' {
+        $context = Script:New-TestContext
+        $process = Start-VlcProcess -Context $context -Arguments @('-NoProfile', '-Command', 'exit 0') -StartupTimeoutSeconds 1 -VlcExe $script:PwshExe
+
+        try {
+            $process.StartInfo.RedirectStandardOutput | Should -BeFalse
+            $process.StartInfo.RedirectStandardError | Should -BeFalse
+            $process.StartInfo.Arguments | Should -Match '--file-logging'
+            $process.StartInfo.Arguments | Should -Match '--logfile'
+            $process.StartInfo.Arguments | Should -Match ([regex]::Escape($context.VlcLogPath))
+            $process.StartInfo.Arguments | Should -Match '--verbose'
+        }
+        finally {
+            if ($process -and -not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            }
+            Remove-Item -LiteralPath $context.VlcLogPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'uses the VLC logfile text in startup failure diagnostics' {
+        $context = Script:New-TestContext
+        Set-Content -LiteralPath $context.VlcLogPath -Value 'decoder exploded before startup' -NoNewline
+
+        { Start-VlcProcess -Context $context -Arguments @('-NoProfile', '-Command', 'exit 9') -StartupTimeoutSeconds 1 -VlcExe $script:PwshExe } |
+            Should -Throw -ExpectedMessage '*decoder exploded before startup*'
+
+        Remove-Item -LiteralPath $context.VlcLogPath -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1
@@ -11,10 +11,30 @@ BeforeAll {
 
     . $script:VlcProcessPath
 
-    $pwsh = Get-Command -Name 'pwsh' -ErrorAction SilentlyContinue
-    if (-not $pwsh) { $pwsh = Get-Command -Name 'powershell' -ErrorAction SilentlyContinue }
-    if (-not $pwsh) { throw 'No PowerShell executable found; cannot run process tests.' }
-    $script:PwshExe = $pwsh.Source
+    function Script:New-NativeExitCommand {
+        param(
+            [Parameter(Mandatory)][int]$ExitCode
+        )
+
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("vlc-process-test-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+        if ($env:OS -eq 'Windows_NT') {
+            $path = Join-Path $dir 'fake-vlc.cmd'
+            [System.IO.File]::WriteAllText($path, ("@echo off`r`nexit /b {0}`r`n" -f $ExitCode))
+        }
+        else {
+            $path = Join-Path $dir 'fake-vlc'
+            [System.IO.File]::WriteAllText($path, ("#!/bin/sh`nexit {0}`n" -f $ExitCode))
+            chmod +x $path
+        }
+
+        [pscustomobject]@{
+            FilePath    = $path
+            Arguments   = @()
+            CleanupPath = $dir
+        }
+    }
 
     function Script:New-TestContext {
         param(
@@ -60,7 +80,8 @@ Describe 'Get-VlcFileLoggingArgs' {
 Describe 'Start-VlcProcess' {
     It 'does not redirect stdout or stderr and appends VLC file logging arguments' {
         $context = Script:New-TestContext
-        $process = Start-VlcProcess -Context $context -Arguments @('-NoProfile', '-Command', 'exit 0') -StartupTimeoutSeconds 1 -VlcExe $script:PwshExe
+        $fakeVlc = Script:New-NativeExitCommand -ExitCode 0
+        $process = Start-VlcProcess -Context $context -Arguments $fakeVlc.Arguments -StartupTimeoutSeconds 1 -VlcExe $fakeVlc.FilePath
 
         try {
             $process.StartInfo.RedirectStandardOutput | Should -BeFalse
@@ -75,16 +96,19 @@ Describe 'Start-VlcProcess' {
                 Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
             }
             Remove-Item -LiteralPath $context.VlcLogPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $fakeVlc.CleanupPath -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 
     It 'uses the VLC logfile text in startup failure diagnostics' {
         $context = Script:New-TestContext
+        $fakeVlc = Script:New-NativeExitCommand -ExitCode 9
         Set-Content -LiteralPath $context.VlcLogPath -Value 'decoder exploded before startup' -NoNewline
 
-        { Start-VlcProcess -Context $context -Arguments @('-NoProfile', '-Command', 'exit 9') -StartupTimeoutSeconds 1 -VlcExe $script:PwshExe } |
+        { Start-VlcProcess -Context $context -Arguments $fakeVlc.Arguments -StartupTimeoutSeconds 1 -VlcExe $fakeVlc.FilePath } |
             Should -Throw -ExpectedMessage '*decoder exploded before startup*'
 
         Remove-Item -LiteralPath $context.VlcLogPath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $fakeVlc.CleanupPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent long-running VLC instances from deadlocking when their stdout/stderr pipes fill while running verbose decoders, while preserving useful startup diagnostics.
- Provide a deterministic, per-run place for VLC diagnostics so failures remain debuggable without relying on redirected process streams.

### Description
- Add `Vlc.LogVerbosity` to `Get-DefaultConfig` and a `VlcLogPath` property to the run context to configure and track VLC sidecar logging.
- Introduce `Get-VlcFileLoggingArgs` and stop redirecting `StandardOutput`/`StandardError` in `Start-VlcProcess`, instead appending `--file-logging --logfile <path> --verbose <n>` (and `--quiet` when verbosity is `0`).
- Initialize a `.vlc_log_<RunGuid>.txt` sidecar in `Start-VideoBatch`, retain it on processing failures for diagnostics, and delete it on successful runs.
- Improve startup-failure diagnostics to read from the VLC logfile when available, add Pester tests (`Vlc.Process.Tests.ps1`), update README/CHANGELOG, and bump module version to `3.2.1`.

### Testing
- Ran `git diff --check` to validate changes and whitespace issues; the check passed (only emitted core.autocrlf warnings in this environment).
- Added Pester coverage (`tests/powershell/modules/Media/Videoscreenshot/Vlc.Process.Tests.ps1`) to validate logging-args composition and startup-diagnostic behavior, but `Invoke-Pester` was not executed here because `pwsh`/PowerShell 7+ is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bc2048ef883259181bb4c8dad5ef5)