### PR TITLE
Add -DeleteSourceZips switch to Expand-ZipsAndClean

### DIFF
--- a/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
+++ b/src/powershell/file-management/Expand-ZipsAndClean.CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG — Expand-ZipsAndClean
 
+## 2.7.0 — 2026-06-01 *(minor — new -DeleteSourceZips switch)*
+
+### Added
+
+- `-DeleteSourceZips` switch parameter. When present, each zip whose extraction succeeds
+  is deleted in place rather than moved to the parent directory. Zips whose extraction
+  failed are left untouched. `Move-ZipFilesToParent` is bypassed entirely.
+- `ProcessedZipPaths` field in the `New-ExtractionSummary` return object (tracked by
+  `Invoke-SerialZipExtractions` and `Merge-ParallelZipResults`) so the script knows which
+  archives to delete without a second directory scan.
+- `ZipPath` field added to `Expand-ZipInRunspace` result objects so the parallel merger
+  can attribute successful extractions to their source paths.
+- `DeleteSourceZips` and `DeletedSummary` parameters on `Write-ExtractionSummary`:
+  when `-DeleteSourceZips` is set the summary view shows `ZipsDeleted`/`DeletedBytes`
+  instead of `ZipsMoved`/`MoveSkipped`/`MoveOverwritten`/`MoveRenamed`/`MovedTo`.
+
+### Tests
+
+- Added `Describe '-DeleteSourceZips behaviour'` block covering: empty-source
+  `ProcessedZipPaths`; summary view shows deletion fields when switch is set; summary view
+  shows move fields (not deletion) by default.
+- Added script-structure assertion that `-DeleteSourceZips` switch is declared in the
+  `param()` block.
+
 ## 2.6.19 — 2026-05-31 *(patch — test refactor; no behaviour change)*
 
 ### Tests

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -1,16 +1,18 @@
 #requires -Version 7.0
 <#
 .SYNOPSIS
-    Unzips all .zip files from a source folder into a destination folder, moves the .zip files
-    to the parent of the source folder, and (optionally) deletes/cleans the source folder.
+    Unzips all .zip files from a source folder into a destination folder, then either moves
+    the .zip files to the parent of the source folder or deletes them in place (if
+    -DeleteSourceZips is specified), and (optionally) deletes/cleans the source folder.
     Prints a summary at the end.
 
 .DESCRIPTION
     Typical workflow:
       - Source folder (example): $HOME\Downloads\picconvert   (or $env:EXPAND_ZIPS_SOURCE_DIR)
       - Destination folder (example): $HOME\Desktop\New folder (or $env:EXPAND_ZIPS_DEST_DIR)
-      - After extraction, all .zip files in the source are moved to the source’s parent
-        (example: $HOME\Downloads)
+      - After extraction, all successfully extracted .zip files are either:
+          * Moved to the source’s parent (example: $HOME\Downloads) — default behaviour, or
+          * Deleted in place — when -DeleteSourceZips is specified.
       - Optionally delete/clean the source folder using -DeleteSource (switch) and
         optionally -CleanNonZips to remove non-zip leftovers.
 
@@ -23,6 +25,7 @@
           per CollisionPolicy before writing each file (Skip/Overwrite/Rename).
     - CollisionPolicy (for overlapping paths in Flat mode AND for the zip-move-to-parent step):
         * Skip | Overwrite | Rename (default: Rename)
+        * Not applicable when -DeleteSourceZips is set (no move step occurs).
     - Progress bars for long runs (suppressed by -Quiet). Move progress shows cumulative AND total bytes.
     - End-of-run summary includes uncompressed bytes, total compressed zip bytes, and compression ratio.
       (CompressionRatio > 1.0 means the original content is larger than the archives; compression saved space.)
@@ -60,6 +63,14 @@
       - Rename     : save the incoming item with a unique suffix (default behavior).
     Default: Rename
 
+.PARAMETER DeleteSourceZips
+    Switch. If present, each .zip file whose extraction succeeds is deleted in place
+    rather than moved to the parent directory. Zips whose extraction failed are left
+    untouched. Move-ZipFilesToParent is bypassed entirely.
+    -CollisionPolicy has no effect on the zip-disposal step when this switch is set.
+    This switch is independent of -DeleteSource and -CleanNonZips; all combinations
+    are valid.
+
 .PARAMETER DeleteSource
     Switch. If present, deletes the source directory after zips are moved and,
     if -CleanNonZips is also set, after non-zip items are removed. If leftovers remain
@@ -96,6 +107,10 @@
     .\Expand-ZipsAndClean.ps1 -ExtractMode Flat -CollisionPolicy Overwrite -Verbose
 
 .EXAMPLE
+    # Delete source zips in place after successful extraction (skip the move-to-parent step)
+    .\Expand-ZipsAndClean.ps1 -DeleteSourceZips
+
+.EXAMPLE
     # Delete the source folder after processing (and also delete any non-zip leftovers)
     .\Expand-ZipsAndClean.ps1 -DeleteSource -CleanNonZips
 
@@ -119,7 +134,7 @@
 
 .NOTES
     Name     : Expand-ZipsAndClean.ps1
-    Version  : 2.6.19
+    Version  : 2.7.0
     Author   : Manoj Bhaskaran
     Requires : PowerShell 7+ (uses ternary operator, null-coalescing ??, null-conditional ?.,
                and ForEach-Object -Parallel); Microsoft.PowerShell.Archive (Expand-Archive)
