### PR TITLE
fix(videoscreenshot): invoke cropper package via module

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,13 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.8] - 2026-05-31
+### Fixed
+- **Packaged cropper invocation via `-PythonScriptPath`**: `Invoke-Cropper` now treats `src/python/media/crop_colours.py` as a locator for `src/python`, sets `PYTHONPATH`, and always runs `python -m media.crop_colours` so the cropper's package-relative imports resolve correctly. The no-path and `CropOnly` paths continue to use the same module invocation and preserve existing cropper flags/resume tracking.
+
+### Docs
+- Updated cropper examples and parameter help to document that `-PythonScriptPath` remains supported as a packaged-cropper locator rather than a loose script execution path.
+
 ## [3.2.7] - 2026-05-31
 ### Fixed
 - **Startup banner version resolution**: `New-VideoRunContext` now reads `ModuleVersion` directly from `Videoscreenshot.psd1` via `Import-PowerShellDataFile`, making the manifest the single authoritative source. The previous logic preferred `Get-Module`, which returns the version of a stale import when the module has been edited without an `Import-Module -Force` reload. The hard-coded `'3.0.5'` fallback (which silently masked lookup failures with a long-obsolete literal) is replaced by `'unknown'`, making missed lookups obvious in the startup banner and logs.

--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,13 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.2.9] - 2026-05-31
+### Fixed
+- **Package-root working directory for cropper module invocation**: `Invoke-Cropper` now sets the child Python process working directory to the selected `src/python` package root before running `python -m media.crop_colours`. This ensures Python resolves the cropper package selected by `-PythonScriptPath` before any unrelated `media` package in the caller's current directory. The cropper input folder is resolved to an absolute path before launch so changing the child working directory does not alter which images are processed.
+
+### Tests
+- Expanded cropper invocation regression coverage to assert the child process runs from the selected `src/python` directory in both explicit `-PythonScriptPath` and omitted-path modes.
+
 ## [3.2.8] - 2026-05-31
 ### Fixed
 - **Packaged cropper invocation via `-PythonScriptPath`**: `Invoke-Cropper` now treats `src/python/media/crop_colours.py` as a locator for `src/python`, sets `PYTHONPATH`, and always runs `python -m media.crop_colours` so the cropper's package-relative imports resolve correctly. The no-path and `CropOnly` paths continue to use the same module invocation and preserve existing cropper flags/resume tracking.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Cropper.Invoke.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Cropper.Invoke.ps1
