### PR TITLE
feat(videoscreenshot): add -DeduplicateFrames content-hash de-dup of snapshot frames

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,19 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-05-31
+### Added
+- **`-DeduplicateFrames` switch** on `Start-VideoBatch`: when set, consecutive snapshot frames whose file bytes are identical are collapsed to a single kept frame per video after capture completes. Genuinely distinct frames are always preserved. Default off; enable for image/slideshow→MP4 conversions (e.g. `picconvert_*` folders) that produce long runs of identical frames at the configured FPS.
+- **`Private/Snapshot.Dedup.ps1`** (`Invoke-SnapshotDedup`): new private helper that walks all `${ScenePrefix}*.png` files in lexical order and removes consecutive duplicates by content hash. Tolerant of locked/unreadable files (skipped with a Verbose log; IO errors do not abort the batch). Returns `OriginalCount`, `KeptCount`, and `RemovedCount` for status accounting.
+- **`DeduplicateHashAlgorithm`** (default `'SHA256'`) in `Get-DefaultConfig`: controls the hash algorithm used by `Invoke-SnapshotDedup`. Override with `'MD5'` for faster hashing on large batches; any algorithm accepted by `[System.Security.Cryptography.HashAlgorithm]::Create` is valid.
+
+### Changed
+- **Frame count / status accounting** in `Start-VideoBatch`: when `-DeduplicateFrames` is set, the final frame delta is re-derived from the post-dedup disk count so that `Frames saved:` and processed-log status reflect the kept unique frames rather than the raw capture count. De-dup is skipped when no new frames were produced (zero capture delta) to avoid inadvertently removing frames from a previous run.
+- A video whose N captured frames are all identical is recorded as a successful capture (1 kept frame), not `NoFrames`.
+
+### Tests
+- New `tests/.../Snapshot.Dedup.Tests.ps1`: covers consecutive-duplicate removal, distinct-frame preservation, A-B-A non-consecutive pattern, empty folder, single frame, prefix isolation, IO-error tolerance, return-object invariants (`KeptCount + RemovedCount == OriginalCount`, `KeptCount` matches disk), and MD5 algorithm override.
+
 ## [3.2.9] - 2026-05-31
 ### Fixed
 - **Package-root working directory for cropper module invocation**: `Invoke-Cropper` now sets the child Python process working directory to the selected `src/python` package root before running `python -m media.crop_colours`. This ensures Python resolves the cropper package selected by `-PythonScriptPath` before any unrelated `media` package in the caller's current directory. The cropper input folder is resolved to an absolute path before launch so changing the child working directory does not alter which images are processed.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -144,6 +144,16 @@ function Get-DefaultConfig {
         }
 
         # =========================