@@ -154,6 +169,9 @@ param(
     [Parameter()]
     [ValidateSet('Skip', 'Overwrite', 'Rename')]
     [string]$CollisionPolicy = 'Rename',
+
+    [Parameter()]
+    [switch]$DeleteSourceZips,
 
     [Parameter()]
     [switch]$DeleteSource,
@@ -208,6 +226,7 @@ $totalFilesExtracted = 0
 $totalUncompressedBytes = [int64]0
 $totalCompressedZipBytes = [int64]0
 $moveSummary = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = ""; Skipped = 0; Overwritten = 0; Renamed = 0 }
+$deletedSummary = [pscustomobject]@{ Count = 0; Bytes = 0 }
 
 try {
     ZipWorkflow\Test-ScriptPreconditions -SourceDir $SourceDirectory -DestinationDir $DestinationDirectory
@@ -229,14 +248,36 @@ try {
     $totalUncompressedBytes = $extractionResult.UncompressedBytes
     $totalCompressedZipBytes = $extractionResult.CompressedBytes
 
-    try {
-        if ($PSCmdlet.ShouldProcess($SourceDirectory, "Move .zip files to parent")) {
-            $moveSummary = ZipWorkflow\Move-ZipFilesToParent -SourceDir $SourceDirectory -QuietMode $Quiet.IsPresent -CollisionPolicy $CollisionPolicy
+    if ($DeleteSourceZips.IsPresent) {
+        $deletedCount = 0
+        $deletedBytes = [int64]0
+        foreach ($zipPath in $extractionResult.ProcessedZipPaths) {
+            if (-not [System.IO.File]::Exists($zipPath)) { continue }
+            try {
+                if ($PSCmdlet.ShouldProcess($zipPath, "Delete extracted zip")) {
+                    $zipLen = (Get-Item -LiteralPath $zipPath).Length
+                    Remove-Item -LiteralPath $zipPath -Force
+                    $deletedCount++
+                    $deletedBytes += $zipLen
+                    Write-LogDebug "Deleted extracted zip: $zipPath"
+                }
+            } catch {
+                $msg = "Failed to delete zip '$zipPath': $($_.Exception.Message)"
+                Write-LogDebug $msg
+                $errors.Add($msg) | Out-Null
+            }
         }
-    } catch {
-        $msg = "Moving .zip files to parent failed: $($_.Exception.Message)"
-        Write-LogDebug $msg
-        $errors.Add($msg) | Out-Null
+        $deletedSummary = [pscustomobject]@{ Count = $deletedCount; Bytes = $deletedBytes }
+    } else {
+        try {
+            if ($PSCmdlet.ShouldProcess($SourceDirectory, "Move .zip files to parent")) {
+                $moveSummary = ZipWorkflow\Move-ZipFilesToParent -SourceDir $SourceDirectory -QuietMode $Quiet.IsPresent -CollisionPolicy $CollisionPolicy
+            }
+        } catch {
+            $msg = "Moving .zip files to parent failed: $($_.Exception.Message)"
+            Write-LogDebug $msg
+            $errors.Add($msg) | Out-Null
+        }
     }
 
     FileSystem\Remove-SourceDirectory `
@@ -253,18 +294,24 @@ try {
 
 #------------------------------ Summary -----------------------------#
 
-ProgressReporter\Write-ExtractionSummary `
-    -SourceDirectory    $SourceDirectory `
-    -DestinationDirectory $DestinationDirectory `
-    -ExtractMode        $ExtractMode `
-    -CollisionPolicy    $CollisionPolicy `
-    -ZipCount           $zipCount `
-    -ProcessedZips      $processedZips `
-    -FilesExtracted     $totalFilesExtracted `
-    -UncompressedBytes  $totalUncompressedBytes `
-    -CompressedBytes    $totalCompressedZipBytes `
-    -MoveSummary        $moveSummary `
-    -Errors             $errors `
-    -Elapsed            $stopwatch.Elapsed
+$summaryParams = @{
+    SourceDirectory     = $SourceDirectory
+    DestinationDirectory = $DestinationDirectory
+    ExtractMode         = $ExtractMode
+    CollisionPolicy     = $CollisionPolicy
+    ZipCount            = $zipCount
+    ProcessedZips       = $processedZips
+    FilesExtracted      = $totalFilesExtracted
+    UncompressedBytes   = $totalUncompressedBytes
+    CompressedBytes     = $totalCompressedZipBytes
+    MoveSummary         = $moveSummary
+    Errors              = $errors
+    Elapsed             = $stopwatch.Elapsed
+}
+if ($DeleteSourceZips.IsPresent) {
+    $summaryParams['DeleteSourceZips'] = $true
+    $summaryParams['DeletedSummary']   = $deletedSummary
+}
+ProgressReporter\Write-ExtractionSummary @summaryParams
 
 # End of script

--- a/src/powershell/file-management/Expand-ZipsAndClean.ps1
+++ b/src/powershell/file-management/Expand-ZipsAndClean.ps1
@@ -255,8 +255,8 @@ try {
             if (-not [System.IO.File]::Exists($zipPath)) { continue }
             try {
                 if ($PSCmdlet.ShouldProcess($zipPath, "Delete extracted zip")) {
-                    $zipLen = (Get-Item -LiteralPath $zipPath).Length
-                    Remove-Item -LiteralPath $zipPath -Force
+                    $zipLen = (Get-Item -LiteralPath $zipPath -ErrorAction Stop).Length
+                    Remove-Item -LiteralPath $zipPath -Force -ErrorAction Stop
                     $deletedCount++
                     $deletedBytes += $zipLen
                     Write-LogDebug "Deleted extracted zip: $zipPath"

--- a/src/powershell/file-management/README.md
+++ b/src/powershell/file-management/README.md
@@ -63,6 +63,13 @@ All scripts use the PowerShell Logging Framework and write logs to the standard 
   - Ensures `Invoke-WithRetry`, `Copy-FileWithRetry`, and `Remove-FileWithRetry` resolve from FileDistributor module scope for RecycleBin deletes, Immediate deletes, state sidecar writes, and consolidation runs.
   - Version bump: `FileDistributor.ps1` `4.9.4`; support module `1.3.3` (patch — module dependency bug fix).
 
+- **Expand-ZipsAndClean -DeleteSourceZips switch (issue #1187)** (2026-06-01)
+  - Added `-DeleteSourceZips` switch. When present, each successfully extracted zip is deleted in place instead of moved to the parent directory; failed-extraction zips are left untouched.
+  - `Move-ZipFilesToParent` is bypassed entirely when the switch is set.
+  - `Write-ExtractionSummary` now shows `ZipsDeleted`/`DeletedBytes` in the summary when operating in deletion mode; `ZipsMoved`/`MovedTo` appear only in the default (move) mode.
+  - `ZipExtraction` module tracks `ProcessedZipPaths` in the extraction result so the script can target exactly the successfully extracted zips for deletion.
+  - Version bump: `2.7.0` (minor — new switch parameter).
+
 - **Expand-ZipsAndClean Pester helper-loading cleanup (issue #1144)** (2026-05-31)
   - Added shared test setup helpers for loading `ZipWorkflow` and `ZipExtraction` dependencies in `Expand-ZipsAndClean.Tests.ps1`, loaded during Pester's run phase so `BeforeAll` blocks can call them.
   - Replaced repeated per-`Describe` `BeforeAll` module-loading boilerplate with calls into the shared helper file without changing behavioral coverage.

--- a/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
+++ b/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
@@ -8,25 +8,43 @@ function New-ExtractionSummaryView {
         "n/a"
     }
 
-    [pscustomobject]@{
-        SrcDir          = $SummaryState.SourceDirectory
-        DestDir         = $SummaryState.DestinationDirectory
-        Mode            = $SummaryState.ExtractMode
-        Policy          = $SummaryState.CollisionPolicy
-        ZipsFound       = $SummaryState.ZipCount
-        ZipsDone        = $SummaryState.ProcessedZips
-        Files           = $SummaryState.FilesExtracted
-        Uncompressed    = (Format-Bytes $SummaryState.UncompressedBytes)
-        Compressed      = (Format-Bytes $SummaryState.CompressedBytes)
-        Ratio           = $compressionRatio
-        ZipsMoved       = ($SummaryState.MoveSummary.Count)
-        MoveSkipped     = ($SummaryState.MoveSummary.Skipped)
-        MoveOverwritten = ($SummaryState.MoveSummary.Overwritten)
-        MoveRenamed     = ($SummaryState.MoveSummary.Renamed)
-        MovedBytes      = (Format-Bytes $SummaryState.MoveSummary.Bytes)
-        MovedTo         = ($SummaryState.MoveSummary.Destination)
-        Errors          = $SummaryState.ErrorCount
-        Duration        = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
+    if ($SummaryState.DeleteSourceZips) {
+        [pscustomobject]@{
+            SrcDir       = $SummaryState.SourceDirectory
+            DestDir      = $SummaryState.DestinationDirectory
+            Mode         = $SummaryState.ExtractMode
+            ZipsFound    = $SummaryState.ZipCount
+            ZipsDone     = $SummaryState.ProcessedZips
+            Files        = $SummaryState.FilesExtracted
+            Uncompressed = (Format-Bytes $SummaryState.UncompressedBytes)
+            Compressed   = (Format-Bytes $SummaryState.CompressedBytes)
+            Ratio        = $compressionRatio
+            ZipsDeleted  = ($SummaryState.DeletedSummary.Count)
+            DeletedBytes = (Format-Bytes $SummaryState.DeletedSummary.Bytes)
+            Errors       = $SummaryState.ErrorCount
+            Duration     = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
+        }
+    } else {
+        [pscustomobject]@{
+            SrcDir          = $SummaryState.SourceDirectory
+            DestDir         = $SummaryState.DestinationDirectory
+            Mode            = $SummaryState.ExtractMode
+            Policy          = $SummaryState.CollisionPolicy
+            ZipsFound       = $SummaryState.ZipCount
+            ZipsDone        = $SummaryState.ProcessedZips
+            Files           = $SummaryState.FilesExtracted
+            Uncompressed    = (Format-Bytes $SummaryState.UncompressedBytes)
+            Compressed      = (Format-Bytes $SummaryState.CompressedBytes)
+            Ratio           = $compressionRatio
+            ZipsMoved       = ($SummaryState.MoveSummary.Count)
+            MoveSkipped     = ($SummaryState.MoveSummary.Skipped)
+            MoveOverwritten = ($SummaryState.MoveSummary.Overwritten)
+            MoveRenamed     = ($SummaryState.MoveSummary.Renamed)
+            MovedBytes      = (Format-Bytes $SummaryState.MoveSummary.Bytes)
+            MovedTo         = ($SummaryState.MoveSummary.Destination)
+            Errors          = $SummaryState.ErrorCount
+            Duration        = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
+        }
     }
 }
 
@@ -124,9 +142,15 @@ function Write-ExtractionSummaryErrors {
     Total uncompressed bytes extracted.
 .PARAMETER CompressedBytes
     Total compressed (on-disk) bytes of the zip files processed.
+.PARAMETER DeleteSourceZips
+    Switch. When set, the summary shows deletion statistics instead of move statistics.
+    Pass this when the script was invoked with -DeleteSourceZips.
+.PARAMETER DeletedSummary
+    PSCustomObject with Count and Bytes for the zips deleted in place. Required when
+    DeleteSourceZips is set. Ignored when DeleteSourceZips is absent.
 .PARAMETER MoveSummary
     PSCustomObject returned by Move-ZipFilesToParent containing Count, Bytes,
-    Destination, Skipped, Overwritten, and Renamed.
+    Destination, Skipped, Overwritten, and Renamed. Required when DeleteSourceZips is absent.
 .PARAMETER Errors
     List of non-fatal error messages accumulated during the run.
 .PARAMETER Elapsed
@@ -163,6 +187,8 @@ function Write-ExtractionSummary {
         [Parameter(Mandatory)][pscustomobject]$MoveSummary,
         [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Errors,
         [Parameter(Mandatory)][timespan]$Elapsed,
+        [switch]$DeleteSourceZips,
+        [pscustomobject]$DeletedSummary,
         [string]$HostName = $Host.Name,
         [int]$ConsoleWidth = 0,
         [switch]$PassThru

--- a/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
+++ b/src/powershell/modules/Core/Progress/Public/Write-ExtractionSummary.ps1
@@ -8,44 +8,35 @@ function New-ExtractionSummaryView {
         "n/a"
     }
 
-    if ($SummaryState.DeleteSourceZips) {
-        [pscustomobject]@{
-            SrcDir       = $SummaryState.SourceDirectory
-            DestDir      = $SummaryState.DestinationDirectory
-            Mode         = $SummaryState.ExtractMode
-            ZipsFound    = $SummaryState.ZipCount
-            ZipsDone     = $SummaryState.ProcessedZips
-            Files        = $SummaryState.FilesExtracted
-            Uncompressed = (Format-Bytes $SummaryState.UncompressedBytes)
-            Compressed   = (Format-Bytes $SummaryState.CompressedBytes)
-            Ratio        = $compressionRatio
-            ZipsDeleted  = ($SummaryState.DeletedSummary.Count)
-            DeletedBytes = (Format-Bytes $SummaryState.DeletedSummary.Bytes)
-            Errors       = $SummaryState.ErrorCount
-            Duration     = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
-        }
-    } else {
-        [pscustomobject]@{
-            SrcDir          = $SummaryState.SourceDirectory
-            DestDir         = $SummaryState.DestinationDirectory
-            Mode            = $SummaryState.ExtractMode
-            Policy          = $SummaryState.CollisionPolicy
-            ZipsFound       = $SummaryState.ZipCount
-            ZipsDone        = $SummaryState.ProcessedZips
-            Files           = $SummaryState.FilesExtracted
-            Uncompressed    = (Format-Bytes $SummaryState.UncompressedBytes)
-            Compressed      = (Format-Bytes $SummaryState.CompressedBytes)
-            Ratio           = $compressionRatio
-            ZipsMoved       = ($SummaryState.MoveSummary.Count)
-            MoveSkipped     = ($SummaryState.MoveSummary.Skipped)
-            MoveOverwritten = ($SummaryState.MoveSummary.Overwritten)
-            MoveRenamed     = ($SummaryState.MoveSummary.Renamed)
-            MovedBytes      = (Format-Bytes $SummaryState.MoveSummary.Bytes)
-            MovedTo         = ($SummaryState.MoveSummary.Destination)
-            Errors          = $SummaryState.ErrorCount
-            Duration        = ("{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed)
-        }
+    $view = [ordered]@{
+        SrcDir       = $SummaryState.SourceDirectory
+        DestDir      = $SummaryState.DestinationDirectory
+        Mode         = $SummaryState.ExtractMode
+        ZipsFound    = $SummaryState.ZipCount
+        ZipsDone     = $SummaryState.ProcessedZips
+        Files        = $SummaryState.FilesExtracted
+        Uncompressed = (Format-Bytes $SummaryState.UncompressedBytes)
+        Compressed   = (Format-Bytes $SummaryState.CompressedBytes)
+        Ratio        = $compressionRatio
     }
+
+    if ($SummaryState.DeleteSourceZips) {
+        $view['ZipsDeleted']  = $SummaryState.DeletedSummary.Count
+        $view['DeletedBytes'] = (Format-Bytes $SummaryState.DeletedSummary.Bytes)
+    } else {
+        $view['Policy']          = $SummaryState.CollisionPolicy
+        $view['ZipsMoved']       = $SummaryState.MoveSummary.Count
+        $view['MoveSkipped']     = $SummaryState.MoveSummary.Skipped
+        $view['MoveOverwritten'] = $SummaryState.MoveSummary.Overwritten
+        $view['MoveRenamed']     = $SummaryState.MoveSummary.Renamed
+        $view['MovedBytes']      = (Format-Bytes $SummaryState.MoveSummary.Bytes)
+        $view['MovedTo']         = $SummaryState.MoveSummary.Destination
+    }
+
+    $view['Errors']   = $SummaryState.ErrorCount
+    $view['Duration'] = "{0:hh\:mm\:ss\.fff}" -f $SummaryState.Elapsed
+
+    [pscustomobject]$view
 }
 
 function New-ExtractionSummaryState {

--- a/src/powershell/modules/FileManagement/ZipExtraction/Private/Expand-ZipInRunspace.ps1
+++ b/src/powershell/modules/FileManagement/ZipExtraction/Private/Expand-ZipInRunspace.ps1
@@ -20,6 +20,7 @@ function Expand-ZipInRunspace {
 
         return [pscustomobject]@{
             Success           = $true
+            ZipPath           = $Zip.FullName
             FilesExtracted    = $r.FilesExtracted
             UncompressedBytes = $r.UncompressedBytes
             CompressedBytes   = $r.CompressedBytes
@@ -30,6 +31,7 @@ function Expand-ZipInRunspace {
         $localLogs.Add("Extraction error for '$($Zip.Name)': $($_.Exception.Message)") | Out-Null
         return [pscustomobject]@{
             Success           = $false
+            ZipPath           = $Zip.FullName
             FilesExtracted    = 0
             UncompressedBytes = [int64]0
             CompressedBytes   = [int64]0

--- a/src/powershell/modules/FileManagement/ZipExtraction/Private/Orchestration.Helpers.ps1
+++ b/src/powershell/modules/FileManagement/ZipExtraction/Private/Orchestration.Helpers.ps1
@@ -9,6 +9,7 @@ function Merge-ParallelZipResults {
     $totalFilesExtracted     = 0
     $totalUncompressedBytes  = [int64]0
     $totalCompressedZipBytes = [int64]0
+    $processedZipPaths       = [System.Collections.Generic.List[string]]::new()
 
     foreach ($r in $Results) {
         foreach ($log in $r.Logs) { Write-LogDebug $log }
@@ -17,9 +18,10 @@ function Merge-ParallelZipResults {
             $totalFilesExtracted     += $r.FilesExtracted
             $totalUncompressedBytes  += $r.UncompressedBytes
             $totalCompressedZipBytes += $r.CompressedBytes
+            if ($r.ZipPath) { $processedZipPaths.Add($r.ZipPath) | Out-Null }
         }
     }
     foreach ($e in $ConcurrentErrors) { $ErrorList.Add($e) | Out-Null }
     Write-LogInfo "Parallel extraction complete: $processedZips / $ZipCount archive(s) processed."
-    return New-ExtractionSummary -ZipCount $ZipCount -ProcessedZips $processedZips -FilesExtracted $totalFilesExtracted -UncompressedBytes $totalUncompressedBytes -CompressedBytes $totalCompressedZipBytes
+    return New-ExtractionSummary -ZipCount $ZipCount -ProcessedZips $processedZips -FilesExtracted $totalFilesExtracted -UncompressedBytes $totalUncompressedBytes -CompressedBytes $totalCompressedZipBytes -ProcessedZipPaths $processedZipPaths.ToArray()
 }

--- a/src/powershell/modules/FileManagement/ZipExtraction/Public/Invoke-SerialZipExtractions.ps1
+++ b/src/powershell/modules/FileManagement/ZipExtraction/Public/Invoke-SerialZipExtractions.ps1
@@ -9,6 +9,7 @@ function Invoke-SerialZipExtractions {
     )
     if ($ThrottleLimit -gt 1 -and $WhatIfPreference) { Write-Verbose "WhatIf is active — falling back to serial extraction so -WhatIf/-Confirm are honoured." }
     $processedZips = 0; $totalFilesExtracted = 0; $totalUncompressedBytes = [int64]0; $totalCompressedZipBytes = [int64]0; $index = 0
+    $processedZipPaths = [System.Collections.Generic.List[string]]::new()
 
     foreach ($zip in $Zips) {
         $index++
@@ -18,11 +19,12 @@ function Invoke-SerialZipExtractions {
                 $r = Invoke-SingleZipExtraction -Zip $zip -DestDir $DestinationDir -Mode $Mode -Policy $Policy -MaxLen $SafeNameMaxLen
                 $totalFilesExtracted += $r.FilesExtracted
                 $totalUncompressedBytes += $r.UncompressedBytes; $totalCompressedZipBytes += $r.CompressedBytes; $processedZips++
+                $processedZipPaths.Add($zip.FullName) | Out-Null
                 Write-LogDebug $r.Log
             }
         } catch { $msg = $_.Exception.Message; $ErrorList.Add("Extraction failed for '$($zip.FullName)': $msg") | Out-Null; Write-LogDebug $msg }
     }
 
     Show-ProgressPhase -Activity "Extracting archives" -Status "Done" -Current $ZipCount -Total $ZipCount -QuietMode $QuietMode -Completed
-    return New-ExtractionSummary -ZipCount $ZipCount -ProcessedZips $processedZips -FilesExtracted $totalFilesExtracted -UncompressedBytes $totalUncompressedBytes -CompressedBytes $totalCompressedZipBytes
+    return New-ExtractionSummary -ZipCount $ZipCount -ProcessedZips $processedZips -FilesExtracted $totalFilesExtracted -UncompressedBytes $totalUncompressedBytes -CompressedBytes $totalCompressedZipBytes -ProcessedZipPaths $processedZipPaths.ToArray()
 }

--- a/src/powershell/modules/FileManagement/ZipExtraction/ZipExtraction.psm1
+++ b/src/powershell/modules/FileManagement/ZipExtraction/ZipExtraction.psm1
@@ -18,7 +18,8 @@ function New-ExtractionSummary {
         [int]$ProcessedZips,
         [int]$FilesExtracted,
         [int64]$UncompressedBytes,
-        [int64]$CompressedBytes
+        [int64]$CompressedBytes,
+        [string[]]$ProcessedZipPaths = @()
     )
     return [pscustomobject]@{
         ZipCount          = $ZipCount
@@ -26,6 +27,7 @@ function New-ExtractionSummary {
         FilesExtracted    = $FilesExtracted
         UncompressedBytes = $UncompressedBytes
         CompressedBytes   = $CompressedBytes
+        ProcessedZipPaths = $ProcessedZipPaths
     }
 }
 

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -215,14 +215,15 @@ Describe '-DeleteSourceZips behaviour' {
         $deletedSummary = [pscustomobject]@{ Count = 3; Bytes = 1024 }
         $moveSummary    = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = ''; Skipped = 0; Overwritten = 0; Renamed = 0 }
 
-        $view = ProgressReporter\Write-ExtractionSummary `
+        $view = @(ProgressReporter\Write-ExtractionSummary `
             -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
             -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
             -ZipCount 3 -ProcessedZips 3 -FilesExtracted 9 `
             -UncompressedBytes 4096 -CompressedBytes 1024 `
             -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
             -DeleteSourceZips -DeletedSummary $deletedSummary `
-            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200
+            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200) |
+            Where-Object { $_ -is [pscustomobject] } | Select-Object -First 1
 
         $view.ZipsDeleted | Should -Be 3
         $view.PSObject.Properties.Name | Should -Contain 'DeletedBytes'
@@ -237,13 +238,14 @@ Describe '-DeleteSourceZips behaviour' {
         $errors = [System.Collections.Generic.List[string]]::new()
         $moveSummary = [pscustomobject]@{ Count = 2; Bytes = 512; Destination = $TestDrive; Skipped = 0; Overwritten = 0; Renamed = 0 }
 
-        $view = ProgressReporter\Write-ExtractionSummary `
+        $view = @(ProgressReporter\Write-ExtractionSummary `
             -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
             -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
             -ZipCount 2 -ProcessedZips 2 -FilesExtracted 4 `
             -UncompressedBytes 2048 -CompressedBytes 512 `
             -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
-            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200
+            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200) |
+            Where-Object { $_ -is [pscustomobject] } | Select-Object -First 1
 
         $view.ZipsMoved | Should -Be 2
         $view.PSObject.Properties.Name | Should -Contain 'MovedTo'

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -186,6 +186,71 @@ Describe 'Resolve-MoveTarget' {
     }
 }
 
+Describe '-DeleteSourceZips behaviour' {
+    BeforeAll {
+        Import-ExpandZipsAndCleanZipExtractionTestModule
+    }
+
+    It 'ProcessedZipPaths is empty when no zips are found' {
+        $sourceDir = Join-Path $TestDrive 'dsz-empty-src'
+        $destDir   = Join-Path $TestDrive 'dsz-empty-dest'
+        New-Item -ItemType Directory -Path $sourceDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $destDir   -Force | Out-Null
+
+        $errorList = [System.Collections.Generic.List[string]]::new()
+        $result = ZipExtraction\Invoke-ZipExtractions `
+            -SourceDir $sourceDir -DestinationDir $destDir `
+            -Mode 'PerArchiveSubfolder' -Policy 'Rename' `
+            -SafeNameMaxLen 0 -QuietMode $true `
+            -ErrorList $errorList -ThrottleLimit 1
+
+        $result.ProcessedZipPaths | Should -BeNullOrEmpty
+    }
+
+    It 'Write-ExtractionSummary shows ZipsDeleted and DeletedBytes when -DeleteSourceZips is set' {
+        $moduleRoot = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules'
+        Import-Module (Join-Path $moduleRoot 'Core\Progress\ProgressReporter.psm1') -Force -ErrorAction Stop
+
+        $errors = [System.Collections.Generic.List[string]]::new()
+        $deletedSummary = [pscustomobject]@{ Count = 3; Bytes = 1024 }
+        $moveSummary    = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = ''; Skipped = 0; Overwritten = 0; Renamed = 0 }
+
+        $view = ProgressReporter\Write-ExtractionSummary `
+            -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 3 -ProcessedZips 3 -FilesExtracted 9 `
+            -UncompressedBytes 4096 -CompressedBytes 1024 `
+            -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
+            -DeleteSourceZips -DeletedSummary $deletedSummary `
+            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200
+
+        $view.ZipsDeleted | Should -Be 3
+        $view.PSObject.Properties.Name | Should -Contain 'DeletedBytes'
+        $view.PSObject.Properties.Name | Should -Not -Contain 'ZipsMoved'
+        $view.PSObject.Properties.Name | Should -Not -Contain 'MovedTo'
+    }
+
+    It 'Write-ExtractionSummary shows ZipsMoved (not ZipsDeleted) by default' {
+        $moduleRoot = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules'
+        Import-Module (Join-Path $moduleRoot 'Core\Progress\ProgressReporter.psm1') -Force -ErrorAction Stop
+
+        $errors = [System.Collections.Generic.List[string]]::new()
+        $moveSummary = [pscustomobject]@{ Count = 2; Bytes = 512; Destination = $TestDrive; Skipped = 0; Overwritten = 0; Renamed = 0 }
+
+        $view = ProgressReporter\Write-ExtractionSummary `
+            -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 2 -ProcessedZips 2 -FilesExtracted 4 `
+            -UncompressedBytes 2048 -CompressedBytes 512 `
+            -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
+            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200
+
+        $view.ZipsMoved | Should -Be 2
+        $view.PSObject.Properties.Name | Should -Contain 'MovedTo'
+        $view.PSObject.Properties.Name | Should -Not -Contain 'ZipsDeleted'
+    }
+}
+
 Describe 'Expand-ZipsAndClean script structure' {
     It 'uses terminating imports for all startup modules before workflow execution' {
         $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
@@ -210,6 +275,12 @@ Describe 'Expand-ZipsAndClean script structure' {
         foreach ($import in $startupImports) {
             $import.Extent.Text | Should -Match '(?i)-ErrorAction\s+Stop'
         }
+    }
+
+    It 'declares -DeleteSourceZips switch parameter' {
+        $scriptPath = Join-Path $PSScriptRoot '..\..\..\src\powershell\file-management\Expand-ZipsAndClean.ps1'
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+        $scriptText | Should -Match '\[switch\]\$DeleteSourceZips'
     }
 
     It 'contains no script-local helper function definitions' {

--- a/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
+++ b/tests/powershell/file-management/Expand-ZipsAndClean.Tests.ps1
@@ -207,50 +207,6 @@ Describe '-DeleteSourceZips behaviour' {
         $result.ProcessedZipPaths | Should -BeNullOrEmpty
     }
 
-    It 'Write-ExtractionSummary shows ZipsDeleted and DeletedBytes when -DeleteSourceZips is set' {
-        $moduleRoot = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules'
-        Import-Module (Join-Path $moduleRoot 'Core\Progress\ProgressReporter.psm1') -Force -ErrorAction Stop
-
-        $errors = [System.Collections.Generic.List[string]]::new()
-        $deletedSummary = [pscustomobject]@{ Count = 3; Bytes = 1024 }
-        $moveSummary    = [pscustomobject]@{ Count = 0; Bytes = 0; Destination = ''; Skipped = 0; Overwritten = 0; Renamed = 0 }
-
-        $view = @(ProgressReporter\Write-ExtractionSummary `
-            -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
-            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 3 -ProcessedZips 3 -FilesExtracted 9 `
-            -UncompressedBytes 4096 -CompressedBytes 1024 `
-            -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
-            -DeleteSourceZips -DeletedSummary $deletedSummary `
-            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200) |
-            Where-Object { $_ -is [pscustomobject] } | Select-Object -First 1
-
-        $view.ZipsDeleted | Should -Be 3
-        $view.PSObject.Properties.Name | Should -Contain 'DeletedBytes'
-        $view.PSObject.Properties.Name | Should -Not -Contain 'ZipsMoved'
-        $view.PSObject.Properties.Name | Should -Not -Contain 'MovedTo'
-    }
-
-    It 'Write-ExtractionSummary shows ZipsMoved (not ZipsDeleted) by default' {
-        $moduleRoot = Join-Path $PSScriptRoot '..\..\..\src\powershell\modules'
-        Import-Module (Join-Path $moduleRoot 'Core\Progress\ProgressReporter.psm1') -Force -ErrorAction Stop
-
-        $errors = [System.Collections.Generic.List[string]]::new()
-        $moveSummary = [pscustomobject]@{ Count = 2; Bytes = 512; Destination = $TestDrive; Skipped = 0; Overwritten = 0; Renamed = 0 }
-
-        $view = @(ProgressReporter\Write-ExtractionSummary `
-            -SourceDirectory $TestDrive -DestinationDirectory $TestDrive `
-            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
-            -ZipCount 2 -ProcessedZips 2 -FilesExtracted 4 `
-            -UncompressedBytes 2048 -CompressedBytes 512 `
-            -MoveSummary $moveSummary -Errors $errors -Elapsed ([timespan]::Zero) `
-            -PassThru -HostName 'ConsoleHost' -ConsoleWidth 200) |
-            Where-Object { $_ -is [pscustomobject] } | Select-Object -First 1
-
-        $view.ZipsMoved | Should -Be 2
-        $view.PSObject.Properties.Name | Should -Contain 'MovedTo'
-        $view.PSObject.Properties.Name | Should -Not -Contain 'ZipsDeleted'
-    }
 }
 
 Describe 'Expand-ZipsAndClean script structure' {

--- a/tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1
+++ b/tests/powershell/modules/Core/Progress/ProgressReporter.Tests.ps1
@@ -89,4 +89,49 @@ Describe 'Write-ExtractionSummary' {
         Should -Invoke Format-List -ModuleName ProgressReporter -Times 1
         Should -Invoke Format-Table -ModuleName ProgressReporter -Times 0
     }
+
+    It 'shows ZipsDeleted and DeletedBytes when -DeleteSourceZips is set' {
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        $deletedSummary = [pscustomobject]@{ Count = 3; Bytes = [int64]1024 }
+        $moveSummary    = [pscustomobject]@{ Count = 0; Bytes = [int64]0; Destination = ''; Skipped = 0; Overwritten = 0; Renamed = 0 }
+
+        $allOutput = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 3 -ProcessedZips 3 -FilesExtracted 9 `
+            -UncompressedBytes ([int64]4096) -CompressedBytes ([int64]1024) `
+            -MoveSummary $moveSummary -Errors $script:emptyErrors -Elapsed $script:testElapsed `
+            -DeleteSourceZips -DeletedSummary $deletedSummary `
+            -HostName 'ConsoleHost' -ConsoleWidth 200 -PassThru)
+
+        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
+        $view                               | Should -Not -BeNullOrEmpty
+        $view.ZipsDeleted                   | Should -Be 3
+        $view.PSObject.Properties.Name      | Should -Contain 'DeletedBytes'
+        $view.PSObject.Properties.Name      | Should -Not -Contain 'ZipsMoved'
+        $view.PSObject.Properties.Name      | Should -Not -Contain 'MovedTo'
+    }
+
+    It 'shows ZipsMoved (not ZipsDeleted) by default' {
+        Mock Format-Table -ModuleName ProgressReporter { }
+        Mock Format-List -ModuleName ProgressReporter { }
+
+        $moveSummary = [pscustomobject]@{ Count = 2; Bytes = [int64]512; Destination = 'C:\parent'; Skipped = 0; Overwritten = 0; Renamed = 0 }
+
+        $allOutput = @(Write-ExtractionSummary `
+            -SourceDirectory 'C:\src' -DestinationDirectory 'C:\dest' `
+            -ExtractMode 'PerArchiveSubfolder' -CollisionPolicy 'Rename' `
+            -ZipCount 2 -ProcessedZips 2 -FilesExtracted 4 `
+            -UncompressedBytes ([int64]2048) -CompressedBytes ([int64]512) `
+            -MoveSummary $moveSummary -Errors $script:emptyErrors -Elapsed $script:testElapsed `
+            -HostName 'ConsoleHost' -ConsoleWidth 200 -PassThru)
+
+        $view = $allOutput | Where-Object { $_ -isnot [string] } | Select-Object -First 1
+        $view                               | Should -Not -BeNullOrEmpty
+        $view.ZipsMoved                     | Should -Be 2
+        $view.PSObject.Properties.Name      | Should -Contain 'MovedTo'
+        $view.PSObject.Properties.Name      | Should -Not -Contain 'ZipsDeleted'
+    }
 }


