### PR TITLE
fix(videoscreenshot): tolerate VLC snapshot caps

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,15 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.4] - 2026-05-31
+### Fixed
+- **Tolerant VLC snapshot completion**: duration-probed snapshot caps now use `max(duration × SnapshotDurationSlackFactor, SnapshotMinimumTimeoutSeconds) + SnapshotDurationGraceSeconds`, making VLC `--play-and-exit` the primary completion signal while keeping a generous stuck-process safety net.
+- **Retryable cap truncation**: cap hits while VLC is still alive are logged as `TimedOutProcessed`/`SnapshotCapHit` instead of clean success, so status-aware resume can retry partially captured videos.
+- **Less aggressive idle detection**: default idle warm-up/timeout values are higher, and the idle timer starts after warm-up for cold/slow sources rather than counting the warm-up period itself.
+
+### Added
+- **Snapshot cap tuning knobs**: `SnapshotDurationSlackFactor` and `SnapshotMinimumTimeoutSeconds` in `Get-DefaultConfig`.
+
 ## [3.2.3] - 2026-05-31
 ### Fixed
 - **Empty retry-only resume indexes**: `Get-ResumeIndex` now emits its `HashSet` with `Write-Output -NoEnumerate`, so logs containing only retry-eligible rows (or missing logs) return an empty set instead of `$null`.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -19,6 +19,7 @@
   [hashtable] with well-known keys:
     - Timing: PollIntervalMs, VideoProbeTimeoutSeconds,
               SnapshotFallbackTimeoutSeconds, SnapshotDurationGraceSeconds,
+              SnapshotDurationSlackFactor, SnapshotMinimumTimeoutSeconds,
               SnapshotTerminationExtraSeconds, StopVlcWaitMs, WaitProcessTimeoutSeconds
     - Discovery: VideoExtensions
     - GDI: GdiCaptureDefaultSeconds