+        # Snapshot de-duplication
+        # =========================
+
+        # Hash algorithm used by Invoke-SnapshotDedup when -DeduplicateFrames is set.
+        # 'SHA256' is the safe default (exact, collision-resistant). 'MD5' is faster
+        # for large batches. Any algorithm accepted by
+        # [System.Security.Cryptography.HashAlgorithm]::Create is valid.
+        DeduplicateHashAlgorithm        = 'SHA256'
+
+        # =========================
         # Python / Cropper preflight
         # =========================
 

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Dedup.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Snapshot.Dedup.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+  Remove consecutive duplicate snapshot frames for a single video scene prefix.
+.DESCRIPTION
+  Walks all PNG files matching ${ScenePrefix}*.png in SaveFolder in lexical order.
+  Any frame whose content hash equals the previous *kept* frame's hash is deleted.
+  Only consecutive duplicates are removed; genuinely distinct frames are preserved.
+
+  Hash mode is controlled by HashAlgorithm (default SHA256). File-byte hashing is
+  used: PNG byte-identity is a reliable proxy for VLC scene-filter output of
+  identical decoded frames.
+
+  IO errors on individual files are tolerated: a locked or still-writing file is
+  skipped and left in place; the error is written to the Verbose stream so callers
+  can surface it without failing the batch.
+
+  Returns a [pscustomobject] with:
+    OriginalCount  - frames found before de-dup
+    KeptCount      - frames retained after de-dup
+    RemovedCount   - frames deleted
+.PARAMETER SaveFolder
+  Folder that contains the snapshot PNG files.
+.PARAMETER ScenePrefix
+  Filename prefix (e.g. "myvideo_") used to scope the operation to a single video.
+.PARAMETER HashAlgorithm
+  Cryptographic hash name passed to [System.Security.Cryptography.HashAlgorithm]::Create.
+  Defaults to 'SHA256'. 'MD5' is faster for large batches but less collision-resistant.
+.OUTPUTS
+  [pscustomobject] with OriginalCount, KeptCount, RemovedCount.
+#>
+function Invoke-SnapshotDedup {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string]$SaveFolder,
+        [Parameter(Mandatory)][string]$ScenePrefix,
+        [string]$HashAlgorithm = 'SHA256'
+    )
+
+    $frames = @(
+        Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue |
+            Sort-Object -Property Name
+    )
+
+    $originalCount = $frames.Count
+    $removedCount  = 0
+    $lastHash      = $null
+
+    $hasher = $null
+    try {
+        $hasher = [System.Security.Cryptography.HashAlgorithm]::Create($HashAlgorithm)
+        if ($null -eq $hasher) {
+            throw "Unknown hash algorithm: $HashAlgorithm"
+        }
+
+        foreach ($frame in $frames) {
+            $hash = $null
+            try {
+                $bytes = [System.IO.File]::ReadAllBytes($frame.FullName)
+                $hashBytes = $hasher.ComputeHash($bytes)
+                $hash = [System.BitConverter]::ToString($hashBytes) -replace '-', ''
+            }
+            catch {
+                Write-Verbose ("Snapshot.Dedup: skipping locked/unreadable file '{0}': {1}" -f $frame.Name, $_.Exception.Message)
+                $lastHash = $null
+                continue
+            }
+
+            if ($hash -eq $lastHash) {
+                try {
+                    Remove-Item -LiteralPath $frame.FullName -Force -ErrorAction Stop
+                    $removedCount++
+                    Write-Verbose ("Snapshot.Dedup: removed duplicate '{0}'" -f $frame.Name)
+                }
+                catch {
+                    Write-Verbose ("Snapshot.Dedup: could not remove '{0}' (locked/IO error): {1}" -f $frame.Name, $_.Exception.Message)
+                }
+            }
+            else {
+                $lastHash = $hash
+            }
+        }
+    }
+    finally {
+        if ($null -ne $hasher) { $hasher.Dispose() }
+    }
+
+    [pscustomobject]@{
+        OriginalCount = $originalCount
+        KeptCount     = $originalCount - $removedCount
+        RemovedCount  = $removedCount
+    }
+}

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -59,6 +59,8 @@ Delete existing frames with the scene prefix before each video.
 Full path to vlc.exe. Use when VLC is not on PATH (e.g. "D:\Program Files\VideoLAN\VLC\vlc.exe").
 .PARAMETER NoAudio
 Pass --no-audio to VLC. Use when the VLC audio plugin crashes on your system (e.g. libmmdevice_plugin.dll access violation).
+.PARAMETER DeduplicateFrames
+After each video capture, remove consecutive duplicate frames whose file bytes are identical. One frame per distinct image is kept. Default off; enable for image/slideshow MP4 conversions that produce long runs of identical frames (e.g. picconvert output). Frame counts and status logging reflect the kept frames after de-dup runs.
 
 .EXAMPLE
 Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots -RunCropper -PythonScriptPath .\src\python\media\crop_colours.py
@@ -100,7 +102,8 @@ function Start-VideoBatch {
         [switch]$ClearSnapshotsBeforeRun,
 
         [string]$VlcExe,
-        [switch]$NoAudio
+        [switch]$NoAudio,
+        [switch]$DeduplicateFrames
     )
 
     # Enforce pwsh 7+ at runtime (friendly error if invoked directly)
@@ -476,11 +479,34 @@ function Start-VideoBatch {
             }
         }
 