### PR DESCRIPTION
## Summary
Added a new `-DeleteSourceZips` switch parameter to `Expand-ZipsAndClean.ps1` that allows users to delete successfully extracted zip files in place rather than moving them to the parent directory. This provides an alternative workflow for users who want to clean up source archives immediately after extraction without the intermediate move step.

## Key Changes

- **New `-DeleteSourceZips` switch parameter**: When present, each zip whose extraction succeeds is deleted in place; failed extractions are left untouched. The `Move-ZipFilesToParent` step is bypassed entirely when this switch is set.

- **Extraction result tracking**: Added `ProcessedZipPaths` field to the extraction summary object (returned by `Invoke-ZipExtractions`, `Invoke-SerialZipExtractions`, and `Merge-ParallelZipResults`) to track which archives were successfully extracted without requiring a second directory scan.

- **Runspace result enhancement**: Added `ZipPath` field to `Expand-ZipInRunspace` result objects so the parallel merger can attribute successful extractions to their source archive paths.

- **Summary reporting**: Updated `Write-ExtractionSummary` to accept `DeleteSourceZips` and `DeletedSummary` parameters. When `-DeleteSourceZips` is set, the summary view displays `ZipsDeleted`/`DeletedBytes` instead of `ZipsMoved`/`MoveSkipped`/`MoveOverwritten`/`MoveRenamed`/`MovedTo`.

- **Documentation updates**: Enhanced help text and examples to explain the new switch behavior and its interaction with other parameters. Updated CHANGELOG and README with feature details.

- **Test coverage**: Added comprehensive test cases covering empty source handling, summary view behavior with and without the switch, and script structure validation.

## Implementation Details

- The deletion logic iterates through `ProcessedZipPaths` from the extraction result, checking file existence before attempting deletion to handle edge cases gracefully.
- Error handling is consistent with the move-to-parent workflow—failed deletions are logged but don't halt execution.
- The switch is independent of `-DeleteSource` and `-CleanNonZips`; all combinations are valid.
- `-CollisionPolicy` has no effect on the zip-disposal step when `-DeleteSourceZips` is set (no move step occurs).
- Version bumped to `2.7.0` (minor release).

https://claude.ai/code/session_01DKdDQpQNMMFDjjB5qvSxRp