### PR TITLE
fix(file-distributor): declare retry module dependencies

### DIFF
--- a/src/powershell/file-management/FileDistributor.CHANGELOG.md
+++ b/src/powershell/file-management/FileDistributor.CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG — FileDistributor
 
+## 4.9.4 — 2026-05-31
+
+### Fixed
+
+- Declared `Core/ErrorHandling` and `Core/FileOperations` as formal `FileDistributor` module dependencies so `Invoke-WithRetry`, `Copy-FileWithRetry`, and `Remove-FileWithRetry` are available during module loading.
+- Imported those dependencies inside `FileDistributor.psm1` before private/public function dot-sourcing so retry and file operation commands resolve from the `FileDistributor` module scope instead of relying on global session fallback.
+
+### Tests
+
+- Added regression coverage for the dependency declarations and module-scope dependency import ordering.
+
+### Versioning
+
+- Bumped `FileDistributor.ps1` script version to `4.9.4`.
+- Bumped `FileDistributor` module version to `1.3.3`.
+
 ## 4.9.3 — 2026-05-29
 
 ### Changed

--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -331,7 +331,7 @@ Import-Module "$PSScriptRoot\..\modules\FileManagement\FileDistributor\FileDistr
 # Note: Logger initialization moved to after LogFilePath resolution
 
 # Define script-scoped variables for warnings and errors
-$script:Version = "4.9.3"
+$script:Version = "4.9.4"
 $script:Warnings = 0
 $script:Errors = 0
 

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -18,6 +18,9 @@ Scripts for file operations, distribution, copying, and archiving.
 ### PowerShell Modules
 
 - **PowerShellLoggingFramework** (`src/powershell/modules/Core/Logging/`) - Structured logging
+- **ErrorHandling** (`src/powershell/modules/Core/ErrorHandling/`) - Retry orchestration used by `FileDistributor.ps1` and file operation helpers
+- **FileOperations** (`src/powershell/modules/Core/FileOperations/`) - Retry-aware copy, move, remove, rename, and content helpers used by `FileDistributor.ps1`
+- **FileQueue** (`src/powershell/modules/FileManagement/FileQueue/`) - Queue primitives used by the `FileDistributor` support module
 - **FileSystem** (`src/powershell/modules/Core/FileSystem/`) - Path normalization, safe naming, unique path resolution
 - **Zip** (`src/powershell/modules/Core/Zip/`) - ZIP archive primitives used by `Expand-ZipsAndClean.ps1`
 - **ZipExtraction** (`src/powershell/modules/FileManagement/ZipExtraction/`) - ZIP extraction orchestration helpers used by `Expand-ZipsAndClean.ps1`
@@ -49,6 +52,11 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
 - These versions are intentionally independent and may advance separately under SemVer.
 
 ## Recent Updates