-        # Always do a final file count check to ensure accuracy
-        # This catches cases where stats might be incorrect but files were actually saved
+        # De-duplicate consecutive identical frames if requested.
+        # Gated on $framesDelta > 0 so a zero-capture run (e.g. VLC produced nothing)
+        # never de-dups pre-existing frames from a previous run on the same prefix.
+        $dedupStats = $null
+        if ($DeduplicateFrames -and -not $processingFailed -and $framesDelta -gt 0) {
+            $dedupAlgorithm = if ($context.Config.ContainsKey('DeduplicateHashAlgorithm')) {
+                [string]$context.Config.DeduplicateHashAlgorithm
+            } else { 'SHA256' }
+            try {
+                $dedupStats = Invoke-SnapshotDedup -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -HashAlgorithm $dedupAlgorithm
+                Write-Debug ("Snapshot.Dedup: removed {0}/{1} frame(s) for prefix '{2}'" -f $dedupStats.RemovedCount, $dedupStats.OriginalCount, $scenePrefix)
+                if ($dedupStats.RemovedCount -gt 0) {
+                    Write-Message -Level Info -Message ("De-dup: removed {0} duplicate frame(s) for '{1}' ({2} unique frame(s) kept)" -f $dedupStats.RemovedCount, $scenePrefix, $dedupStats.KeptCount)
+                }
+            }
+            catch {
+                Write-Message -Level Warn -Message ("De-dup failed for prefix '{0}': {1}" -f $scenePrefix, $_.Exception.Message)
+            }
+        }
+
+        # Final disk count — always recompute for accuracy; when de-dup ran, use the
+        # actual post-dedup count (which may be lower than the stats-derived estimate).
         $actualPostCount = (Get-ChildItem -Path $SaveFolder -Filter "${scenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
         $actualFramesDelta = [int]($actualPostCount - $preCount)
-        if ($actualFramesDelta -gt $framesDelta) {
+        if ($null -ne $dedupStats) {
+            $framesDelta = $actualFramesDelta
+        }
+        elseif ($actualFramesDelta -gt $framesDelta) {
             Write-Debug ("Stats reported {0} frames but disk shows {1} frames; using actual count" -f $framesDelta, $actualFramesDelta)
             $framesDelta = $actualFramesDelta
         }

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -500,11 +500,18 @@ function Start-VideoBatch {
         }
 
         # Final disk count — always recompute for accuracy; when de-dup ran, use the
-        # actual post-dedup count (which may be lower than the stats-derived estimate).
+        # post-dedup count only when it is positive (new unique frames were added).
+        # When the delta is 0 or negative — e.g. VLC overwrote pre-existing files with
+        # the same names rather than appending new ones, so the file count did not rise —
+        # fall back to the stats-derived $framesDelta so valid captures are not falsely
+        # flagged as NoFrames.
         $actualPostCount = (Get-ChildItem -Path $SaveFolder -Filter "${scenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
         $actualFramesDelta = [int]($actualPostCount - $preCount)
         if ($null -ne $dedupStats) {
-            $framesDelta = $actualFramesDelta
+            if ($actualFramesDelta -gt 0) {
+                $framesDelta = $actualFramesDelta
+            }
+            # else: overwrite case or de-dup removed below preCount — keep stats-derived value
         }
         elseif ($actualFramesDelta -gt $framesDelta) {
             Write-Debug ("Stats reported {0} frames but disk shows {1} frames; using actual count" -f $framesDelta, $actualFramesDelta)

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -376,3 +376,27 @@ Key config knobs (in `Get-DefaultConfig`, `Private/Config.ps1`):
 | `Vlc.LogVerbosity` | `1` | VLC sidecar logfile verbosity (`0`-`2`); `0` also passes `--quiet`. |
 
 A `WARNING` log line is emitted when idle-break fires or the safety-net cap is reached while VLC is still alive, so the problem video is visible in the run log. When a cap/idle break leaves VLC running under the headless dummy interface, `Stop-Vlc` does not wait on a GUI main-window close or preemptively stop the process; it uses `SnapshotTerminationExtraSeconds` as the bounded scene-filter flush window before force-killing the process if needed.
+
+### Frame de-duplication (`-DeduplicateFrames`) {#frame-de-duplication}
+
+Image/slideshow-to-MP4 conversions (e.g. `picconvert_*` output) typically hold one still image for several seconds. At 1 fps, a 20 s clip produces ~20 identical PNG files. Enable `-DeduplicateFrames` to collapse runs of identical frames to a single kept copy:
+
+```powershell
+Start-VideoBatch -SourceFolder .\picconvert_20240101 -SaveFolder .\shots `
+    -UseVlcSnapshots -FramesPerSecond 1 -DeduplicateFrames
+```
+
+**How it works:**
+- After `Wait-ForSnapshotFrames` returns for a video, the module walks all `${scenePrefix}*.png` files in lexical order.
+- Any frame whose raw file bytes match the previous *kept* frame is deleted. Only consecutive duplicates are removed; genuinely distinct frames are always preserved.
+- De-dup is skipped entirely when no new frames were produced in the current capture (zero capture delta), to avoid inadvertently removing frames from a previous run on the same prefix.
+- Frame counts (`Frames saved: N`) and the processed-log status reflect the kept frames after de-dup.
+- A video that produces N identical frames (collapsed to 1) is recorded as a successful capture, not `NoFrames`.
+
+**Configuration:**
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `DeduplicateHashAlgorithm` | `'SHA256'` | Hash algorithm for byte-level frame comparison. `'MD5'` is faster for large batches; any name accepted by `[System.Security.Cryptography.HashAlgorithm]::Create` is valid. |
+
+De-dup is scoped strictly to each video's scene prefix; files from other videos are never touched. IO errors on individual frames are tolerated (logged at Verbose level; the frame is left in place and de-dup continues).

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.2.9'
+  ModuleVersion     = '3.3.0'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.2.9: Invoke-Cropper now sets the cropper child working directory to the selected src/python package root and passes an absolute input path so python -m resolves the intended media package before any caller cwd package.'
+      ReleaseNotes = '3.3.0: Add -DeduplicateFrames opt-in switch that removes consecutive identical snapshot frames by content hash (SHA256 default); frame counts and status logging reflect kept frames. Config knob DeduplicateHashAlgorithm allows algorithm override.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Dedup.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Snapshot.Dedup.Tests.ps1
@@ -1,0 +1,235 @@
+<#
+.SYNOPSIS
+Pester tests for Invoke-SnapshotDedup (Snapshot.Dedup.ps1).
+#>
+
+BeforeAll {
+    $script:DedupPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' `
+        'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Snapshot.Dedup.ps1'
+    if (-not (Test-Path -LiteralPath $script:DedupPath)) {
+        throw "Required file not found: $script:DedupPath"
+    }
+    . $script:DedupPath
+
+    function Script:New-TempFolder {
+        $dir = New-Item -ItemType Directory `
+            -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) `
+            -Force
+        $dir.FullName
+    }
+
+    # Creates a PNG file in $Folder named "${Prefix}{Index:D4}.png" containing $Content bytes.
+    function Script:New-FakeFrame {
+        param([string]$Folder, [string]$Prefix, [int]$Index, [byte[]]$Content)
+        $path = Join-Path $Folder ("{0}{1:D4}.png" -f $Prefix, $Index)
+        [System.IO.File]::WriteAllBytes($path, $Content)
+        $path
+    }
+
+    $script:BytesA = [byte[]]@(1, 2, 3, 4, 5)
+    $script:BytesB = [byte[]]@(6, 7, 8, 9, 10)
+    $script:BytesC = [byte[]]@(11, 12, 13, 14, 15)
+}
+
+Describe 'Invoke-SnapshotDedup' {
+
+    Context 'consecutive identical frames are collapsed' {
+
+        It 'removes all but the first of a run of identical frames' {
+            $folder = Script:New-TempFolder
+            try {
+                1..5 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index $_ -Content $script:BytesA }
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_'
+
+                $result.OriginalCount | Should -Be 5
+                $result.KeptCount     | Should -Be 1
+                $result.RemovedCount  | Should -Be 4
+
+                $remaining = @(Get-ChildItem $folder -Filter 'vid_*.png' | Sort-Object Name)
+                $remaining.Count | Should -Be 1
+                $remaining[0].Name | Should -Be 'vid_0001.png'
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'collapses runs but keeps genuine scene changes between runs' {
+            $folder = Script:New-TempFolder
+            try {
+                # 3×A, 2×B, 3×C → 3 unique groups → 3 kept
+                1..3 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index $_ -Content $script:BytesA }
+                4..5 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index $_ -Content $script:BytesB }
+                6..8 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index $_ -Content $script:BytesC }
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_'
+
+                $result.OriginalCount | Should -Be 8
+                $result.KeptCount     | Should -Be 3
+                $result.RemovedCount  | Should -Be 5
+
+                $remaining = @(Get-ChildItem $folder -Filter 'vid_*.png' | Sort-Object Name)
+                $remaining.Count | Should -Be 3
+                $remaining[0].Name | Should -Be 'vid_0001.png'
+                $remaining[1].Name | Should -Be 'vid_0004.png'
+                $remaining[2].Name | Should -Be 'vid_0006.png'
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'does not remove non-consecutive identical frames (A B A pattern)' {
+            $folder = Script:New-TempFolder
+            try {
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 1 -Content $script:BytesA
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 2 -Content $script:BytesB
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 3 -Content $script:BytesA
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_'
+
+                $result.OriginalCount | Should -Be 3
+                $result.KeptCount     | Should -Be 3
+                $result.RemovedCount  | Should -Be 0
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'distinct frames are all preserved' {
+
+        It 'keeps every frame when all are distinct' {
+            $folder = Script:New-TempFolder
+            try {
+                Script:New-FakeFrame -Folder $folder -Prefix 'clip_' -Index 1 -Content $script:BytesA
+                Script:New-FakeFrame -Folder $folder -Prefix 'clip_' -Index 2 -Content $script:BytesB
+                Script:New-FakeFrame -Folder $folder -Prefix 'clip_' -Index 3 -Content $script:BytesC
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'clip_'
+
+                $result.OriginalCount | Should -Be 3
+                $result.KeptCount     | Should -Be 3
+                $result.RemovedCount  | Should -Be 0
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'handles a single frame without error' {
+            $folder = Script:New-TempFolder
+            try {
+                Script:New-FakeFrame -Folder $folder -Prefix 'solo_' -Index 1 -Content $script:BytesA
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'solo_'
+
+                $result.OriginalCount | Should -Be 1
+                $result.KeptCount     | Should -Be 1
+                $result.RemovedCount  | Should -Be 0
+                (Get-ChildItem $folder -Filter 'solo_*.png').Count | Should -Be 1
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'handles an empty folder without error' {
+            $folder = Script:New-TempFolder
+            try {
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'empty_'
+
+                $result.OriginalCount | Should -Be 0
+                $result.KeptCount     | Should -Be 0
+                $result.RemovedCount  | Should -Be 0
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'prefix isolation' {
+
+        It 'does not touch frames belonging to a different prefix' {
+            $folder = Script:New-TempFolder
+            try {
+                # Target prefix: 2 identical frames → 1 kept
+                Script:New-FakeFrame -Folder $folder -Prefix 'video1_' -Index 1 -Content $script:BytesA
+                Script:New-FakeFrame -Folder $folder -Prefix 'video1_' -Index 2 -Content $script:BytesA
+                # Other prefix: 3 identical frames — must not be touched
+                Script:New-FakeFrame -Folder $folder -Prefix 'video2_' -Index 1 -Content $script:BytesB
+                Script:New-FakeFrame -Folder $folder -Prefix 'video2_' -Index 2 -Content $script:BytesB
+                Script:New-FakeFrame -Folder $folder -Prefix 'video2_' -Index 3 -Content $script:BytesB
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'video1_'
+
+                $result.OriginalCount | Should -Be 2
+                $result.RemovedCount  | Should -Be 1
+
+                # Other prefix untouched
+                (Get-ChildItem $folder -Filter 'video2_*.png').Count | Should -Be 3
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'IO-error tolerance' {
+
+        It 'skips a frame that cannot be read and continues de-duplication' {
+            $folder = Script:New-TempFolder
+            try {
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 1 -Content $script:BytesA
+                # Frame 2: write zero bytes to simulate a corrupt/empty file that differs from frame 1
+                $path2 = Join-Path $folder 'vid_0002.png'
+                [System.IO.File]::WriteAllBytes($path2, [byte[]]@())
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 3 -Content $script:BytesA
+
+                # Should not throw even though frame 2 is unusual
+                { Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_' } | Should -Not -Throw
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_'
+                $result | Should -Not -BeNullOrEmpty
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'return object accuracy' {
+
+        It 'KeptCount + RemovedCount equals OriginalCount' {
+            $folder = Script:New-TempFolder
+            try {
+                1..4 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'v_' -Index $_ -Content $script:BytesA }
+                5..6 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'v_' -Index $_ -Content $script:BytesB }
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'v_'
+
+                ($result.KeptCount + $result.RemovedCount) | Should -Be $result.OriginalCount
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'KeptCount matches the actual files remaining on disk' {
+            $folder = Script:New-TempFolder
+            try {
+                1..5 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'v_' -Index $_ -Content $script:BytesA }
+                6..7 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'v_' -Index $_ -Content $script:BytesB }
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'v_'
+
+                $onDisk = (Get-ChildItem $folder -Filter 'v_*.png').Count
+                $result.KeptCount | Should -Be $onDisk
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'MD5 algorithm override' {
+
+        It 'accepts MD5 as HashAlgorithm and produces correct de-dup results' {
+            $folder = Script:New-TempFolder
+            try {
+                1..3 | ForEach-Object { Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index $_ -Content $script:BytesA }
+                Script:New-FakeFrame -Folder $folder -Prefix 'vid_' -Index 4 -Content $script:BytesB
+
+                $result = Invoke-SnapshotDedup -SaveFolder $folder -ScenePrefix 'vid_' -HashAlgorithm 'MD5'
+
+                $result.OriginalCount | Should -Be 4
+                $result.KeptCount     | Should -Be 2
+                $result.RemovedCount  | Should -Be 2
+            }
+            finally { Remove-Item $folder -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #1204.

- **New `Private/Snapshot.Dedup.ps1`** (`Invoke-SnapshotDedup`): walks `${ScenePrefix}*.png` in lexical order and removes any consecutive frame whose raw bytes hash identically to the previous kept frame. Tolerant of locked/unreadable files (skipped with Verbose log). Returns `OriginalCount`, `KeptCount`, `RemovedCount`.
- **New `-DeduplicateFrames` switch** on `Start-VideoBatch`: after each video's capture completes, calls `Invoke-SnapshotDedup`; `Frames saved:` count and processed-log status reflect kept unique frames. A video whose N identical frames collapse to 1 is recorded as success, not `NoFrames`. Default off — existing behaviour unchanged.
- **`DeduplicateHashAlgorithm`** (default `'SHA256'`) added to `Get-DefaultConfig`; override with `'MD5'` for faster hashing on large batches.
- **Overwrite guard**: when VLC/GDI writes frames that replace pre-existing files with the same sequential names (disk delta stays 0), the stats-derived frame count is retained so valid captures are not falsely flagged as `NoFrames`.
- Version bumped `3.2.0 → 3.3.0` (new opt-in feature, minor bump).
- `CHANGELOG.md`, `README.md` (new *Frame de-duplication* section), and `Videoscreenshot.psd1` updated.
- New `tests/.../Snapshot.Dedup.Tests.ps1`: 10 Pester tests covering consecutive collapse, distinct-frame preservation, A-B-A non-consecutive pattern, empty folder, single frame, prefix isolation, IO-error tolerance, return-object invariants, and MD5 algorithm override.

## Test plan

- [ ] `Invoke-Pester tests/powershell/modules/Media/Videoscreenshot/Snapshot.Dedup.Tests.ps1` — all tests pass
- [ ] Existing Pester tests for `Start-VideoBatch` and `Snapshot.Monitor` pass unchanged
- [ ] Run with `-DeduplicateFrames` against a `picconvert_*` slideshow folder; confirm `Frames saved: 1` per static clip and `De-dup: removed N duplicate frame(s)` log lines appear
- [ ] Run without `-DeduplicateFrames`; confirm all frames are kept (default behaviour unchanged)
- [ ] Run with pre-existing frames and no `-ClearSnapshotsBeforeRun`; confirm valid captures are not logged as `NoFrames`

https://claude.ai/code/session_01Vf69JwmHpUwHzitFzrQ93F
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf69JwmHpUwHzitFzrQ93F)_