### PR TITLE
test(powershell): deduplicate expand-zips setup

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.6.19 — 2026-05-31 *(patch — test refactor; no behaviour change)*
+
+### Tests
+
+- Added shared `Expand-ZipsAndClean.TestHelpers.ps1` Pester setup helpers for loading the
+  `ZipWorkflow` and `ZipExtraction` test dependencies.
+- Replaced repeated `Expand-ZipsAndClean.Tests.ps1` `BeforeAll` module-loading boilerplate
+  with calls into the shared setup helpers while preserving the existing test coverage.
+
 ## 2.6.18 — 2026-05-30 *(patch — import guard test fix)*
 
 ### Fixed

--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added shared `Expand-ZipsAndClean.TestHelpers.ps1` Pester setup helpers for loading the
   `ZipWorkflow` and `ZipExtraction` test dependencies.
+- Load the shared helper during Pester's run phase so its helper functions are available
+  to `BeforeAll` blocks.
 - Replaced repeated `Expand-ZipsAndClean.Tests.ps1` `BeforeAll` module-loading boilerplate
   with calls into the shared setup helpers while preserving the existing test coverage.
 

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -119,7 +119,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.18
+    Version  : 2.6.19
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -51,7 +51,7 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 ## Recent Updates
 
 - **Expand-ZipsAndClean Pester helper-loading cleanup (issue #1144)** (2026-05-31)
-  - Added shared test setup helpers for loading `ZipWorkflow` and `ZipExtraction` dependencies in `Expand-ZipsAndClean.Tests.ps1`.
+  - Added shared test setup helpers for loading `ZipWorkflow` and `ZipExtraction` dependencies in `Expand-ZipsAndClean.Tests.ps1`, loaded during Pester's run phase so `BeforeAll` blocks can call them.
   - Replaced repeated per-`Describe` `BeforeAll` module-loading boilerplate with calls into the shared helper file without changing behavioral coverage.
   - Version bump: `2.6.19` (patch — tests-only refactor, no runtime behavior change).
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -50,6 +50,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 
 ## Recent Updates
 
+- **Expand-ZipsAndClean Pester helper-loading cleanup (issue #1144)** (2026-05-31)
+  - Added shared test setup helpers for loading `ZipWorkflow` and `ZipExtraction` dependencies in `Expand-ZipsAndClean.Tests.ps1`.
+  - Replaced repeated per-`Describe` `BeforeAll` module-loading boilerplate with calls into the shared helper file without changing behavioral coverage.
+  - Version bump: `2.6.19` (patch — tests-only refactor, no runtime behavior change).
+
 - **Expand-ZipsAndClean path-aware import guard test fix (issue #1191)** (2026-05-30)
   - Used a platform-appropriate path comparer for `ZipWorkflow` dependency path checks before skipping already-loaded same-name modules.
   - Corrected regression tests to validate nested dependency behavior through `ZipWorkflow` commands rather than global module visibility.

--- a/tests/powershell/file-management/Expand-ZipsAndClean.TestHelpers.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.TestHelpers.ps1
@@ -1,0 +1,13 @@
+Set-StrictMode -Version Latest
+
+$script:ExpandZipsAndCleanRepositoryRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+$script:ExpandZipsAndCleanModuleRoot = Join-Path $script:ExpandZipsAndCleanRepositoryRoot 'src/powershell/modules'
+
+function Import-ExpandZipsAndCleanZipWorkflowTestModule {
+    Import-Module (Join-Path $script:ExpandZipsAndCleanModuleRoot 'FileManagement/ZipWorkflow/ZipWorkflow.psm1') -Force -ErrorAction Stop
+}
+
+function Import-ExpandZipsAndCleanZipExtractionTestModule {
+    Import-Module (Join-Path $script:ExpandZipsAndCleanModuleRoot 'FileManagement/ZipExtraction/ZipExtraction.psm1') -Force -ErrorAction Stop
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+}

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -1,5 +1,8 @@
 Set-StrictMode -Version Latest
-. (Join-Path $PSScriptRoot 'Expand-ZipsAndClean.TestHelpers.ps1')
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'Expand-ZipsAndClean.TestHelpers.ps1')
+}
 
 Describe 'Move-ZipFilesToParent' {
     BeforeAll {

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -1,8 +1,9 @@
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'Expand-ZipsAndClean.TestHelpers.ps1')
 
 Describe 'Move-ZipFilesToParent' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
+        Import-ExpandZipsAndCleanZipWorkflowTestModule
     }
 
     It 'moves zip files from source to parent directory' {
@@ -56,8 +57,7 @@ Describe 'Move-ZipFilesToParent' {
 
 Describe 'Invoke-ZipExtractions — wrapper delegation' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipExtraction\ZipExtraction.psm1') -Force
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+        Import-ExpandZipsAndCleanZipExtractionTestModule
     }
 
     It 'returns a zero-count summary when source has no zip files, confirming module delegation' {
@@ -85,7 +85,7 @@ Describe 'Invoke-ZipExtractions — wrapper delegation' {
 
 Describe 'Test-ScriptPreconditions' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
+        Import-ExpandZipsAndCleanZipWorkflowTestModule
     }
 
     It 'throws when source and destination are the same path' {
@@ -120,7 +120,7 @@ Describe 'Test-ScriptPreconditions' {
 
 Describe 'Resolve-MoveTarget' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..\..\..\src\powershell\modules\FileManagement\ZipWorkflow\ZipWorkflow.psm1') -Force
+        Import-ExpandZipsAndCleanZipWorkflowTestModule
     }
 
     It 'returns PolicyTag None and canonical TargetPath when no collision' {


### PR DESCRIPTION
### Motivation
- Reduce repeated per-`Describe` module-import boilerplate in the `Expand-ZipsAndClean` Pester tests by centralizing helper setup while keeping existing coverage and no runtime behavior changes.

### Description
- Added `tests/powershell/file-management/Expand-ZipsAndClean.TestHelpers.ps1` with `Import-ExpandZipsAndCleanZipWorkflowTestModule` and `Import-ExpandZipsAndCleanZipExtractionTestModule` helpers that load the repository-local `ZipWorkflow` and `ZipExtraction` modules and the compression assembly.
- Dot-sourced the new test helper from `tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1` and replaced repeated `BeforeAll` `Import-Module` / `Add-Type` boilerplate with calls to the new helpers.
- Bumped the script `Version` to `2.6.19` in `src/powershell/file-management/Expand-ZipsAndClean.ps1` and added a `2.6.19` entry to `src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md` and a README note in `src/powershell/file-management/README.md` describing the tests-only refactor.
- This change is tests-only and does not alter runtime behavior of the script or modules.

### Testing
- Ran `git diff --check` which produced no problems.
- Attempted to run the Pester suite with `pwsh -NoProfile -Command "Invoke-Pester -Path 'tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1' -PassThru | Select-Object TotalCount,PassedCount,FailedCount,SkippedCount"` but `pwsh` is not installed in the execution environment, so the Pester run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0efd511c8325bf51da4abcc8094c)