+
+- **FileDistributor module dependency fix (issue #1228)** (2026-05-31)
+  - Declared `Core/ErrorHandling` and `Core/FileOperations` as `FileDistributor` module dependencies and imported them inside the module before FileDistributor functions are dot-sourced.
+  - Ensures `Invoke-WithRetry`, `Copy-FileWithRetry`, and `Remove-FileWithRetry` resolve from FileDistributor module scope for RecycleBin deletes, Immediate deletes, state sidecar writes, and consolidation runs.
+  - Version bump: `FileDistributor.ps1` `4.9.4`; support module `1.3.3` (patch — module dependency bug fix).
 
 - **Expand-ZipsAndClean Pester helper-loading cleanup (issue #1144)** (2026-05-31)
   - Added shared test setup helpers for loading `ZipWorkflow` and `ZipExtraction` dependencies in `Expand-ZipsAndClean.Tests.ps1`, loaded during Pester's run phase so `BeforeAll` blocks can call them.

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'FileDistributor.psm1'
-    ModuleVersion     = '1.3.2'
+    ModuleVersion     = '1.3.3'
     GUID              = '7ce4ef6c-cc9f-4c89-a0d9-6c2751f4f0df'
     Author            = 'Manoj Bhaskaran'
     CompanyName       = 'Unknown'
@@ -25,6 +25,8 @@
         'Invoke-FolderConsolidation'
     )
     RequiredModules   = @(
+        '..\..\Core\ErrorHandling\ErrorHandling.psd1',
+        '..\..\Core\FileOperations\FileOperations.psd1',
         '..\FileQueue\FileQueue.psd1'
     )
     CmdletsToExport   = @()

--- a/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
+++ b/src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1
@@ -2,6 +2,15 @@
 
 $ModuleRoot = $PSScriptRoot
 
+$moduleDependencies = @(
+    '..\..\Core\ErrorHandling\ErrorHandling.psd1',
+    '..\..\Core\FileOperations\FileOperations.psd1'
+)
+foreach ($dependency in $moduleDependencies) {
+    $dependencyPath = Join-Path -Path $ModuleRoot -ChildPath $dependency
+    Import-Module -Name $dependencyPath -Force -ErrorAction Stop
+}
+
 $runStateClassPath = Join-Path -Path $ModuleRoot -ChildPath 'Private\FileDistributorRunState.ps1'
 if (Test-Path -LiteralPath $runStateClassPath) {
     . $runStateClassPath

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -331,6 +331,27 @@ Describe 'FileDistributor Module Public API' {
         $runState.GetType().Name | Should -Be 'FileDistributorRunState'
     }
 
+    It 'Should declare retry and file operation modules as required dependencies' {
+        $manifest = Import-PowerShellDataFile -LiteralPath $script:ModulePath
+
+        $manifest.RequiredModules | Should -Contain '..\..\Core\ErrorHandling\ErrorHandling.psd1'
+        $manifest.RequiredModules | Should -Contain '..\..\Core\FileOperations\FileOperations.psd1'
+        $manifest.RequiredModules | Should -Contain '..\FileQueue\FileQueue.psd1'
+    }
+
+    It 'Should import retry and file operation dependencies into module scope before function dot-sourcing' {
+        $moduleScriptPath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'powershell' 'modules' 'FileManagement' 'FileDistributor' 'FileDistributor.psm1'
+        $moduleScriptContent = Get-Content -LiteralPath $moduleScriptPath -Raw
+        $dependencyImportIndex = $moduleScriptContent.IndexOf('foreach ($dependency in $moduleDependencies)')
+        $privateDotSourceIndex = $moduleScriptContent.IndexOf('$privateFunctions = @(')
+
+        $dependencyImportIndex | Should -BeGreaterOrEqual 0
+        $privateDotSourceIndex | Should -BeGreaterThan $dependencyImportIndex
+        $moduleScriptContent | Should -Match [regex]::Escape('..\..\Core\ErrorHandling\ErrorHandling.psd1')
+        $moduleScriptContent | Should -Match [regex]::Escape('..\..\Core\FileOperations\FileOperations.psd1')
+        $moduleScriptContent | Should -Match 'Import-Module\s+-Name\s+\$dependencyPath\s+-Force\s+-ErrorAction\s+Stop'
+    }
+
     It 'Should expose the complete expected function API through module exports' {
         $expectedExports = @(
             'Initialize-FileDistributorPaths',

--- a/tests/powershell/unit/FileDistributor.Tests.ps1
+++ b/tests/powershell/unit/FileDistributor.Tests.ps1
@@ -347,8 +347,8 @@ Describe 'FileDistributor Module Public API' {
 
         $dependencyImportIndex | Should -BeGreaterOrEqual 0
         $privateDotSourceIndex | Should -BeGreaterThan $dependencyImportIndex
-        $moduleScriptContent | Should -Match [regex]::Escape('..\..\Core\ErrorHandling\ErrorHandling.psd1')
-        $moduleScriptContent | Should -Match [regex]::Escape('..\..\Core\FileOperations\FileOperations.psd1')
+        $moduleScriptContent | Should -Match ([regex]::Escape('..\..\Core\ErrorHandling\ErrorHandling.psd1'))
+        $moduleScriptContent | Should -Match ([regex]::Escape('..\..\Core\FileOperations\FileOperations.psd1'))
         $moduleScriptContent | Should -Match 'Import-Module\s+-Name\s+\$dependencyPath\s+-Force\s+-ErrorAction\s+Stop'
     }
 


### PR DESCRIPTION
### Motivation

- Prevent intermittent `Invoke-WithRetry` / `Copy-FileWithRetry` / `Remove-FileWithRetry` resolution failures caused by missing module dependency declarations and imports during `FileDistributor` module load. 
- Ensure the `FileDistributor` support module is self-contained so retry and file-operation helpers resolve from module scope instead of relying on global session imports.

### Description

- Add `RequiredModules` entries to `src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psd1` for `..\..\Core\ErrorHandling\ErrorHandling.psd1` and `..\..\Core\FileOperations\FileOperations.psd1`. 
- Import those dependencies at the top of `src/powershell/modules/FileManagement/FileDistributor/FileDistributor.psm1` prior to dot-sourcing private and public function files via an explicit `moduleDependencies` loop and `Import-Module -Force -ErrorAction Stop`. 
- Bump `FileDistributor` runtime script version to `4.9.4` in `src/powershell/file-management/FileDistributor.ps1` and the module `ModuleVersion` to `1.3.3` in the module manifest. 
- Update `src/powershell/file-management/FileDistributor.CHANGELOG.md` and `src/powershell/file-management/README.md` with the dependency fix and add regression Pester assertions in `tests/powershell/unit/FileDistributor.Tests.ps1` that validate the manifest `RequiredModules` and the module import ordering.

### Testing

- Ran static checks (Python-based assertions) that verified the updated `FileDistributor.ps1` version, module `ModuleVersion`, changelog heading, README note, manifest dependencies, and that dependency imports appear before private dot-sourcing, and they passed. 
- Ran `git diff --check` to validate working-tree whitespace/line-ending warnings and found no blocking issues. 
- Added Pester test cases to `tests/powershell/unit/FileDistributor.Tests.ps1` for the manifest entries and import-order behavior, but a full `Invoke-Pester` run could not be executed in this environment because `pwsh` was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4e731e788325a7028292469209e1)