### PR TITLE
fix(videoscreenshot): retry failed resume log entries

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,10 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-05-31
+### Fixed
+- **Empty retry-only resume indexes**: `Get-ResumeIndex` now emits its `HashSet` with `Write-Output -NoEnumerate`, so logs containing only retry-eligible rows (or missing logs) return an empty set instead of `$null`.
+
 ## [3.2.2] - 2026-05-31
 ### Fixed
 - **Status-aware resume logs**: `Get-ResumeIndex` now skips only true `Processed` successes and deliberate `Skipped`/`NotPlayable` rows. `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` entries remain eligible for retry on resume.

--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,11 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-05-31
+### Fixed
+- **Status-aware resume logs**: `Get-ResumeIndex` now skips only true `Processed` successes and deliberate `Skipped`/`NotPlayable` rows. `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` entries remain eligible for retry on resume.
+- **Zero-frame labelling**: zero-frame captures are now logged as `Failed`/`NoFrames` instead of `Processed`/`NoFrames`, making incomplete coverage visible and retryable.
+
 ## [3.2.1] - 2026-05-31
 ### Fixed
 - **VLC stdout/stderr pipe-buffer deadlock**: long-running VLC sessions no longer redirect stdout/stderr pipes. VLC now writes diagnostics to a `.vlc_log_<RunGuid>.txt` sidecar under `SaveFolder`, with startup-failure errors reading from that logfile instead of unread stderr.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
@@ -17,6 +17,34 @@ function Resolve-VideoPath {
     return $full
 }
 
+function Convert-ProcessedLogLineToResumePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Line
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Line)) { return $null }
+
+    $trimmedLine = $Line.Trim()
+    if ($trimmedLine.StartsWith('#')) { return $null }
+
+    $columns = $trimmedLine.Split("`t")
+    $rawPath = $columns[0]
+    $isTsv = $columns.Count -gt 1
+    $status = if ($isTsv) { $columns[1] } else { 'Processed' }
+    $reason = if ($columns.Count -ge 3) { $columns[2] } else { '' }
+    $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status $status -Reason $reason -LegacyEntry:(-not $isTsv)
+
+    if (-not $shouldSkip -or [string]::IsNullOrWhiteSpace($rawPath)) { return $null }
+
+    try {
+        return (Resolve-VideoPath -Path $rawPath)
+    }
+    catch {
+        return $rawPath
+    }
+}
+
 function Test-ProcessedLogEntryShouldSkip {
     [CmdletBinding()]
     param(
@@ -74,36 +102,9 @@ function Get-ResumeIndex {
     }
     try {
         Get-Content -LiteralPath $Path -ErrorAction Stop | ForEach-Object {
-            if ([string]::IsNullOrWhiteSpace($_)) { return }
-            $line = $_.Trim()
-            if ($line.StartsWith('#')) { return }
-
-            $rawPath = $null
-            $shouldSkip = $false
-            if ($line -like "*`t*") {
-                # TSV (current) format: <FullPath>\t<Status>\t<Reason>\t<Timestamp>
-                $columns = $line.Split("`t")
-                $rawPath = $columns[0]
-                $status = if ($columns.Count -ge 2) { $columns[1] } else { '' }
-                $reason = if ($columns.Count -ge 3) { $columns[2] } else { '' }
-                $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status $status -Reason $reason
-            }
-            else {
-                # Legacy format: a single path per line; keep old skip behavior.
-                $rawPath = $line
-                $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status 'Processed' -LegacyEntry
-            }
-
-            if ($shouldSkip -and -not [string]::IsNullOrWhiteSpace($rawPath)) {
-                try {
-                    $full = Resolve-VideoPath -Path $rawPath
-                }
-                catch {
-                    $full = $rawPath
-                }
-                if (-not [string]::IsNullOrWhiteSpace($full)) {
-                    [void]$set.Add($full)
-                }
+            $full = Convert-ProcessedLogLineToResumePath -Line $_
+            if (-not [string]::IsNullOrWhiteSpace($full)) {
+                [void]$set.Add($full)
             }
         }
     }

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
@@ -68,7 +68,10 @@ function Get-ResumeIndex {
     )
     # Case-insensitive by default on Windows; keeps behavior stable cross-platform.
     $set = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    if (-not (Test-Path -LiteralPath $Path)) { return $set }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Output -NoEnumerate $set
+        return
+    }
     try {
         Get-Content -LiteralPath $Path -ErrorAction Stop | ForEach-Object {
             if ([string]::IsNullOrWhiteSpace($_)) { return }
@@ -107,7 +110,7 @@ function Get-ResumeIndex {
     catch {
         Write-Debug ("Get-ResumeIndex: failed to read '{0}': {1}" -f $Path, $_.Exception.Message)
     }
-    return $set
+    Write-Output -NoEnumerate $set
 }
 
 <#

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
@@ -17,6 +17,30 @@ function Resolve-VideoPath {
     return $full
 }
 
+function Test-ProcessedLogEntryShouldSkip {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Status,
+        [string]$Reason = '',
+        [switch]$LegacyEntry
+    )
+
+    if ($LegacyEntry) { return $true }
+
+    $normalizedStatus = $Status.Trim()
+    $normalizedReason = ($Reason ?? '').Trim()
+
+    if ($normalizedStatus.Equals('Processed', [StringComparison]::OrdinalIgnoreCase)) {
+        return (-not $normalizedReason.Equals('NoFrames', [StringComparison]::OrdinalIgnoreCase))
+    }
+
+    if ($normalizedStatus.Equals('Skipped', [StringComparison]::OrdinalIgnoreCase)) {
+        return $normalizedReason.Equals('NotPlayable', [StringComparison]::OrdinalIgnoreCase)
+    }
+
+    return $false
+}
+
 <#
 .SYNOPSIS
   Build a normalized set of already-processed video paths.
@@ -24,8 +48,14 @@ function Resolve-VideoPath {
   Reads a processed log and returns a HashSet[string] of normalized absolute paths.
   Supports both the current TSV format (`<FullPath>`<tab>`<Status>`<tab>`<Reason>`<tab>`<Timestamp>`)
   and the **legacy format** that contains one `<FullPath>` per line. Blank lines and
-  comment lines (starting with '#') are ignored. Status values in TSV are
-  currently informational; presence of the path implies "already processed".
+  comment lines (starting with '#') are ignored.
+
+  TSV rows are status-aware: only successful `Processed` rows, excluding
+  `Processed`/`NoFrames`, and deliberate `Skipped`/`NotPlayable` rows are added to
+  the resume skip set. Retry-eligible rows such as `Failed`, `TimedOutProcessed`,
+  `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` are not skipped. Legacy
+  single-column rows are treated as successful `Processed` entries for backward
+  compatibility.
 .PARAMETER Path
   Path to the processed log. The file may be missing (returns an empty set).
 .OUTPUTS
@@ -46,17 +76,22 @@ function Get-ResumeIndex {
             if ($line.StartsWith('#')) { return }
 
             $rawPath = $null
+            $shouldSkip = $false
             if ($line -like "*`t*") {
                 # TSV (current) format: <FullPath>\t<Status>\t<Reason>\t<Timestamp>
-                # Path is always in the first column
-                $rawPath = ($line.Split("`t"))[0]
+                $columns = $line.Split("`t")
+                $rawPath = $columns[0]
+                $status = if ($columns.Count -ge 2) { $columns[1] } else { '' }
+                $reason = if ($columns.Count -ge 3) { $columns[2] } else { '' }
+                $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status $status -Reason $reason
             }
             else {
-                # Legacy format: a single path per line
+                # Legacy format: a single path per line; keep old skip behavior.
                 $rawPath = $line
+                $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status 'Processed' -LegacyEntry
             }
 
-            if (-not [string]::IsNullOrWhiteSpace($rawPath)) {
+            if ($shouldSkip -and -not [string]::IsNullOrWhiteSpace($rawPath)) {
                 try {
                     $full = Resolve-VideoPath -Path $rawPath
                 }

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -477,14 +477,14 @@ function Start-VideoBatch {
 
         # Determine status and log the video as processed
         if ($processingFailed) {
-            # Even if processing failed, log it to avoid reprocessing
+            # Failed rows remain retry-eligible on subsequent resume runs.
             $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Failed' -Reason $processingError
-            Write-Message -Level Warn -Message ("Video marked as failed (will not retry): {0}" -f $video.FullName)
+            Write-Message -Level Warn -Message ("Video marked as failed (eligible for retry on resume): {0}" -f $video.FullName)
         }
         elseif ($framesDelta -le 0) {
             Write-Message -Level Warn -Message ("No frames produced for: {0}" -f $video.FullName)
-            # Still log it to avoid reprocessing the same video
-            $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Processed' -Reason 'NoFrames'
+            # Log zero-frame captures as failed so resume runs can retry them.
+            $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Failed' -Reason 'NoFrames'
         }
         else {
             if ($null -ne $achievedFps) {

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -154,7 +154,7 @@ Start-VideoBatch `
 ```
 * -IncludeExtensions overrides the discovery set (defaults come from module config).
 * -VerifyVideos attempts a lightweight, bounded `Test-VideoPlayable` check before the main VLC session. `-PreflightProbe` and `-SkipUnplayable` are aliases for the same switch.
-* If the probe returns false or times out, the video is logged as `Skipped`/`NotPlayable` in the processed log and skipped on later resume runs.
+* If the probe returns false or times out, the video is logged as `Skipped`/`NotPlayable` in the processed log and skipped on later resume runs. Probe errors are logged as `Skipped`/`VideoProbeError` and retried on resume.
 * `-VideoProbeTimeoutSeconds` controls the force-kill deadline for the probe; omit it to use `VideoProbeTimeoutSeconds` from module config.
 
 #### What the cropper flags do
@@ -175,7 +175,7 @@ The module tracks which videos have been handled so future runs can skip work.
   Each line is `<FullPath>\t<Status>[\t<Reason>]`:
   ```
   C:\path\to\video1.mp4\tProcessed
-  C:\path\to\video2.mp4\tSkipped\tnot playable
+  C:\path\to\video2.mp4\tSkipped\tNotPlayable
   ```
 
 * **Legacy (single-column)**
@@ -191,7 +191,10 @@ The module tracks which videos have been handled so future runs can skip work.
 **Behavior**
 - Entries are normalized to absolute provider paths at import time.
 - On Windows, matching is case-insensitive to minimize false mismatches.
-- Mixing TSV and legacy lines in the same file is supported; new writes use TSV.
+- Resume parsing is status-aware for TSV rows: successful `Processed` rows are skipped, except `Processed`/`NoFrames`, which is retried for compatibility with older logs.
+- `Skipped`/`NotPlayable` rows remain skipped because they represent deliberate pre-flight exclusions; `Failed`, `TimedOutProcessed`, and `Skipped`/`VideoProbeError` rows are retried automatically on the next run.
+- New zero-frame captures are written as `Failed`/`NoFrames` so the log accurately marks them as incomplete and retry-eligible.
+- Mixing TSV and legacy lines in the same file is supported; legacy single-column rows are treated as successful `Processed` rows and skipped as before; new writes use TSV.
 
 **Legacy wrapper (decommissioned)**
 The legacy `src\powershell\videoscreenshot.ps1` wrapper (now `Show-VideoscreenshotDeprecation.ps1`) has been **removed**.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.1'
+  ModuleVersion     = '3.2.2'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.1: VLC capture now logs diagnostics to a .vlc_log_<RunGuid>.txt sidecar instead of redirecting stdout/stderr pipes, preventing pipe-buffer deadlocks while preserving startup-failure diagnostics.'
+      ReleaseNotes = '3.2.2: Resume processing now honors processed-log Status/Reason values so Failed, TimedOutProcessed, VideoProbeError, and NoFrames rows are retried while successful Processed and Skipped/NotPlayable rows remain skipped.'
     }
   }
 }

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.2'
+  ModuleVersion     = '3.2.3'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.2: Resume processing now honors processed-log Status/Reason values so Failed, TimedOutProcessed, VideoProbeError, and NoFrames rows are retried while successful Processed and Skipped/NotPlayable rows remain skipped.'
+      ReleaseNotes = '3.2.3: Get-ResumeIndex now returns an empty HashSet without pipeline enumeration when all processed-log rows are retry-eligible or the log is missing.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
@@ -82,6 +82,8 @@ Describe 'Write-ProcessedLog zero-frame-compatible statuses' {
         Write-ProcessedLog -Path $script:LogPath -VideoPath $video -Status Failed -Reason NoFrames
         $index = Get-ResumeIndex -Path $script:LogPath
 
+        $index.GetType().GetGenericTypeDefinition().FullName | Should -Be 'System.Collections.Generic.HashSet`1'
+        $index.GetType().GenericTypeArguments[0].FullName | Should -Be 'System.String'
         $line = Get-Content -LiteralPath $script:LogPath -Raw
         $line | Should -Match "`tFailed`tNoFrames`t"
         $index.Contains((Resolve-VideoPath -Path $video)) | Should -BeFalse

--- a/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+Pester tests for Videoscreenshot processed/resume log parsing.
+#>
+
+BeforeAll {
+    $script:ProcessedLogPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Processed.Log.ps1'
+    if (-not (Test-Path -LiteralPath $script:ProcessedLogPath)) {
+        throw "Required file not found: $script:ProcessedLogPath"
+    }
+
+    . $script:ProcessedLogPath
+}
+
+Describe 'Get-ResumeIndex processed-log status handling' {
+    BeforeEach {
+        $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("processed-log-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:TempRoot -Force | Out-Null
+        $script:LogPath = Join-Path $script:TempRoot 'processed.tsv'
+    }
+
+    AfterEach {
+        if ($script:TempRoot -and (Test-Path -LiteralPath $script:TempRoot -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $script:TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'skips only true successes and deliberately unplayable videos' {
+        $processed = Join-Path $script:TempRoot 'processed.mp4'
+        $notPlayable = Join-Path $script:TempRoot 'not-playable.mp4'
+        $failed = Join-Path $script:TempRoot 'failed.mp4'
+        $noFrames = Join-Path $script:TempRoot 'no-frames.mp4'
+        $probeError = Join-Path $script:TempRoot 'probe-error.mp4'
+        $timedOut = Join-Path $script:TempRoot 'timed-out.mp4'
+
+        Set-Content -LiteralPath $script:LogPath -Value @(
+            "# comments are ignored",
+            "$processed`tProcessed`t`t2026-05-31T00:00:00.000Z",
+            "$notPlayable`tSkipped`tNotPlayable`t2026-05-31T00:00:00.000Z",
+            "$failed`tFailed`tVLC crashed`t2026-05-31T00:00:00.000Z",
+            "$noFrames`tProcessed`tNoFrames`t2026-05-31T00:00:00.000Z",
+            "$probeError`tSkipped`tVideoProbeError`t2026-05-31T00:00:00.000Z",
+            "$timedOut`tTimedOutProcessed`tCapReached`t2026-05-31T00:00:00.000Z"
+        )
+
+        $index = Get-ResumeIndex -Path $script:LogPath
+
+        $index.Contains((Resolve-VideoPath -Path $processed)) | Should -BeTrue
+        $index.Contains((Resolve-VideoPath -Path $notPlayable)) | Should -BeTrue
+        $index.Contains((Resolve-VideoPath -Path $failed)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $noFrames)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $probeError)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $timedOut)) | Should -BeFalse
+    }
+
+    It 'treats legacy single-column entries as processed for backward compatibility' {
+        $legacy = Join-Path $script:TempRoot 'legacy.mp4'
+        Set-Content -LiteralPath $script:LogPath -Value $legacy
+
+        $index = Get-ResumeIndex -Path $script:LogPath
+
+        $index.Contains((Resolve-VideoPath -Path $legacy)) | Should -BeTrue
+    }
+}
+
+Describe 'Write-ProcessedLog zero-frame-compatible statuses' {
+    BeforeEach {
+        $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("processed-log-write-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:TempRoot -Force | Out-Null
+        $script:LogPath = Join-Path $script:TempRoot 'processed.tsv'
+    }
+
+    AfterEach {
+        if ($script:TempRoot -and (Test-Path -LiteralPath $script:TempRoot -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $script:TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'accepts Failed/NoFrames rows and leaves them retry-eligible' {
+        $video = Join-Path $script:TempRoot 'zero-frame.mp4'
+
+        Write-ProcessedLog -Path $script:LogPath -VideoPath $video -Status Failed -Reason NoFrames
+        $index = Get-ResumeIndex -Path $script:LogPath
+
+        $line = Get-Content -LiteralPath $script:LogPath -Raw
+        $line | Should -Match "`tFailed`tNoFrames`t"
+        $index.Contains((Resolve-VideoPath -Path $video)) | Should -BeFalse
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+Pester tests for Start-VideoBatch processed-log status writes.
+#>
+
+BeforeAll {
+    $script:StartPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Public' 'Start-VideoBatch.ps1'
+    if (-not (Test-Path -LiteralPath $script:StartPath)) {
+        throw "Required file not found: $script:StartPath"
+    }
+
+    . $script:StartPath
+
+    function Assert-Pwsh7OrThrow { }
+    function Write-Message { param([string]$Level, [string]$Message) }
+    function New-VideoRunContext {
+        param([int]$RequestedFps, [string]$SaveFolder, [string]$RunGuid)
+        [pscustomobject]@{
+            Version = 'test'
+            Config = @{
+                VideoExtensions                 = @('.mp4')
+                VideoProbeTimeoutSeconds        = 1
+                SnapshotFallbackTimeoutSeconds  = 1
+                SnapshotDurationGraceSeconds    = 1
+                SnapshotIdleTimeoutSeconds      = 0
+                SnapshotIdleWarmUpSeconds       = 0
+                GdiCaptureDefaultSeconds        = 1
+                VlcLogVerbosity                 = 1
+            }
+            RunGuid = $RunGuid
+            SaveFolder = $SaveFolder
+            RequestedFps = $RequestedFps
+        }
+    }
+    function Test-FolderWritable { param([string]$Folder) New-Item -ItemType Directory -Path $Folder -Force | Out-Null }
+    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
+    function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
+    function Write-ProcessedLog {
+        param([string]$Path, [string]$VideoPath, [string]$Status, [string]$Reason = '')
+        $script:ProcessedLogCalls += [pscustomobject]@{ Path = $Path; VideoPath = $VideoPath; Status = $Status; Reason = $Reason }
+    }
+    function Start-Vlc {
+        param($Context, [string]$VideoPath, [string]$SaveFolder, [switch]$UseVlcSnapshots, [int]$RequestedFps, [double]$StopAtSeconds, [switch]$GdiFullscreen, [int]$StartupTimeoutSeconds, [string]$VlcExe, [switch]$NoAudio)
+        $script:StartVlcCalls++
+        return [pscustomobject]@{ Id = 12345 }
+    }
+    function Wait-ForSnapshotFrames {
+        param([string]$SaveFolder, [string]$ScenePrefix, [int]$MaxSeconds, $Process, [int]$IdleTimeoutSeconds, [int]$WarmUpSeconds)
+        return [pscustomobject]@{ FramesDelta = 0; ElapsedSeconds = 1 }
+    }
+    function Stop-Vlc { param($Context, $Process) }
+    function Unregister-RunPid { param($Context, [int]$ProcessId) }
+    function Invoke-Cropper { throw 'Invoke-Cropper should not be called in this test.' }
+}
+
+Describe 'Start-VideoBatch processed-log status writes' {
+    BeforeEach {
+        $script:ProcessedLogCalls = @()
+        $script:StartVlcCalls = 0
+        $script:SourceFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-source-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        $script:SaveFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-save-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:SourceFolder, $script:SaveFolder -Force | Out-Null
+        $script:VideoPath = Join-Path $script:SourceFolder 'zero.mp4'
+        Set-Content -LiteralPath $script:VideoPath -Value 'fake video' -NoNewline
+        $script:FakeVlc = Join-Path $script:SourceFolder 'vlc.exe'
+        Set-Content -LiteralPath $script:FakeVlc -Value 'fake vlc' -NoNewline
+    }
+
+    AfterEach {
+        foreach ($path in @($script:SourceFolder, $script:SaveFolder)) {
+            if ($path -and (Test-Path -LiteralPath $path -ErrorAction SilentlyContinue)) {
+                Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'logs zero-frame captures as Failed/NoFrames instead of Processed/NoFrames' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -UseVlcSnapshots -MaxPerVideoSeconds 1
+
+        $script:StartVlcCalls | Should -Be 1
+        $script:ProcessedLogCalls | Should -HaveCount 1
+        $script:ProcessedLogCalls[0].Status | Should -Be 'Failed'
+        $script:ProcessedLogCalls[0].Reason | Should -Be 'NoFrames'
+    }
+}


### PR DESCRIPTION
### Motivation
- Resume should respect processed-log `Status`/`Reason` so failures and zero-frame captures are retried instead of silently skipped.
- Make resume behavior robust and backward compatible with legacy single-column processed logs.

### Description
- Add `Test-ProcessedLogEntryShouldSkip` and make `Get-ResumeIndex` status-aware so only true `Processed` successes and deliberate `Skipped`/`NotPlayable` rows are excluded from resume, while `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` remain retryable.
- Update `Start-VideoBatch` to write zero-frame captures as `Failed`/`NoFrames` and adjust user messaging so failed videos are clearly marked as retry-eligible, not permanently skipped.
- Bump Videoscreenshot `ModuleVersion` to `3.2.2` and update `ReleaseNotes`, `CHANGELOG.md`, and `README.md` to document status-aware resume semantics and zero-frame logging.
- Add Pester tests under `tests/powershell/modules/Media/Videoscreenshot/` to cover processed-log parsing (`Processed.Log.Tests.ps1`) and `Start-VideoBatch` processed-log writes (`Start-VideoBatch.ProcessedLog.Tests.ps1`).

### Testing
- Ran repository static checks including `git diff --check` and custom static content validations (Python scripts) which passed.
- Added Pester test files to exercise `Get-ResumeIndex` classification and zero-frame write behavior, but `Invoke-Pester` could not be executed here because `pwsh` is not available in the environment, so tests were not run in CI in this session.
- Verified the changes build-clean in the working tree and committed with message `fix(videoscreenshot): retry failed resume log entries`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcca24d288325b45348e9c0a89adb)