### PR TITLE
Add -Global flag to Import-Module calls in RandomName provider

### DIFF
--- a/src/powershell/modules/Core/FileOperations/Public/Import-RandomNameProvider.ps1
+++ b/src/powershell/modules/Core/FileOperations/Public/Import-RandomNameProvider.ps1
@@ -74,7 +74,7 @@ function Import-RandomNameProvider {
     if ($ModulePath) {
         try {
             $resolved = Resolve-Path -LiteralPath $ModulePath -ErrorAction Stop
-            Import-Module -Name $resolved.Path -Force -ErrorAction Stop
+            Import-Module -Name $resolved.Path -Force -Global -ErrorAction Stop
             Write-RandomNameProviderLog -Level Info -Message "Imported RandomName module from '$($resolved.Path)'."
             return
         } catch {
@@ -94,7 +94,7 @@ function Import-RandomNameProvider {
         foreach ($candidate in $scriptRootCandidates) {
             if (Test-Path -LiteralPath $candidate) {
                 try {
-                    Import-Module -Name $candidate -Force -ErrorAction Stop
+                    Import-Module -Name $candidate -Force -Global -ErrorAction Stop
                     Write-RandomNameProviderLog -Level Info -Message "Imported RandomName module from script-root '$candidate'."
                     return
                 } catch {
@@ -105,7 +105,7 @@ function Import-RandomNameProvider {
     }
 
     try {
-        Import-Module -Name RandomName -ErrorAction Stop
+        Import-Module -Name RandomName -Force -Global -ErrorAction Stop
         Write-RandomNameProviderLog -Level Info -Message 'Imported RandomName module from PSModulePath.'
         return
     } catch {


### PR DESCRIPTION
## Summary
Updated the `Import-RandomNameProvider` function to ensure the RandomName module is imported into the global scope by adding the `-Global` flag to all `Import-Module` calls.

## Key Changes
- Added `-Global` flag to `Import-Module` command when importing from explicit `$ModulePath`
- Added `-Global` flag to `Import-Module` command when importing from script-root candidates
- Added `-Global` flag and `-Force` flag to `Import-Module` command when importing from PSModulePath (fallback case)

## Implementation Details
These changes ensure that the RandomName module and its exported functions are available in the global scope regardless of which import path is used. This provides consistent behavior across all three import scenarios:
1. Explicit module path resolution
2. Script-root based discovery
3. PSModulePath fallback

The addition of `-Force` in the fallback case ensures the module is reimported if already loaded, maintaining consistency with the other import paths.

https://claude.ai/code/session_01BTTeqi8ZYciJ9QGenuHyY1