@@ -88,6 +88,7 @@ function Invoke-Cropper {
     if (-not (Test-Path -LiteralPath $InputFolder -PathType Container)) {
         throw "InputFolder not found for cropper: $InputFolder"
     }
+    $resolvedInputFolder = (Resolve-Path -LiteralPath $InputFolder).Path
 
     # ---- Resolve Python executable -----------------------------------------
     # Preference order: explicit -PythonExe → 'py' (Windows launcher) → 'python'
@@ -193,7 +194,7 @@ function Invoke-Cropper {
     # Per design, these flags are not made configurable here.
     $pyArgs = @('-m', 'media.crop_colours')
     $pyArgs += @(
-        '--input', $InputFolder,
+        '--input', $resolvedInputFolder,
         '--skip-bad-images',
         '--allow-empty',
         '--recurse',
@@ -252,17 +253,20 @@ function Invoke-Cropper {
     $existingPath = [System.Environment]::GetEnvironmentVariable('PYTHONPATH')
     $newPath = if ($existingPath) { "$pythonSrc$([System.IO.Path]::PathSeparator)$existingPath" } else { $pythonSrc }
     $psi.Environment['PYTHONPATH'] = $newPath
+    $psi.WorkingDirectory = $pythonSrc
     Write-Debug ("Invoke-Cropper: Set PYTHONPATH={0}" -f $newPath)
+    Write-Debug ("Invoke-Cropper: Set WorkingDirectory={0}" -f $pythonSrc)
 
     # Pre-flight check: verify Python can import the module
     $psiTest = [System.Diagnostics.ProcessStartInfo]::new()
     $psiTest.FileName = $pythonCmd
     $null = $psiTest.ArgumentList.Add('-c')
-    $null = $psiTest.ArgumentList.Add('import sys; sys.path.insert(0, r"{0}"); import media.crop_colours' -f $pythonSrc)
+    $null = $psiTest.ArgumentList.Add('import media.crop_colours')
     $psiTest.UseShellExecute = $false
     $psiTest.RedirectStandardOutput = $true
     $psiTest.RedirectStandardError = $true
     $psiTest.CreateNoWindow = $true
+    $psiTest.WorkingDirectory = $pythonSrc
     # Copy PYTHONPATH to test process
     $null = $psiTest.Environment
     $psiTest.Environment['PYTHONPATH'] = $newPath
@@ -285,6 +289,7 @@ function Invoke-Cropper {
         $cmdDisplay = "$pythonCmd $($pyArgs -join ' ')"
         Write-Debug ("Invoke-Cropper: Executing command: {0}" -f $cmdDisplay)
         Write-Debug ("Invoke-Cropper: PYTHONPATH={0}" -f $psi.Environment['PYTHONPATH'])
+        Write-Debug ("Invoke-Cropper: WorkingDirectory={0}" -f $psi.WorkingDirectory)
     }
 
     $p = [System.Diagnostics.Process]::new()

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Cropper.Invoke.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Cropper.Invoke.ps1
@@ -4,10 +4,10 @@
 
 .DESCRIPTION
   Invokes the cropper with safe, opinionated defaults (non-destructive and robust).
-  If -PythonScriptPath is provided, the file is executed directly:
-      python <crop_colours.py> --input <folder> --skip-bad-images --allow-empty --recurse --preserve-alpha [--reprocess-cropped [--keep-existing-crops]] [--debug]
-  If -PythonScriptPath is omitted, the module form is used (PYTHONPATH automatically set to include src/python):
+  The packaged cropper is always executed as a module so package-relative imports work:
       python -m media.crop_colours --input <folder> --skip-bad-images --allow-empty --recurse --preserve-alpha [--reprocess-cropped [--keep-existing-crops]] [--debug]
+  If -PythonScriptPath is provided, it is used as a locator for src/python (the parent of the media package) rather than executed as a loose script.
+  If -PythonScriptPath is omitted, src/python is located from the repository root and added to PYTHONPATH automatically.
 
   This helper follows the “helpers throw; caller owns user-facing messages” policy:
   - It validates Python is available.
@@ -26,7 +26,8 @@
     - Import-name translation: 'opencv-python' → import 'cv2'; others import by the same name.
 
 .PARAMETER PythonScriptPath
-  Path to the cropper script (e.g., crop_colours.py).
+  Optional path to the packaged cropper script (src/python/media/crop_colours.py).
+  The path is used to locate src/python; the cropper still runs as `python -m media.crop_colours`.
 
 .PARAMETER PythonExe
   Optional Python executable to use. If not supplied, tries 'py' (Windows launcher) then 'python'.
@@ -46,10 +47,10 @@
     - RequiredPackages : string[] (resolved package list used)
 
 .EXAMPLE
-  Invoke-Cropper -PythonScriptPath .\src\python\crop_colours.py -InputFolder .\shots
+  Invoke-Cropper -PythonScriptPath .\src\python\media\crop_colours.py -InputFolder .\shots
 
 .EXAMPLE
-  Invoke-Cropper -PythonScriptPath .\src\python\crop_colours.py -InputFolder .\shots -PythonExe python -NoAutoInstall -Debug
+  Invoke-Cropper -PythonScriptPath .\src\python\media\crop_colours.py -InputFolder .\shots -PythonExe python -NoAutoInstall -Debug
 #>
 function Invoke-Cropper {
     [CmdletBinding()]
@@ -63,16 +64,25 @@ function Invoke-Cropper {
     )
 
     # ---- Validate inputs ----------------------------------------------------
-    $useModuleInvoke = $false
     $resolvedScript = $null
+    $pythonSrcHint = $null
     if (-not [string]::IsNullOrWhiteSpace($PythonScriptPath)) {
         if (-not (Test-Path -LiteralPath $PythonScriptPath -PathType Leaf)) {
             throw "Cropper script not found: $PythonScriptPath"
         }
-        $resolvedScript = $PythonScriptPath
+
+        $resolvedScript = (Resolve-Path -LiteralPath $PythonScriptPath).Path
+        $scriptDirectory = Split-Path -Parent $resolvedScript
+        $packageDirectoryName = Split-Path -Leaf $scriptDirectory
+        $packageInit = Join-Path $scriptDirectory '__init__.py'
+        if ((Split-Path -Leaf $resolvedScript) -ne 'crop_colours.py' -or $packageDirectoryName -ne 'media' -or -not (Test-Path -LiteralPath $packageInit -PathType Leaf)) {
+            throw "PythonScriptPath must point to the packaged cropper at src/python/media/crop_colours.py so it can be invoked as 'python -m media.crop_colours': $PythonScriptPath"
+        }
+
+        $pythonSrcHint = Split-Path -Parent $scriptDirectory
+        Write-Debug ("Invoke-Cropper: PythonScriptPath supplied; using it as package locator and invoking -m media.crop_colours. src/python={0}" -f $pythonSrcHint)
     }
     else {
-        $useModuleInvoke = $true
         Write-Debug "Invoke-Cropper: PythonScriptPath not supplied; using module invocation (-m media.crop_colours)."
     }
     if (-not (Test-Path -LiteralPath $InputFolder -PathType Container)) {
@@ -181,13 +191,7 @@ function Invoke-Cropper {
 
     # ---- Compose cropper arguments (intentionally opinionated) --------------
     # Per design, these flags are not made configurable here.
-    $pyArgs = @()
-    if ($useModuleInvoke) {
-        $pyArgs += @('-m', 'media.crop_colours')
-    }
-    else {
-        $pyArgs += @("$resolvedScript")
-    }
+    $pyArgs = @('-m', 'media.crop_colours')
     $pyArgs += @(
         '--input', $InputFolder,
         '--skip-bad-images',
@@ -213,8 +217,9 @@ function Invoke-Cropper {
     $psi.RedirectStandardError = $false
     $psi.CreateNoWindow = $false
 
-    # If using module invocation, ensure PYTHONPATH includes src/python directory
-    if ($useModuleInvoke) {
+    # Ensure PYTHONPATH includes src/python so `python -m media.crop_colours` can resolve package-relative imports.
+    $pythonSrc = $pythonSrcHint
+    if (-not $pythonSrc) {
         # Locate repository root (parent of src/python directory)
         $moduleRoot = $PSScriptRoot
         # Navigate up from Private/ to module root
@@ -224,66 +229,62 @@ function Invoke-Cropper {
             $moduleRoot = $parent
         }
 
-        if ($moduleRoot) {
-            $pythonSrc = Join-Path $moduleRoot 'src' 'python'
-            if (Test-Path $pythonSrc -PathType Container) {
-                # Verify the media package exists
-                $mediaPackage = Join-Path $pythonSrc 'media'
-                $cropScript = Join-Path $mediaPackage 'crop_colours.py'
-                if (-not (Test-Path $cropScript -PathType Leaf)) {
-                    throw "Python module not found: $cropScript. Ensure the repository is up-to-date and src/python/media/crop_colours.py exists."
-                }
-
-                # Access .Environment property to auto-populate with current environment
-                $null = $psi.Environment
-                # Set PYTHONPATH to include src/python
-                $existingPath = [System.Environment]::GetEnvironmentVariable('PYTHONPATH')
-                $newPath = if ($existingPath) { "$pythonSrc$([System.IO.Path]::PathSeparator)$existingPath" } else { $pythonSrc }
-                $psi.Environment['PYTHONPATH'] = $newPath
-                Write-Debug ("Invoke-Cropper: Set PYTHONPATH={0}" -f $newPath)
-
-                # Pre-flight check: verify Python can import the module
-                $psiTest = [System.Diagnostics.ProcessStartInfo]::new()
-                $psiTest.FileName = $pythonCmd
-                $null = $psiTest.ArgumentList.Add('-c')
-                $null = $psiTest.ArgumentList.Add('import sys; sys.path.insert(0, r"{0}"); import media.crop_colours' -f $pythonSrc)
-                $psiTest.UseShellExecute = $false
-                $psiTest.RedirectStandardOutput = $true
-                $psiTest.RedirectStandardError = $true
-                $psiTest.CreateNoWindow = $true
-                # Copy PYTHONPATH to test process
-                $null = $psiTest.Environment
-                $psiTest.Environment['PYTHONPATH'] = $newPath
-
-                $pTest = [System.Diagnostics.Process]::new()
-                $pTest.StartInfo = $psiTest
-                $null = $pTest.Start()
-                $testOut = $pTest.StandardOutput.ReadToEnd()
-                $testErr = $pTest.StandardError.ReadToEnd()
-                $pTest.WaitForExit()
-
-                if ($pTest.ExitCode -ne 0) {
-                    $errDetail = if ($testErr) { $testErr } else { $testOut }
-                    throw ("Pre-flight check failed: Python cannot import media.crop_colours. PYTHONPATH={0}. Error: {1}" -f $newPath, $errDetail.Trim())
-                }
-                Write-Debug "Invoke-Cropper: Pre-flight check passed (media.crop_colours is importable)"
-            }
-            else {
-                throw "Python source directory not found: $pythonSrc. Ensure the repository structure is intact."
-            }
-        }
-        else {
+        if (-not $moduleRoot -or -not (Test-Path (Join-Path $moduleRoot '.git') -PathType Container)) {
             throw "Could not locate repository root (no .git directory found). Unable to set PYTHONPATH for module invocation."
         }
+        $pythonSrc = Join-Path $moduleRoot 'src' 'python'
     }
+
+    if (-not (Test-Path -LiteralPath $pythonSrc -PathType Container)) {
+        throw "Python source directory not found: $pythonSrc. Ensure the repository structure is intact."
+    }
+
+    # Verify the media package exists
+    $mediaPackage = Join-Path $pythonSrc 'media'
+    $cropScript = Join-Path $mediaPackage 'crop_colours.py'
+    if (-not (Test-Path -LiteralPath $cropScript -PathType Leaf)) {
+        throw "Python module not found: $cropScript. Ensure the repository is up-to-date and src/python/media/crop_colours.py exists."
+    }
+
+    # Access .Environment property to auto-populate with current environment
+    $null = $psi.Environment
+    # Set PYTHONPATH to include src/python
+    $existingPath = [System.Environment]::GetEnvironmentVariable('PYTHONPATH')
+    $newPath = if ($existingPath) { "$pythonSrc$([System.IO.Path]::PathSeparator)$existingPath" } else { $pythonSrc }
+    $psi.Environment['PYTHONPATH'] = $newPath
+    Write-Debug ("Invoke-Cropper: Set PYTHONPATH={0}" -f $newPath)
+
+    # Pre-flight check: verify Python can import the module
+    $psiTest = [System.Diagnostics.ProcessStartInfo]::new()
+    $psiTest.FileName = $pythonCmd
+    $null = $psiTest.ArgumentList.Add('-c')
+    $null = $psiTest.ArgumentList.Add('import sys; sys.path.insert(0, r"{0}"); import media.crop_colours' -f $pythonSrc)
+    $psiTest.UseShellExecute = $false
+    $psiTest.RedirectStandardOutput = $true
+    $psiTest.RedirectStandardError = $true
+    $psiTest.CreateNoWindow = $true
+    # Copy PYTHONPATH to test process
+    $null = $psiTest.Environment
+    $psiTest.Environment['PYTHONPATH'] = $newPath
+
+    $pTest = [System.Diagnostics.Process]::new()
+    $pTest.StartInfo = $psiTest
+    $null = $pTest.Start()
+    $testOut = $pTest.StandardOutput.ReadToEnd()
+    $testErr = $pTest.StandardError.ReadToEnd()
+    $pTest.WaitForExit()
+
+    if ($pTest.ExitCode -ne 0) {
+        $errDetail = if ($testErr) { $testErr } else { $testOut }
+        throw ("Pre-flight check failed: Python cannot import media.crop_colours. PYTHONPATH={0}. Error: {1}" -f $newPath, $errDetail.Trim())
+    }
+    Write-Debug "Invoke-Cropper: Pre-flight check passed (media.crop_colours is importable)"
 
     # Debug: Log the exact command being executed
     if ($PSBoundParameters.ContainsKey('Debug') -or $DebugPreference -eq 'Continue') {
         $cmdDisplay = "$pythonCmd $($pyArgs -join ' ')"
         Write-Debug ("Invoke-Cropper: Executing command: {0}" -f $cmdDisplay)
-        if ($useModuleInvoke) {
-            Write-Debug ("Invoke-Cropper: PYTHONPATH={0}" -f $psi.Environment['PYTHONPATH'])
-        }
+        Write-Debug ("Invoke-Cropper: PYTHONPATH={0}" -f $psi.Environment['PYTHONPATH'])
     }
 
     $p = [System.Diagnostics.Process]::new()

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -48,8 +48,9 @@ By default, existing crops are deleted and regenerated.
 .PARAMETER KeepExistingCrops
 When used with -ReprocessCropped, do not delete existing crops; new outputs are added alongside.
 .PARAMETER PythonScriptPath
-Path to crop_colours.py. If omitted, the module will invoke the cropper as a
-Python module (`python -m media.crop_colours`). PYTHONPATH is automatically configured to include src/python.
+Optional path to the packaged cropper at src/python/media/crop_colours.py.
+The path is used to locate src/python; the cropper is still invoked as a
+Python module (`python -m media.crop_colours`) so package-relative imports work.
 .PARAMETER PythonExe
 Python interpreter to use (optional; falls back to py/python in helper).
 .PARAMETER ClearSnapshotsBeforeRun
@@ -60,7 +61,7 @@ Full path to vlc.exe. Use when VLC is not on PATH (e.g. "D:\Program Files\VideoL
 Pass --no-audio to VLC. Use when the VLC audio plugin crashes on your system (e.g. libmmdevice_plugin.dll access violation).
 
 .EXAMPLE
-Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots -RunCropper -PythonScriptPath .\src\python\crop_colours.py
+Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots -RunCropper -PythonScriptPath .\src\python\media\crop_colours.py
 #>
 function Start-VideoBatch {
     [CmdletBinding()]

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -106,7 +106,7 @@ When `-RunCropper` is set, the module invokes the Python cropper after capture. 
   ```
   python -m media.crop_colours --input <SaveFolder> --skip-bad-images --allow-empty --recurse --preserve-alpha
   ```
-  PYTHONPATH is automatically configured to include `src/python`.
+  PYTHONPATH is automatically configured to include `src/python`, and the child process working directory is set to that same package root so `python -m` resolves the intended `media` package before any package in the caller's current directory.
 
 To force a full re-crop, use:
 ```
@@ -126,7 +126,7 @@ Notes:
 - The cropper operates on images under `-SaveFolder`.
 
 Notes:
-- The cropper receives absolute paths and streams logs to the console; Ctrl+C cancels cleanly.
+- The cropper receives absolute input paths, runs from the selected `src/python` package root, and streams logs to the console; Ctrl+C cancels cleanly.
 - On failure, the module throws a concise error; see on-screen logs for details.
 
 ### Crop-only mode

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -19,7 +19,7 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
    ```
 3. **Crop-only cleanup runs** – rerun the Python cropper without capturing new frames.
    ```powershell
-   Start-VideoBatch -CropOnly -SaveFolder .\shots -PythonScriptPath .\src\python\crop_colours.py -ReprocessCropped
+   Start-VideoBatch -CropOnly -SaveFolder .\shots -PythonScriptPath .\src\python\media\crop_colours.py -ReprocessCropped
    ```
 4. **Extension-filtered processing** – restrict work to specific formats and verify playability.
    ```powershell
@@ -43,7 +43,7 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
 - `VideoProbeTimeoutSeconds` (int, default config value `10`): Maximum time to wait for the `-VerifyVideos` probe before force-killing it and treating the video as unplayable.
 - `RunCropper` (switch): Invoke the Python cropper after capture.
 - `CropOnly` (switch): Run the cropper without taking screenshots.
-- `PythonScriptPath` (string): Path to `crop_colours.py` when cropping.
+- `PythonScriptPath` (string): Optional path to the packaged `src/python/media/crop_colours.py`; used as a package locator while the cropper still runs via `python -m media.crop_colours`.
 - `PythonExe` (string): Python interpreter to use for the cropper.
 - `ReprocessCropped` (switch): Force re-crop even if images were processed before.
 - `KeepExistingCrops` (switch): Preserve existing crops when reprocessing.
@@ -100,12 +100,13 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
 ### Cropper integration
 When `-RunCropper` is set, the module invokes the Python cropper after capture. By default the cropper **skips images that were already cropped in previous runs** (tracked via `.processed_images`).
 
-- **If `-PythonScriptPath` is provided** (path to `crop_colours.py`), the script file is executed directly.
-- **If `-PythonScriptPath` is omitted**, the module falls back to **module invocation**:
+- **If `-PythonScriptPath` is provided** (path to `src/python/media/crop_colours.py`), it is treated as a locator for `src/python`; the file is not executed directly.
+- **If `-PythonScriptPath` is omitted**, the module locates `src/python` from the repository root.
+- In both cases, the cropper uses **module invocation** so package-relative imports work:
   ```
   python -m media.crop_colours --input <SaveFolder> --skip-bad-images --allow-empty --recurse --preserve-alpha
   ```
-  PYTHONPATH is automatically configured to include `src/python` from the repository root.
+  PYTHONPATH is automatically configured to include `src/python`.
 
 To force a full re-crop, use:
 ```
@@ -118,7 +119,7 @@ If you call `Start-VideoBatch -Debug`, `--debug` is added to the Python invocati
 #### Crop-only mode
 Run the cropper without taking screenshots:
 ```powershell
-Start-VideoBatch -CropOnly -SaveFolder .\shots -PythonScriptPath .\src\python\crop_colours.py
+Start-VideoBatch -CropOnly -SaveFolder .\shots -PythonScriptPath .\src\python\media\crop_colours.py
 ```
 Notes:
 - `-CropOnly` ignores capture-related parameters (e.g., `-UseVlcSnapshots`, `-TimeLimitSeconds`); a warning lists any that were supplied.
@@ -131,7 +132,7 @@ Notes:
 ### Crop-only mode
 Skip screenshot capture and only run the cropper:
 ```powershell
-Start-VideoBatch -CropOnly -SaveFolder .\shots [-PythonScriptPath .\src\python\crop_colours.py]
+Start-VideoBatch -CropOnly -SaveFolder .\shots [-PythonScriptPath .\src\python\media\crop_colours.py]
 ```
 Requirements/behavior:
 - **`-SaveFolder` is required** in crop-only mode and must point to the folder containing images to process.
@@ -163,7 +164,7 @@ Start-VideoBatch `
 * (reprocessing) Default behavior skips previously cropped images.
   - `--reprocess-cropped` reprocesses everything.
   - `--keep-existing-crops` (with `--reprocess-cropped`) keeps existing outputs; new files are de-duplicated.
-See the Python script’s docstring for advanced options: src/python/crop_colours.py.
+See the Python script’s docstring for advanced options: src/python/media/crop_colours.py.
 
 ### Resume / processed logging
 
@@ -248,7 +249,7 @@ src/
 - -GdiFullscreen – when using GDI, request fullscreen/top-most playback
 - -VlcStartupTimeoutSeconds – timeout for VLC to initialize
 - -RunCropper – after capture, run the Python cropper over the output images
-- -PythonScriptPath – path to crop_colours.py when using -RunCropper
+- -PythonScriptPath – optional path to src/python/media/crop_colours.py as a package locator when using -RunCropper
 - -PythonExe – optional Python interpreter to use (defaults to py launcher or python)
 - -NoAutoInstall – disable automatic installation of missing Python packages (see below)
 - -TimeLimitSeconds – per-video time cap for playback/capture (0 = no cap)
@@ -263,7 +264,7 @@ src/
 - -RunCropper – run Python cropper after frames saved
 - -ReprocessCropped – force re-crop even if images were processed previously (deletes existing crops by default)
 - -KeepExistingCrops – with -ReprocessCropped, keep existing crops and add new outputs alongside
-- -PythonScriptPath, -PythonExe – cropper script & interpreter
+- -PythonScriptPath, -PythonExe – packaged cropper locator & interpreter
 - -ClearSnapshotsBeforeRun – clear existing frames for the current video prefix before capture
 
 ### Example (with resume + processed logging)
@@ -303,7 +304,7 @@ If any package is missing, the module automatically installs them via python -m 
 > and adds `--reprocess-cropped` (plus `--keep-existing-crops`) when you pass the corresponding PowerShell flags.
 > Note: The cropper’s stdout/stderr stream live to the console (always-on). For advanced control over cropping arguments, adjust the Python script directly. The module uses safe defaults: `--skip-bad-images --allow-empty --recurse --preserve-alpha`, and adds `--reprocess-cropped` (plus `--keep-existing-crops`) when you pass the corresponding PowerShell flags.
 - GDI capture currently targets Windows (uses GDI+/System.Drawing); VLC snapshot mode is cross-platform where VLC is available.
-> See also the docstring in src/python/crop_colours.py for a full list of cropper flags, behaviors, and troubleshooting notes.
+> See also the docstring in src/python/media/crop_colours.py for a full list of cropper flags, behaviors, and troubleshooting notes.
 ### If you see a version error
 The script/module will refuse to run under Windows PowerShell (5.1/Desktop).
 Install PowerShell 7+ and re-run using pwsh.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.7'
+  ModuleVersion     = '3.2.8'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.7: Version resolution in New-VideoRunContext is now manifest-authoritative (Import-PowerShellDataFile); stale hard-coded fallback removed; guard test added; README documents Import-Module -Force reload requirement.'
+      ReleaseNotes = '3.2.8: Invoke-Cropper now treats -PythonScriptPath as a packaged cropper locator and always runs python -m media.crop_colours with PYTHONPATH set, fixing package-relative imports.'
     }
   }
 }

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.8'
+  ModuleVersion     = '3.2.9'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.8: Invoke-Cropper now treats -PythonScriptPath as a packaged cropper locator and always runs python -m media.crop_colours with PYTHONPATH set, fixing package-relative imports.'
+      ReleaseNotes = '3.2.9: Invoke-Cropper now sets the cropper child working directory to the selected src/python package root and passes an absolute input path so python -m resolves the intended media package before any caller cwd package.'
     }
   }
 }

--- a/src/python/media/CHANGELOG.md
+++ b/src/python/media/CHANGELOG.md
@@ -8,6 +8,11 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [4.2.1] - 2026-05-31
+### Fixed
+- Updated `crop_colours.py` usage guidance to show `python -m media.crop_colours` instead of direct loose-script execution.
+- Added a direct-execution guard that exits with a clear message when `crop_colours.py` is run without its parent `media` package.
+
 ## [4.2.0] - 2026-04-10
 
 ### Added

--- a/src/python/media/README.md
+++ b/src/python/media/README.md
@@ -50,7 +50,7 @@ Analyze file content to determine the correct file type and restore proper exten
 python find_duplicate_images.py --path /path/to/images --threshold 5
 
 # Crop colored borders
-python crop_colours.py --input image.jpg --output cropped.jpg
+PYTHONPATH=src/python python -m media.crop_colours --input image.jpg --output cropped.jpg
 
 # Recover file extensions
 python recover_extensions.py --directory /path/to/files
@@ -67,6 +67,11 @@ python recover_extensions.py --directory /path/to/files
 All scripts use the Python Logging Framework located in `src/python/modules/logging/`.
 
 ## Troubleshooting crop_colours.py
+
+> `crop_colours.py` is part of the `media` package. Run it with `python -m media.crop_colours`
+> from a context where `src/python` is on `PYTHONPATH`; direct `python crop_colours.py`
+> execution is unsupported because package-relative imports need the parent package.
+
 
 - **"No valid images found"**:
   Ensure `--input` has `.png`/`.jpg`/`.jpeg` files. Use `--recurse` to include subfolders.

--- a/src/python/media/__init__.py
+++ b/src/python/media/__init__.py
@@ -8,4 +8,4 @@ This package contains Python scripts for image and media file processing:
 - recover_extensions: Recovers or fixes file extensions based on content analysis
 """
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"

--- a/src/python/media/crop_colours.py
+++ b/src/python/media/crop_colours.py
@@ -1,7 +1,7 @@
 """
 Frame cropper for image folders.
 
-Version: 4.2.0
+Version: 4.2.1
 Author: Manoj Bhaskaran
 
 DESCRIPTION
@@ -28,7 +28,7 @@ DEPENDENCIES
 
 USAGE
     # Safe default (non-destructive): Cropped/ + suffix
-    python crop_colours.py --input /path/to/images [--output /path/to/out]
+    python -m media.crop_colours --input /path/to/images [--output /path/to/out]
                       [--suffix _cropped] [--no-suffix]
                       [--max-workers N] [--retry-writes 3]
                       [--progress-interval 100]
@@ -42,7 +42,7 @@ USAGE
                       [--debug]
 
     # Overwrite originals (opt-in)
-    python crop_colours.py --input /path/to/images --in-place
+    python -m media.crop_colours --input /path/to/images --in-place
 
 SEE ALSO
     - Troubleshooting & FAQs:  src/python/media/README.md
@@ -60,6 +60,14 @@ import sys
 import time
 from pathlib import Path
 from typing import Optional, Sequence
+
+if __package__ in (None, ""):
+    print(
+        "crop_colours.py is part of the media package; run it with "
+        "`python -m media.crop_colours` from a context where src/python is on PYTHONPATH.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 from ._tracking import get_processed_set, mark_processed
 from ._image_ops import (

--- a/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+Pester tests for Invoke-Cropper package/module invocation behavior.
+#>
+
+BeforeAll {
+    $script:InvokePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Cropper.Invoke.ps1'
+    if (-not (Test-Path -LiteralPath $script:InvokePath)) {
+        throw "Required file not found: $script:InvokePath"
+    }
+
+    . $script:InvokePath
+}
+
+Describe 'Invoke-Cropper package invocation' {
+    BeforeEach {
+        $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("cropper-invoke-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        $script:InputFolder = Join-Path $script:TempRoot 'images'
+        New-Item -ItemType Directory -Path $script:InputFolder -Force | Out-Null
+        $script:InvocationLog = Join-Path $script:TempRoot 'python-invocations.jsonl'
+        $env:FAKE_PYTHON_LOG = $script:InvocationLog
+
+        if ($IsWindows) {
+            $script:FakePython = Join-Path $script:TempRoot 'fake-python.cmd'
+            $fakePowerShell = Join-Path $script:TempRoot 'fake-python.ps1'
+            @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$PythonArgs)
+$record = [pscustomobject]@{
+    args = $PythonArgs
+    pythonpath = [Environment]::GetEnvironmentVariable('PYTHONPATH')
+}
+$record | ConvertTo-Json -Compress | Add-Content -LiteralPath $env:FAKE_PYTHON_LOG
+exit 0
+'@ | Set-Content -LiteralPath $fakePowerShell -NoNewline
+            @"
+@echo off
+pwsh -NoLogo -NoProfile -File "$fakePowerShell" %*
+"@ | Set-Content -LiteralPath $script:FakePython -NoNewline
+        }
+        else {
+            $script:FakePython = Join-Path $script:TempRoot 'fake-python'
+            @"
+#!/usr/bin/env bash
+set -euo pipefail
+python3 - "`$@" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+log_path = Path(os.environ['FAKE_PYTHON_LOG'])
+record = {
+    'args': sys.argv[1:],
+    'pythonpath': os.environ.get('PYTHONPATH', ''),
+}
+with log_path.open('a', encoding='utf-8') as handle:
+    handle.write(json.dumps(record) + '\n')
+sys.exit(0)
+PY
+"@ | Set-Content -LiteralPath $script:FakePython -NoNewline
+            chmod +x $script:FakePython
+        }
+    }
+
+    AfterEach {
+        Remove-Item Env:FAKE_PYTHON_LOG -ErrorAction SilentlyContinue
+        if ($script:TempRoot -and (Test-Path -LiteralPath $script:TempRoot -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $script:TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'uses -PythonScriptPath as a src/python locator and invokes media.crop_colours as a module' {
+        $cropperPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python' 'media' 'crop_colours.py'
+
+        $result = Invoke-Cropper -PythonScriptPath $cropperPath -InputFolder $script:InputFolder -PythonExe $script:FakePython -NoAutoInstall -ReprocessCropped -KeepExistingCrops
+
+        $result.ExitCode | Should -Be 0
+        $records = Get-Content -LiteralPath $script:InvocationLog | ForEach-Object { $_ | ConvertFrom-Json }
+        $actual = $records | Where-Object { $_.args -contains '-m' -and $_.args -contains 'media.crop_colours' } | Select-Object -Last 1
+
+        $actual | Should -Not -BeNullOrEmpty
+        $actual.args[0] | Should -Be '-m'
+        $actual.args[1] | Should -Be 'media.crop_colours'
+        $actual.args | Should -Contain '--input'
+        $actual.args | Should -Contain $script:InputFolder
+        $actual.args | Should -Contain '--skip-bad-images'
+        $actual.args | Should -Contain '--allow-empty'
+        $actual.args | Should -Contain '--recurse'
+        $actual.args | Should -Contain '--preserve-alpha'
+        $actual.args | Should -Contain '--reprocess-cropped'
+        $actual.args | Should -Contain '--keep-existing-crops'
+        $actual.pythonpath | Should -Match ([regex]::Escape((Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path))
+    }
+
+    It 'keeps omitted PythonScriptPath on module invocation with repository PYTHONPATH' {
+        $result = Invoke-Cropper -InputFolder $script:InputFolder -PythonExe $script:FakePython -NoAutoInstall
+
+        $result.ExitCode | Should -Be 0
+        $records = Get-Content -LiteralPath $script:InvocationLog | ForEach-Object { $_ | ConvertFrom-Json }
+        $actual = $records | Where-Object { $_.args -contains '-m' -and $_.args -contains 'media.crop_colours' } | Select-Object -Last 1
+
+        $actual | Should -Not -BeNullOrEmpty
+        $actual.args[0] | Should -Be '-m'
+        $actual.args[1] | Should -Be 'media.crop_colours'
+        $actual.pythonpath | Should -Match ([regex]::Escape((Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path))
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
@@ -40,26 +40,19 @@ pwsh -NoLogo -NoProfile -File "$fakePowerShell" %*
         }
         else {
             $script:FakePython = Join-Path $script:TempRoot 'fake-python'
-            @"
-#!/usr/bin/env bash
-set -euo pipefail
-python3 - "`$@" <<'PY'
-import json
-import os
-import sys
-from pathlib import Path
-
-log_path = Path(os.environ['FAKE_PYTHON_LOG'])
-record = {
-    'args': sys.argv[1:],
-    'pythonpath': os.environ.get('PYTHONPATH', ''),
-    'cwd': os.getcwd(),
+            $fakePythonContent = @'
+#!/usr/bin/env pwsh
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$PythonArgs)
+$record = [pscustomobject]@{
+    args = $PythonArgs
+    pythonpath = [Environment]::GetEnvironmentVariable('PYTHONPATH')
+    cwd = (Get-Location).Path
 }
-with log_path.open('a', encoding='utf-8') as handle:
-    handle.write(json.dumps(record) + '\n')
-sys.exit(0)
-PY
-"@ | Set-Content -LiteralPath $script:FakePython -NoNewline
+$record | ConvertTo-Json -Compress | Add-Content -LiteralPath $env:FAKE_PYTHON_LOG
+exit 0
+'@
+            $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+            [System.IO.File]::WriteAllText($script:FakePython, $fakePythonContent.Replace("`r`n", "`n"), $utf8NoBom)
             chmod +x $script:FakePython
         }
     }

--- a/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1
@@ -28,6 +28,7 @@ param([Parameter(ValueFromRemainingArguments = $true)][string[]]$PythonArgs)
 $record = [pscustomobject]@{
     args = $PythonArgs
     pythonpath = [Environment]::GetEnvironmentVariable('PYTHONPATH')
+    cwd = (Get-Location).Path
 }
 $record | ConvertTo-Json -Compress | Add-Content -LiteralPath $env:FAKE_PYTHON_LOG
 exit 0
@@ -52,6 +53,7 @@ log_path = Path(os.environ['FAKE_PYTHON_LOG'])
 record = {
     'args': sys.argv[1:],
     'pythonpath': os.environ.get('PYTHONPATH', ''),
+    'cwd': os.getcwd(),
 }
 with log_path.open('a', encoding='utf-8') as handle:
     handle.write(json.dumps(record) + '\n')
@@ -78,6 +80,8 @@ PY
         $records = Get-Content -LiteralPath $script:InvocationLog | ForEach-Object { $_ | ConvertFrom-Json }
         $actual = $records | Where-Object { $_.args -contains '-m' -and $_.args -contains 'media.crop_colours' } | Select-Object -Last 1
 
+        $expectedPythonSrc = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path
+
         $actual | Should -Not -BeNullOrEmpty
         $actual.args[0] | Should -Be '-m'
         $actual.args[1] | Should -Be 'media.crop_colours'
@@ -89,7 +93,8 @@ PY
         $actual.args | Should -Contain '--preserve-alpha'
         $actual.args | Should -Contain '--reprocess-cropped'
         $actual.args | Should -Contain '--keep-existing-crops'
-        $actual.pythonpath | Should -Match ([regex]::Escape((Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path))
+        $actual.pythonpath | Should -Match ([regex]::Escape($expectedPythonSrc))
+        $actual.cwd | Should -Be $expectedPythonSrc
     }
 
     It 'keeps omitted PythonScriptPath on module invocation with repository PYTHONPATH' {
@@ -99,9 +104,12 @@ PY
         $records = Get-Content -LiteralPath $script:InvocationLog | ForEach-Object { $_ | ConvertFrom-Json }
         $actual = $records | Where-Object { $_.args -contains '-m' -and $_.args -contains 'media.crop_colours' } | Select-Object -Last 1
 
+        $expectedPythonSrc = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path
+
         $actual | Should -Not -BeNullOrEmpty
         $actual.args[0] | Should -Be '-m'
         $actual.args[1] | Should -Be 'media.crop_colours'
-        $actual.pythonpath | Should -Match ([regex]::Escape((Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'python')).Path))
+        $actual.pythonpath | Should -Match ([regex]::Escape($expectedPythonSrc))
+        $actual.cwd | Should -Be $expectedPythonSrc
     }
 }

--- a/tests/python/unit/test_crop_colours_direct_execution.py
+++ b/tests/python/unit/test_crop_colours_direct_execution.py
@@ -1,0 +1,24 @@
+"""Regression tests for crop_colours package invocation guidance."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_crop_colours_direct_execution_reports_module_invocation() -> None:
+    """Running crop_colours.py as a loose script should fail with guidance."""
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "src" / "python" / "media" / "crop_colours.py"
+
+    completed = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "python -m media.crop_colours" in completed.stderr
+    assert "package" in completed.stderr


### PR DESCRIPTION
### Motivation
- Running the cropper by executing `crop_colours.py` directly broke package-relative imports (`ImportError: No module named ...`) when the script relied on the `media` package layout.
- Treating a user-supplied `-PythonScriptPath` as a loose script was fragile for packaged invocation and confused both users and CI that expect `python -m` usage.

### Description
- `Invoke-Cropper` now always invokes the packaged cropper as a module: `python -m media.crop_colours`, and `-PythonScriptPath` is validated as `src/python/media/crop_colours.py` and used only to locate `src/python` (added to `PYTHONPATH`).
- Consolidated and simplified PYTHONPATH resolution and pre-flight import check so the child Python process can import `media.crop_colours` reliably in both locator and no-path cases.
- Added a direct-execution guard in `src/python/media/crop_colours.py` that prints guidance and exits (code 2) when run without the parent `media` package, and updated usage examples/docstrings to recommend `python -m media.crop_colours`.
- Bumped versions and changelogs: Videoscreenshot module to `3.2.8` and media package to `4.2.1`, updated README/CHANGELOG entries, and added regression tests: a PowerShell Pester test for invocation shape and a Python pytest that verifies direct script execution shows the module-invocation guidance.

### Testing
- Ran `python -m py_compile src/python/media/crop_colours.py src/python/media/__init__.py` and it succeeded.
- Ran the new Python regression test `tests/python/unit/test_crop_colours_direct_execution.py` via `pytest` and it passed.
- Attempted the broader Python unit suite `pytest tests/python/unit/test_image_ops.py tests/python/unit/test_tracking.py ...` but it failed due to environment limitations where OpenCV cannot load native `libGL.so.1` (resulting in cv2 import errors), so image-op tests did not complete successfully in this environment.
- Added a PowerShell Pester test `tests/powershell/modules/Media/Videoscreenshot/Cropper.Invoke.Tests.ps1`; running it was attempted but `pwsh` is not available in the CI container, so the PowerShell tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c131223788325a2d3bdd3c9f53ba6)