@@ -46,15 +47,26 @@ function Get-DefaultConfig {
 
         # Last-resort cap (seconds) used when no explicit per-video limit is given
         # AND duration detection fails. When duration is detectable, Start-VideoBatch
-        # computes cap = video_duration + SnapshotDurationGraceSeconds instead.
+        # computes a generous safety-net cap from duration, slack, floor, and grace.
         # Typical range: 60–600 s depending on expected clip durations.
         SnapshotFallbackTimeoutSeconds  = 300
 
-        # Grace margin (seconds) added to a probed video duration to form the
-        # per-video snapshot cap: cap = duration + SnapshotDurationGraceSeconds.
+        # Multiplier applied to probed video duration when computing the VLC
+        # snapshot safety-net cap. This makes --play-and-exit the normal completion
+        # signal while absorbing slow decode and under-reported metadata.
+        # Typical range: 1.5–3.0.
+        SnapshotDurationSlackFactor     = 2.0
+
+        # Minimum safety-net cap (seconds) for duration-probed VLC snapshot runs.
+        # The floor does not delay healthy short clips because polling exits when
+        # VLC self-exits; it only bounds genuinely stuck sessions.
+        # Typical range: 60–300 s.
+        SnapshotMinimumTimeoutSeconds   = 120
+
+        # Grace margin (seconds) added after the duration-derived slack/floor cap.
         # Accounts for VLC startup, buffering, and slow-flush at end of playback.
-        # Typical range: 15–60 s.
-        SnapshotDurationGraceSeconds    = 30
+        # Typical range: 15–120 s.
+        SnapshotDurationGraceSeconds    = 60
 
         # Extra grace seconds allowed after requesting termination of snapshotting,
         # giving VLC time to flush/close cleanly before any force-kill paths.
@@ -63,14 +75,14 @@ function Get-DefaultConfig {
 
         # Seconds without a new frame before Wait-ForSnapshotFrames abandons a stalled
         # VLC session (idle-frame stall detection). Only triggers after the warm-up window
-        # elapses. Set to 0 to disable. Typical range: 10–60 s.
-        SnapshotIdleTimeoutSeconds      = 20
+        # elapses. Set to 0 to disable. Typical range: 30–180 s.
+        SnapshotIdleTimeoutSeconds      = 60
 
         # Seconds at the start of a snapshot session during which idle detection is
         # suppressed, to allow slow-starting sources (e.g., cold network shares) to
         # produce their first frame before the idle timer starts counting.
-        # Typical range: 5–30 s.
-        SnapshotIdleWarmUpSeconds       = 10
+        # Typical range: 15–120 s.
+        SnapshotIdleWarmUpSeconds       = 30
 
         # Milliseconds to wait after CloseMainWindow() before force-terminating VLC
         # in Stop-Vlc. Larger values are gentler on VLC; smaller values speed up

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Monitor.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Monitor.ps1
@@ -21,7 +21,7 @@ function Wait-ForSnapshotFrames {
   Seconds at the start of the session during which idle detection is suppressed, to allow
   slow-starting sources to produce their first frame (default 10).
   .OUTPUTS
-  PSCustomObject with FramesDelta and ElapsedSeconds.
+  PSCustomObject with FramesDelta, ElapsedSeconds, ExitReason, HitMaxSeconds, and ProcessAliveAtExit.
   #>
     [CmdletBinding()]
     param(
@@ -40,6 +40,9 @@ function Wait-ForSnapshotFrames {
     $lastCount = $initial
     $vlcExitTime = $null
     $lastFrameTime = $start
+    $exitReason = 'MaxSeconds'
+    $hitMaxSeconds = $true
+    $processAliveAtExit = $false
 
     while ((New-TimeSpan -Start $start -End (Get-Date)).TotalSeconds -lt $MaxSeconds) {
         $now = Get-Date
@@ -61,6 +64,8 @@ function Wait-ForSnapshotFrames {
                     # Exit polling after grace period to avoid duplicate frames
                     if ((New-TimeSpan -Start $vlcExitTime -End (Get-Date)).TotalSeconds -ge $GracePeriodSeconds) {
                         Write-Debug "Grace period elapsed; stopping snapshot polling"
+                        $exitReason = 'ProcessExited'
+                        $hitMaxSeconds = $false
                         break
                     }
                 }
@@ -68,9 +73,16 @@ function Wait-ForSnapshotFrames {
                     # Idle-frame stall detection: only fire after warm-up window has elapsed
                     $elapsed = (New-TimeSpan -Start $start -End $now).TotalSeconds
                     if ($elapsed -ge $WarmUpSeconds) {
-                        $idleSeconds = (New-TimeSpan -Start $lastFrameTime -End $now).TotalSeconds
+                        # Count idle time only after the warm-up window. If no frames arrive
+                        # during warm-up, a slow-starting source still gets a full idle window.
+                        $idleWindowStart = $lastFrameTime
+                        $warmUpEnd = $start.AddSeconds($WarmUpSeconds)
+                        if ($idleWindowStart -lt $warmUpEnd) { $idleWindowStart = $warmUpEnd }
+                        $idleSeconds = (New-TimeSpan -Start $idleWindowStart -End $now).TotalSeconds
                         if ($idleSeconds -ge $IdleTimeoutSeconds) {
-                            Write-Message -Level Warn -Message ("Idle-frame stall detected: no new frames for {0:F0}s; abandoning VLC session early." -f $idleSeconds)
+                            Write-Message -Level Warn -Message ("Idle-frame stall detected: no new frames for {0:F0}s after warm-up; abandoning VLC session early." -f $idleSeconds)
+                            $exitReason = 'IdleTimeout'
+                            $hitMaxSeconds = $false
                             break
                         }
                     }
@@ -81,15 +93,34 @@ function Wait-ForSnapshotFrames {
                 if ($null -eq $vlcExitTime) {
                     $vlcExitTime = $now
                 }
+                $exitReason = 'ProcessUnknown'
+                $hitMaxSeconds = $false
+                break
             }
         }
 
         Start-Sleep -Milliseconds $PollMs
     }
 
+    if ($hitMaxSeconds -and $Process) {
+        try {
+            $Process.Refresh()
+            $processAliveAtExit = -not $Process.HasExited
+        }
+        catch {
+            $processAliveAtExit = $false
+        }
+        if ($processAliveAtExit) {
+            Write-Message -Level Warn -Message ("Snapshot safety-net cap reached after {0}s while VLC is still running; capture may be truncated." -f $MaxSeconds)
+        }
+    }
+
     $elapsed = [int][Math]::Ceiling((New-TimeSpan -Start $start -End (Get-Date)).TotalSeconds)
     [pscustomobject]@{
-        FramesDelta    = [int]($lastCount - $initial)
-        ElapsedSeconds = $elapsed
+        FramesDelta        = [int]($lastCount - $initial)
+        ElapsedSeconds     = $elapsed
+        ExitReason         = $exitReason
+        HitMaxSeconds      = [bool]$hitMaxSeconds
+        ProcessAliveAtExit = [bool]$processAliveAtExit
     }
 }

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -393,20 +393,29 @@ function Start-VideoBatch {
                     $detectedDuration = Get-VideoDuration -Path $video.FullName
                     if ($detectedDuration -gt 0) {
                         $grace = [int]$context.Config.SnapshotDurationGraceSeconds
-                        [int][Math]::Ceiling($detectedDuration + $grace)
+                        $slackFactor = [double]$context.Config.SnapshotDurationSlackFactor
+                        if ($slackFactor -le 0) { $slackFactor = 2.0 }
+                        $floorSeconds = [int]$context.Config.SnapshotMinimumTimeoutSeconds
+                        if ($floorSeconds -lt 1) { $floorSeconds = 1 }
+                        $slackSeconds = [Math]::Ceiling([double]$detectedDuration * $slackFactor)
+                        [int][Math]::Ceiling([Math]::Max($slackSeconds, $floorSeconds) + $grace)
                     } else {
                         Write-Debug ("Duration probe failed for '{0}'; using flat fallback ({1} s)." -f $video.FullName, $context.Config.SnapshotFallbackTimeoutSeconds)
                         [int]$context.Config.SnapshotFallbackTimeoutSeconds
                     }
                 }
                 $waitSeconds = [int]([Math]::Max(1, $baseWait + [int]$StartupGraceSeconds))
-                Write-Debug ("TRACE Start-VideoBatch: about to call Wait-ForSnapshotFrames (MaxSeconds={0}, Prefix={1})" -f $waitSeconds, $scenePrefix)
+                Write-Debug ("TRACE Start-VideoBatch: about to call Wait-ForSnapshotFrames (MaxSeconds={0}, Prefix={1}, CapSeconds={2})" -f $waitSeconds, $scenePrefix, $capSeconds)
                 $snapStats = Wait-ForSnapshotFrames -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -MaxSeconds $waitSeconds -Process $p `
                     -IdleTimeoutSeconds ([int]$context.Config.SnapshotIdleTimeoutSeconds) `
                     -WarmUpSeconds ([int]$context.Config.SnapshotIdleWarmUpSeconds)
                 $snapType = if ($null -ne $snapStats) { $snapStats.GetType().FullName } else { '<null>' }
                 $snapStr = if ($null -ne $snapStats) { $snapStats.ToString() } else { '<null>' }
                 Write-Debug ("TRACE Start-VideoBatch: Wait-ForSnapshotFrames returned type={0} tostring={1}" -f $snapType, $snapStr)
+                if ($null -ne $snapStats -and $snapStats.HitMaxSeconds -and $snapStats.ProcessAliveAtExit) {
+                    $retainVlcLog = $true
+                    Write-Message -Level Warn -Message ("VLC snapshot cap hit while playback was still active for: {0}; marking as timeout/truncation so resume can retry." -f $video.FullName)
+                }
             }
             else {
                 $dur = if ($capSeconds -gt 0) { [int]$capSeconds } else { [int]$context.Config.GdiCaptureDefaultSeconds }
@@ -485,6 +494,12 @@ function Start-VideoBatch {
             Write-Message -Level Warn -Message ("No frames produced for: {0}" -f $video.FullName)
             # Log zero-frame captures as failed so resume runs can retry them.
             $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'Failed' -Reason 'NoFrames'
+        }
+        elseif ($UseVlcSnapshots -and $null -ne $snapStats -and $snapStats.HitMaxSeconds -and $snapStats.ProcessAliveAtExit) {
+            # Some frames were produced, but the safety-net cap interrupted a live VLC session.
+            # Keep the row retry-eligible for status-aware resume.
+            $null = Write-ProcessedLog -Path $processedLog -VideoPath $video.FullName -Status 'TimedOutProcessed' -Reason 'SnapshotCapHit'
+            Write-Message -Level Warn -Message ("Video marked as timed out/truncated (eligible for retry on resume): {0}" -f $video.FullName)
         }
         else {
             if ($null -ne $achievedFps) {

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -350,10 +350,10 @@ Runtime measurements reported by the cropper use wall-clock time (not CPU time) 
 When no explicit `-MaxPerVideoSeconds` / `-TimeLimitSeconds` is set, `Start-VideoBatch` probes each video's duration and computes a per-video cap:
 
 ```
-cap = video_duration + SnapshotDurationGraceSeconds
+cap = max(video_duration × SnapshotDurationSlackFactor, SnapshotMinimumTimeoutSeconds) + SnapshotDurationGraceSeconds
 ```
 
-This means a 20 s clip gets ~50 s, a 4-min video gets ~4.5 min, and a 30-min video gets ~31 min — the entire video always plays. The flat `SnapshotFallbackTimeoutSeconds` is used only when duration cannot be detected (e.g., no ffprobe, no Shell metadata).
+VLC `--play-and-exit` remains the primary completion signal: healthy short clips still finish as soon as VLC exits, without waiting for the floor. The cap is only a generous safety net for stuck VLC sessions, slow decode, or under-reported metadata. A cap hit while VLC is still alive is logged as `TimedOutProcessed`/`SnapshotCapHit` so status-aware resume can retry it. The flat `SnapshotFallbackTimeoutSeconds` is used only when duration cannot be detected (e.g., no ffprobe, no Shell metadata).
 
 ### Idle-frame stall detection (VLC snapshot mode)
 When VLC cannot decode a file (corrupt, unsupported codec, zero-duration stream), it stalls indefinitely with a black screen. The module detects this situation and abandons the session early rather than waiting for the full fallback timeout.
@@ -363,10 +363,12 @@ Key config knobs (in `Get-DefaultConfig`, `Private/Config.ps1`):
 | Key | Default | Description |
 |-----|---------|-------------|
 | `VideoProbeTimeoutSeconds` | `5` | Seconds to wait for the optional `-VerifyVideos` pre-flight VLC probe before force-killing it and marking the video unplayable. |
-| `SnapshotDurationGraceSeconds` | `30` | Grace margin (s) added to detected video duration to form the per-video cap. Absorbs VLC startup, buffering, and end-of-stream flush. |
-| `SnapshotIdleTimeoutSeconds` | `20` | Seconds without a new frame before the session is abandoned. Set to `0` to disable. |
-| `SnapshotIdleWarmUpSeconds` | `10` | Seconds at session start during which idle detection is suppressed (allows slow-starting sources their first frame). |
+| `SnapshotDurationSlackFactor` | `2.0` | Multiplier applied to detected duration when computing the VLC snapshot safety-net cap. |
+| `SnapshotMinimumTimeoutSeconds` | `120` | Minimum safety-net cap for duration-probed VLC snapshot runs; healthy short clips still exit promptly via VLC self-exit. |
+| `SnapshotDurationGraceSeconds` | `60` | Grace margin (s) added after the duration slack/floor cap. Absorbs VLC startup, buffering, and end-of-stream flush. |
+| `SnapshotIdleTimeoutSeconds` | `60` | Seconds without a new frame after warm-up before the session is abandoned. Set to `0` to disable. |
+| `SnapshotIdleWarmUpSeconds` | `30` | Seconds at session start during which idle detection is suppressed; the idle timer starts after this window for cold/slow sources. |
 | `SnapshotFallbackTimeoutSeconds` | `300` | Last-resort cap used only when duration detection fails. |
 | `Vlc.LogVerbosity` | `1` | VLC sidecar logfile verbosity (`0`-`2`); `0` also passes `--quiet`. |
 
-A `WARNING` log line is emitted when idle-break fires so the problem video is visible in the run log.
+A `WARNING` log line is emitted when idle-break fires or the safety-net cap is reached while VLC is still alive, so the problem video is visible in the run log.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.3'
+  ModuleVersion     = '3.2.4'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.3: Get-ResumeIndex now returns an empty HashSet without pipeline enumeration when all processed-log rows are retry-eligible or the log is missing.'
+      ReleaseNotes = '3.2.4: VLC snapshot waits now use a generous duration slack/floor safety-net, more tolerant idle defaults, and retry-eligible timeout status for cap-hit truncation.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Monitor.Tests.ps1
@@ -71,6 +71,8 @@ Describe 'Wait-ForSnapshotFrames' {
                 # Should idle-break at ~2 s, not wait out the full 60 s cap
                 $sw.Elapsed.TotalSeconds | Should -BeLessThan 15
                 $result.FramesDelta | Should -Be 0
+                $result.ExitReason | Should -Be 'IdleTimeout'
+                $result.HitMaxSeconds | Should -BeFalse
             }
             finally {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -93,6 +95,9 @@ Describe 'Wait-ForSnapshotFrames' {
 
                 # Function ran for the full MaxSeconds, not cut short by idle
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
+                $result.ExitReason | Should -Be 'MaxSeconds'
+                $result.HitMaxSeconds | Should -BeTrue
+                $result.ProcessAliveAtExit | Should -BeTrue
             }
             finally {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -119,6 +124,7 @@ Describe 'Wait-ForSnapshotFrames' {
 
                 # Must have run for at least the warm-up window, not bailed at 1 s
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2.5
+                $result.ExitReason | Should -Be 'IdleTimeout'
             }
             finally {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -141,6 +147,7 @@ Describe 'Wait-ForSnapshotFrames' {
 
                 $sw.Elapsed.TotalSeconds | Should -BeGreaterThan 2
                 $sw.Elapsed.TotalSeconds | Should -BeLessThan 15
+                $result.ExitReason | Should -Be 'IdleTimeout'
             }
             finally {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -166,6 +173,8 @@ Describe 'Wait-ForSnapshotFrames' {
                 # Should exit after GracePeriodSeconds (~1 s), not wait 60 s
                 $sw.Elapsed.TotalSeconds | Should -BeLessThan 10
                 $result.FramesDelta | Should -Be 0
+                $result.ExitReason | Should -Be 'ProcessExited'
+                $result.HitMaxSeconds | Should -BeFalse
             }
             finally {
                 Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
@@ -21,6 +21,8 @@ BeforeAll {
                 VideoExtensions                 = @('.mp4')
                 VideoProbeTimeoutSeconds        = 1
                 SnapshotFallbackTimeoutSeconds  = 1
+                SnapshotDurationSlackFactor     = 2.0
+                SnapshotMinimumTimeoutSeconds   = 2
                 SnapshotDurationGraceSeconds    = 1
                 SnapshotIdleTimeoutSeconds      = 0
                 SnapshotIdleWarmUpSeconds       = 0

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
@@ -21,6 +21,8 @@ BeforeAll {
                 VideoExtensions                 = @('.mp4')
                 VideoProbeTimeoutSeconds        = 1
                 SnapshotFallbackTimeoutSeconds  = 1
+                SnapshotDurationSlackFactor     = 2.0
+                SnapshotMinimumTimeoutSeconds   = 2
                 SnapshotDurationGraceSeconds    = 1
                 SnapshotIdleTimeoutSeconds      = 0
                 SnapshotIdleWarmUpSeconds       = 0
@@ -47,8 +49,10 @@ BeforeAll {
     }
     function Wait-ForSnapshotFrames {
         param([string]$SaveFolder, [string]$ScenePrefix, [int]$MaxSeconds, $Process, [int]$IdleTimeoutSeconds, [int]$WarmUpSeconds)
-        return [pscustomobject]@{ FramesDelta = 0; ElapsedSeconds = 1 }
+        $script:WaitMaxSeconds = $MaxSeconds
+        return [pscustomobject]@{ FramesDelta = $script:WaitFramesDelta; ElapsedSeconds = 1; HitMaxSeconds = $script:WaitHitMaxSeconds; ProcessAliveAtExit = $script:WaitProcessAliveAtExit }
     }
+    function Get-VideoDuration { param([string]$Path) $script:DetectedDuration }
     function Stop-Vlc { param($Context, $Process) }
     function Unregister-RunPid { param($Context, [int]$ProcessId) }
     function Invoke-Cropper { throw 'Invoke-Cropper should not be called in this test.' }
@@ -58,6 +62,11 @@ Describe 'Start-VideoBatch processed-log status writes' {
     BeforeEach {
         $script:ProcessedLogCalls = @()
         $script:StartVlcCalls = 0
+        $script:WaitFramesDelta = 0
+        $script:WaitHitMaxSeconds = $false
+        $script:WaitProcessAliveAtExit = $false
+        $script:WaitMaxSeconds = 0
+        $script:DetectedDuration = 2
         $script:SourceFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-source-{0}" -f [System.Guid]::NewGuid().ToString('N'))
         $script:SaveFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-save-{0}" -f [System.Guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $script:SourceFolder, $script:SaveFolder -Force | Out-Null
@@ -82,5 +91,28 @@ Describe 'Start-VideoBatch processed-log status writes' {
         $script:ProcessedLogCalls | Should -HaveCount 1
         $script:ProcessedLogCalls[0].Status | Should -Be 'Failed'
         $script:ProcessedLogCalls[0].Reason | Should -Be 'NoFrames'
+    }
+
+    It 'uses duration slack and floor as a safety-net cap when no explicit cap is supplied' {
+        $script:WaitFramesDelta = 2
+
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -UseVlcSnapshots -StartupGraceSeconds 2
+
+        # max(duration 2s * slack 2.0, floor 2s) + grace 1s + startup grace 2s
+        $script:WaitMaxSeconds | Should -Be 7
+        $script:ProcessedLogCalls[0].Status | Should -Be 'Processed'
+    }
+
+    It 'logs cap-hit VLC snapshot runs with frames as TimedOutProcessed/SnapshotCapHit' {
+        $script:WaitFramesDelta = 3
+        $script:WaitHitMaxSeconds = $true
+        $script:WaitProcessAliveAtExit = $true
+
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -UseVlcSnapshots -MaxPerVideoSeconds 1
+
+        $script:StartVlcCalls | Should -Be 1
+        $script:ProcessedLogCalls | Should -HaveCount 1
+        $script:ProcessedLogCalls[0].Status | Should -Be 'TimedOutProcessed'
+        $script:ProcessedLogCalls[0].Reason | Should -Be 'SnapshotCapHit'
     }
 }


### PR DESCRIPTION
### Motivation
- Improve robustness when VLC is still running at the per-video timeout by making per-video caps more tolerant and by surfacing monitor exit reasons so partially-captured videos can be retried.
- Reduce false aborts for slow/cold sources by increasing idle warm-up/timeout defaults and starting idle timing after warm-up.

### Description
- Added two configuration knobs in `Get-DefaultConfig`: `SnapshotDurationSlackFactor` and `SnapshotMinimumTimeoutSeconds`, and increased `SnapshotDurationGraceSeconds`, `SnapshotIdleWarmUpSeconds`, and `SnapshotIdleTimeoutSeconds` defaults to be more tolerant.
- Changed per-video cap computation in `Start-VideoBatch` to `cap = max(duration × SnapshotDurationSlackFactor, SnapshotMinimumTimeoutSeconds) + SnapshotDurationGraceSeconds` when a duration is available, falling back to `SnapshotFallbackTimeoutSeconds` when not.
- Enhanced `Wait-ForSnapshotFrames` to return `ExitReason`, `HitMaxSeconds`, and `ProcessAliveAtExit`; idle detection now measures idle time after the warm-up window instead of including warm-up in the idle timer.
- When a snapshot safety-net cap is hit while VLC is still alive, `Start-VideoBatch` now marks the row retry-eligible (`TimedOutProcessed` / `SnapshotCapHit`), retains the VLC sidecar log for diagnosis, and emits a warning so status-aware resume can retry the video.
- Updated docs (`README.md`), module manifest (`Videoscreenshot.psd1` bumped to `3.2.4`), and module `CHANGELOG.md` to reflect the behavior and new knobs.
- Extended/updated Pester tests to cover: monitor exit reasons, cap calculation using slack/floor, and cap-hit retry status (`tests/.../Snapshot.Monitor.Tests.ps1`, `Start-VideoBatch.ProcessedLog.Tests.ps1`, `Start-VideoBatch.Preflight.Tests.ps1`).

### Testing
- Ran `git diff --check` with no reported issues after changes (passed).
- Updated and added Pester tests to assert new behaviors in `tests/powershell/modules/Media/Videoscreenshot/*` (see modified tests list); attempted to run `Invoke-Pester`, but `pwsh` is not available in this environment so the test run could not be executed here.
- Committed changes with commitizen-style message `fix(videoscreenshot): tolerate VLC snapshot caps` and bumped module version to `3.2.4`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd4bf00a88325bf1ccb3ed5009c21)