### PR TITLE
feat(videoscreenshot): add per-run log files

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,19 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-06-01
+### Added
+- **Per-run log files for `Start-VideoBatch`**: runs now write timestamped `Write-Message` output to a collision-safe `videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log` file under `SaveFolder` by default. The resolved log path is printed at run start so non-interactive runs leave an inspectable artifact.
+- **`-LogFile` and `-NoLogFile` parameters** on `Start-VideoBatch`: pass an explicit log path (parent directories are created best-effort) or opt out with `-NoLogFile` / `-LogFile ''` while leaving console stream behavior unchanged.
+- **Module-scoped logging sink** in `Private/Logging.ps1`: `Set-VideoScreenshotLogFile`, `Get-VideoScreenshotLogFile`, and `Clear-VideoScreenshotLogFile` let `Write-Message` capture helper-emitted messages without threading `-LogFile` through every private call site.
+
+### Changed
+- `Write-Message` now falls back to the module-scoped run log when its own `-LogFile` parameter is omitted; explicit `-LogFile` values still take precedence, and file writes remain best-effort with warning-only failures.
+- `Start-VideoBatch` clears the module-scoped log sink in a `finally` block so successive runs do not leak log state.
+
+### Tests
+- New `tests/.../Logging.Tests.ps1`: covers explicit log writes, module-scoped default routing, empty-log opt-out, warning-only write failures, default `Start-VideoBatch` log creation under `SaveFolder`, and `-NoLogFile` opt-out.
+
 ## [3.3.0] - 2026-05-31
 ### Added
 - **`-DeduplicateFrames` switch** on `Start-VideoBatch`: when set, consecutive snapshot frames whose file bytes are identical are collapsed to a single kept frame per video after capture completes. Genuinely distinct frames are always preserved. Default off; enable for image/slideshow→MP4 conversions (e.g. `picconvert_*` folders) that produce long runs of identical frames at the configured FPS.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Logging.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Logging.ps1
@@ -9,6 +9,8 @@
 
   Optional behaviors:
     - -LogFile <path> : Append the formatted line to a log file (best-effort).
+    - Module default  : When -LogFile is omitted, append to the module-scoped
+      default set by Set-VideoScreenshotLogFile, if one is configured.
     - -Quiet          : Suppress console emission for Info/Warn (Error still shown).
 
   Notes:
@@ -24,17 +26,67 @@
   LogFile output (when provided) still occurs.
 .PARAMETER LogFile
   Path to a file where the log line should be appended. Directory must exist.
+  Explicit values take precedence over the module-scoped default; an empty value disables file output for that call.
 .EXAMPLE
   Write-Message -Level Info -Message "Starting capture" -LogFile "C:\logs\run.log"
 .EXAMPLE
   Write-Message -Level Warn -Message "No videos found" -Quiet
 #>
+$script:VideoscreenshotLogFile = $null
+
+<#
+.SYNOPSIS
+  Set the module-scoped default run log file used by Write-Message.
+.DESCRIPTION
+  Start-VideoBatch uses this helper to route messages from the entrypoint and
+  private helpers into one per-run log without threading -LogFile through every
+  call site. Pass a null/empty value to clear the sink.
+#>
+function Set-VideoScreenshotLogFile {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $script:VideoscreenshotLogFile = $null
+    }
+    else {
+        $script:VideoscreenshotLogFile = $Path
+    }
+}
+
+<#
+.SYNOPSIS
+  Return the current module-scoped default run log file, if configured.
+#>
+function Get-VideoScreenshotLogFile {
+    [CmdletBinding()]
+    param()
+
+    return $script:VideoscreenshotLogFile
+}
+
+<#
+.SYNOPSIS
+  Clear the module-scoped default run log file.
+#>
+function Clear-VideoScreenshotLogFile {
+    [CmdletBinding()]
+    param()
+
+    $script:VideoscreenshotLogFile = $null
+}
+
 function Write-Message {
     [CmdletBinding()]
     param(
         [ValidateSet('Info', 'Warn', 'Error')][string]$Level = 'Info',
         [Parameter(Mandatory)][string]$Message,
         [switch]$Quiet,
+        [AllowEmptyString()]
         [string]$LogFile
     )
 
@@ -42,15 +94,22 @@ function Write-Message {
     $ts = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
     $formatted = "[$ts] [$($Level.ToUpper().PadRight(5))] $Message"
 
+    $effectiveLogFile = if ($PSBoundParameters.ContainsKey('LogFile')) {
+        $LogFile
+    }
+    else {
+        $script:VideoscreenshotLogFile
+    }
+
     # Best-effort file logging (does not throw the whole function if it fails)
-    if (-not [string]::IsNullOrWhiteSpace($LogFile)) {
+    if (-not [string]::IsNullOrWhiteSpace($effectiveLogFile)) {
         try {
             # Uses helper with retry semantics; caller is responsible for directory existence.
-            Add-ContentWithRetry -Path $LogFile -Value $formatted | Out-Null
+            Add-ContentWithRetry -Path $effectiveLogFile -Value $formatted | Out-Null
         }
         catch {
             # Keep the run going; surface a warning so the user knows file logging failed.
-            Write-Warning ("Write-Message: failed to write to logfile '{0}' — {1}" -f $LogFile, $_.Exception.Message)
+            Write-Warning ("Write-Message: failed to write to logfile '{0}' — {1}" -f $effectiveLogFile, $_.Exception.Message)
         }
     }
 

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -20,6 +20,12 @@ Legacy per-video time budget (seconds). Prefer -MaxPerVideoSeconds.
 Process at most this many videos (0 = no limit).
 .PARAMETER ProcessedLogPath
 TSV log used for resume/skip; auto-located in SaveFolder when not provided.
+.PARAMETER LogFile
+Run log file for timestamped module messages. Defaults to a collision-safe
+videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log file under SaveFolder. Pass an
+empty string or use -NoLogFile to keep console-only output.
+.PARAMETER NoLogFile
+Disable the per-run log file while keeping console stream behavior unchanged.
 .PARAMETER ResumeFile
 Optional file path/name to resume after.
 .PARAMETER MaxPerVideoSeconds
@@ -74,9 +80,12 @@ function Start-VideoBatch {
         [int]$TimeLimitSeconds = 0,
         [int]$VideoLimit = 0,
 
-        # Resume & processed logging
+        # Resume, processed logging, and run logging
         [string]$ProcessedLogPath,
         [string]$ResumeFile,
+        [AllowEmptyString()]
+        [string]$LogFile,
+        [switch]$NoLogFile,
 
         # Advanced timing controls
         [ValidateRange(0, 86400)][int]$MaxPerVideoSeconds = 0,
@@ -114,8 +123,49 @@ function Start-VideoBatch {
     $runGuid = [Guid]::NewGuid().ToString('N').Substring(0, 8)
     $context = New-VideoRunContext -RequestedFps $FramesPerSecond -SaveFolder $SaveFolder -RunGuid $runGuid
 
+    if ($CropOnly -and -not $PSBoundParameters.ContainsKey('SaveFolder')) {
+        throw "CropOnly requires -SaveFolder pointing to the folder containing images to crop."
+    }
+    if ($CropOnly -and -not (Test-Path -LiteralPath $SaveFolder -PathType Container)) {
+        throw "SaveFolder not found (CropOnly expects images here): $SaveFolder"
+    }
+
+    # Validate/create SaveFolder before resolving the default run log path. This
+    # also makes the CropOnly fast-path log-capable before it emits messages.
+    Test-FolderWritable -Folder $SaveFolder | Out-Null
+
+    $resolvedRunLogFile = $null
+    $logFileExplicitlyProvided = $PSBoundParameters.ContainsKey('LogFile')
+    if (-not $NoLogFile -and -not ($logFileExplicitlyProvided -and [string]::IsNullOrWhiteSpace($LogFile))) {
+        $resolvedRunLogFile = if ($logFileExplicitlyProvided) {
+            $LogFile
+        }
+        else {
+            Join-Path $SaveFolder ("videoscreenshot_{0}_{1}.log" -f (Get-Date).ToString('yyyyMMdd_HHmmss'), $runGuid)
+        }
+
+        $runLogParent = Split-Path -Path $resolvedRunLogFile -Parent
+        if (-not [string]::IsNullOrWhiteSpace($runLogParent) -and -not (Test-Path -LiteralPath $runLogParent -PathType Container)) {
+            try {
+                New-Item -ItemType Directory -Path $runLogParent -Force -ErrorAction Stop | Out-Null
+            }
+            catch {
+                Write-Warning ("Unable to create run log directory '{0}': {1}. File logging will remain best-effort." -f $runLogParent, $_.Exception.Message)
+            }
+        }
+
+        Set-VideoScreenshotLogFile -Path $resolvedRunLogFile
+    }
+    else {
+        Clear-VideoScreenshotLogFile
+    }
+
+    try {
     # Context contains Version, Config (defaults incl. VideoExtensions), RunGuid, SaveFolder, RequestedFps
     Write-Message -Level Info -Message ("videoscreenshot module v{0} starting (Mode={1}, FPS={2}, SaveFolder=""{3}"")" -f ($context.Version -as [string]), $mode, $FramesPerSecond, $SaveFolder)
+    if (-not [string]::IsNullOrWhiteSpace($resolvedRunLogFile)) {
+        Write-Message -Level Info -Message ("Run log file: {0}" -f $resolvedRunLogFile)
+    }
 
     # --- Crop-only fast path ---------------------------------------------------
     if ($CropOnly) {
@@ -131,11 +181,6 @@ function Start-VideoBatch {
             Write-Message -Level Warn -Message ("CropOnly: ignoring capture-related parameter(s): {0}" -f ($ignored -join ', '))
         }
 
-        # Require an explicit SaveFolder in CropOnly mode (no implicit default)
-        if (-not $PSBoundParameters.ContainsKey('SaveFolder')) {
-            throw "CropOnly requires -SaveFolder pointing to the folder containing images to crop."
-        }
-
         # Validate inputs for cropper
         if (-not [string]::IsNullOrWhiteSpace($PythonScriptPath)) {
             if (-not (Test-Path -LiteralPath $PythonScriptPath)) {
@@ -145,12 +190,6 @@ function Start-VideoBatch {
         else {
             Write-Debug "CropOnly: PythonScriptPath not supplied; will attempt module invocation via 'python -m media.crop_colours'."
         }
-        if (-not (Test-Path -LiteralPath $SaveFolder -PathType Container)) {
-            throw "SaveFolder not found (CropOnly expects images here): $SaveFolder"
-        }
-        # Ensure we can write logs if needed (non-fatal if read-only images)
-        Test-FolderWritable -Folder $SaveFolder | Out-Null
-
         try {
             $isDebug = $PSBoundParameters.ContainsKey('Debug')
             $crop = Invoke-Cropper `
@@ -227,8 +266,6 @@ function Start-VideoBatch {
             throw "VLC missing."
         }
     }
-    Test-FolderWritable -Folder $SaveFolder | Out-Null
-
     # Resolve processed log path and read processed/resume set (P0)
     $processedLog = if ([string]::IsNullOrWhiteSpace($ProcessedLogPath)) {
         Join-Path $SaveFolder '.processed_videos.txt'
@@ -320,6 +357,7 @@ function Start-VideoBatch {
         if ($vlcLogFile -and (Test-Path -LiteralPath $vlcLogFile)) {
             Remove-Item -LiteralPath $vlcLogFile -Force -ErrorAction SilentlyContinue
         }
+        $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — processed 0 file(s)" -f ($context.Version))
         return
     }
 
@@ -599,4 +637,8 @@ function Start-VideoBatch {
     $null = Write-Message -Level Info -Message ("videoscreenshot module v{0} finished — processed {1} file(s)" -f ($context.Version), $processedCount)
     Write-Debug 'TRACE Start-VideoBatch: leaving (no output intended)'
     return
+    }
+    finally {
+        Clear-VideoScreenshotLogFile
+    }
 }

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -48,6 +48,8 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
 - `ReprocessCropped` (switch): Force re-crop even if images were processed before.
 - `KeepExistingCrops` (switch): Preserve existing crops when reprocessing.
 - `ProcessedLogPath` (string): Location of the processed/resume log under `SaveFolder` by default.
+- `LogFile` (string): Optional run-log path for timestamped module messages. When omitted, `Start-VideoBatch` creates `videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log` under `SaveFolder`. Pass an empty string to opt out.
+- `NoLogFile` (switch): Disable the run log file while keeping console output unchanged.
 
 ## Error Handling
 ```powershell
@@ -56,7 +58,7 @@ try {
 }
 catch {
     Write-Error "Video screenshot run failed: $_"
-    # Inspect on-screen VLC/cropper logs for root cause (network paths, missing VLC/Python, etc.)
+    # Inspect the run log printed at startup, plus VLC/cropper diagnostics, for root cause.
 }
 ```
 
@@ -65,6 +67,7 @@ catch {
 - Set `FramesPerSecond` conservatively for long runs to reduce I/O and disk usage.
 - Enable `-IncludeExtensions` to skip unsupported formats early and speed up discovery.
 - Processed logs allow resumable runs—point `-ProcessedLogPath` at fast storage to avoid lock contention.
+- Run logs are enabled by default under `SaveFolder`; use `-LogFile` for a central logs directory or `-NoLogFile` for console-only smoke tests.
 - Use `-VerifyVideos` (`-PreflightProbe`/`-SkipUnplayable`) to skip corrupt or unsupported files before launching the main VLC capture session; tune the bounded probe with `-VideoProbeTimeoutSeconds` (default `10`). The probe no longer false-skips chatty codecs (AV1/VP9) due to the pipe-buffer deadlock fix.
 - Cropper runs can be CPU intensive; use `-VideoLimit`/`-TimeLimitSeconds` to batch work into smaller chunks.
 
@@ -96,6 +99,23 @@ Use VLC’s scene snapshot filter to write frames directly to disk:
 Import-Module .\src\powershell\module\Videoscreenshot\Videoscreenshot.psd1
 Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots
 ```
+
+### Run logs
+
+Each `Start-VideoBatch` run writes a persistent log through the same `Write-Message` framework used for console output. By default, the file is created under `SaveFolder` with a collision-safe name:
+
+```text
+<SaveFolder>\videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log
+```
+
+The resolved path is printed at startup as `Run log file: ...`. Use `-LogFile` to send the run log elsewhere, or disable file logging with either `-NoLogFile` or `-LogFile ''`:
+
+```powershell
+Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -LogFile .\logs\batch.log
+Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -NoLogFile
+```
+
+Run-log writes are best-effort: a file-write failure emits a warning and the capture continues. Helper warnings (for example VLC snapshot stall/cap messages) are captured in the same run log because the module configures a per-run logging sink before capture or crop-only work starts.
 
 ### Cropper integration
 When `-RunCropper` is set, the module invokes the Python cropper after capture. By default the cropper **skips images that were already cropped in previous runs** (tracked via `.processed_images`).
@@ -256,6 +276,8 @@ src/
 - -VideoLimit – limit how many videos to process in this run (0 = all)
 - **Resume / processed logging (P0)**
 - -ProcessedLogPath – path to append successfully processed videos (defaults under -SaveFolder)
+- -LogFile – path for the per-run timestamped message log (defaults to `videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log` under -SaveFolder)
+- -NoLogFile – disable the per-run message log while keeping console output
 - -ResumeFile – optional list of already-processed video paths to skip
 - **Advanced timing (P0)**
 - -MaxPerVideoSeconds – hard ceiling for wait/monitor phases (snapshots)
@@ -316,6 +338,7 @@ On Windows (example):
 ## Troubleshooting
 - “VLC not found”: ensure `vlc --version` runs in the same session.
 - “Module not found”: verify the path to `Videoscreenshot.psd1` when importing the module manually.
+- **“Where is the log file?”** `Start-VideoBatch` prints `Run log file: <path>` near startup. By default it is under `SaveFolder` as `videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log`; use `-LogFile <path>` to choose a location or `-NoLogFile` for console-only runs.
 - **Startup banner shows a stale version after editing files**: PowerShell caches the module in the current session. Editing files on disk does **not** update what is loaded. Always reload with `Import-Module .\Videoscreenshot.psd1 -Force` (or restart the session) after making edits; otherwise `Get-Module` still returns the old version and any version-dependent behaviour reflects the stale import.
 - “Cropper failed due to missing packages”: by default, the module tries to install them. If you used -NoAutoInstall, install manually with python -m pip install <packages> or remove the switch.
 - “Resume/processed not working”: the module reads `<SaveFolder>\.processed_videos.txt` and accepts **both**

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.3.0'
+  ModuleVersion     = '3.4.0'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -14,7 +14,7 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.3.0: Add -DeduplicateFrames opt-in switch that removes consecutive identical snapshot frames by content hash (SHA256 default); frame counts and status logging reflect kept frames. Config knob DeduplicateHashAlgorithm allows algorithm override.'
+      ReleaseNotes = '3.4.0: Add opt-out per-run logging for Start-VideoBatch via default SaveFolder logs, -LogFile override, and -NoLogFile opt-out. Write-Message now honors a module-scoped sink so helper messages land in the same run log.'
     }
   }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Logging.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Logging.Tests.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+Pester tests for Videoscreenshot run-log routing.
+#>
+
+BeforeAll {
+    $script:ModuleRoot = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot'
+    $script:IoPath = Join-Path $script:ModuleRoot 'Private' 'IO.Helpers.ps1'
+    $script:LoggingPath = Join-Path $script:ModuleRoot 'Private' 'Logging.ps1'
+    $script:ModuleManifest = Join-Path $script:ModuleRoot 'Videoscreenshot.psd1'
+
+    foreach ($f in $script:IoPath, $script:LoggingPath, $script:ModuleManifest) {
+        if (-not (Test-Path -LiteralPath $f)) { throw "Required file not found: $f" }
+    }
+
+    . $script:IoPath
+    . $script:LoggingPath
+
+    function Script:New-TempFolder {
+        New-Item -ItemType Directory `
+            -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString('N'))) `
+            -Force
+    }
+}
+
+Describe 'Write-Message run-log routing' {
+    AfterEach {
+        Clear-VideoScreenshotLogFile
+        if ($script:TempFolder -and (Test-Path -LiteralPath $script:TempFolder -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $script:TempFolder -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'writes formatted lines to an explicit -LogFile path' {
+        $script:TempFolder = (Script:New-TempFolder).FullName
+        $log = Join-Path $script:TempFolder 'explicit.log'
+
+        Write-Message -Level Info -Message 'explicit file message' -LogFile $log -Quiet
+
+        $content = Get-Content -LiteralPath $log -Raw
+        $content | Should -Match '^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \[INFO \] explicit file message'
+    }
+
+    It 'uses the module-scoped default when -LogFile is omitted' {
+        $script:TempFolder = (Script:New-TempFolder).FullName
+        $log = Join-Path $script:TempFolder 'default.log'
+
+        Set-VideoScreenshotLogFile -Path $log
+        Write-Message -Level Warn -Message 'helper-visible warning' -Quiet
+
+        Get-Content -LiteralPath $log -Raw | Should -Match '\[WARN \] helper-visible warning'
+    }
+
+    It 'lets an explicit empty -LogFile opt out of the module-scoped default for one call' {
+        $script:TempFolder = (Script:New-TempFolder).FullName
+        $log = Join-Path $script:TempFolder 'default.log'
+
+        Set-VideoScreenshotLogFile -Path $log
+        Write-Message -Level Info -Message 'console only' -LogFile '' -Quiet
+
+        Test-Path -LiteralPath $log | Should -BeFalse
+    }
+
+    It 'surfaces file-write failures as warnings without throwing' {
+        $script:TempFolder = (Script:New-TempFolder).FullName
+
+        $warnings = & { Write-Message -Level Info -Message 'cannot append to directory' -LogFile $script:TempFolder -Quiet } 3>&1
+
+        ($warnings | Out-String) | Should -Match 'failed to write to logfile'
+    }
+}
+
+Describe 'Start-VideoBatch run-log defaults' {
+    BeforeEach {
+        $script:TempFolder = (Script:New-TempFolder).FullName
+        $script:SourceFolder = Join-Path $script:TempFolder 'videos'
+        $script:SaveFolder = Join-Path $script:TempFolder 'shots'
+        New-Item -ItemType Directory -Path $script:SourceFolder, $script:SaveFolder -Force | Out-Null
+        $script:FakeVlc = Join-Path $script:TempFolder 'vlc.exe'
+        Set-Content -LiteralPath $script:FakeVlc -Value 'fake vlc' -NoNewline
+
+        Import-Module $script:ModuleManifest -Force
+    }
+
+    AfterEach {
+        Remove-Module Videoscreenshot -Force -ErrorAction SilentlyContinue
+        Clear-VideoScreenshotLogFile
+        if ($script:TempFolder -and (Test-Path -LiteralPath $script:TempFolder -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $script:TempFolder -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'creates a default run log under SaveFolder when -LogFile is omitted' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc
+
+        $logs = Get-ChildItem -LiteralPath $script:SaveFolder -Filter 'videoscreenshot_*.log' -File
+        $logs | Should -HaveCount 1
+        (Get-Content -LiteralPath $logs[0].FullName -Raw) | Should -Match 'Run log file:'
+    }
+
+    It 'does not create a run log when -NoLogFile is supplied' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -NoLogFile
+
+        @(Get-ChildItem -LiteralPath $script:SaveFolder -Filter 'videoscreenshot_*.log' -File) | Should -HaveCount 0
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
@@ -13,6 +13,8 @@ BeforeAll {
 
     function Assert-Pwsh7OrThrow { }
     function Write-Message { param([string]$Level, [string]$Message) }
+    function Set-VideoScreenshotLogFile { param([AllowEmptyString()][string]$Path) $script:TestRunLogFile = $Path }
+    function Clear-VideoScreenshotLogFile { $script:TestRunLogFile = $null }
     function New-VideoRunContext {
         param([int]$RequestedFps, [string]$SaveFolder, [string]$RunGuid)
         [pscustomobject]@{

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
@@ -13,6 +13,8 @@ BeforeAll {
 
     function Assert-Pwsh7OrThrow { }
     function Write-Message { param([string]$Level, [string]$Message) }
+    function Set-VideoScreenshotLogFile { param([AllowEmptyString()][string]$Path) $script:TestRunLogFile = $Path }
+    function Clear-VideoScreenshotLogFile { $script:TestRunLogFile = $null }
     function New-VideoRunContext {
         param([int]$RequestedFps, [string]$SaveFolder, [string]$RunGuid)
         [pscustomobject]@{


### PR DESCRIPTION
### Motivation
- Provide a proper per-run persistent log for `Start-VideoBatch` so module and helper messages are captured to a single file without threading `-LogFile` through every internal call site.
- Allow callers to opt-in/override or opt-out of per-run file logging via `-LogFile` and `-NoLogFile`, and make the resolved run-log path discoverable for non-interactive runs.
- Keep file-writing best-effort (warnings only) and preserve existing console/stream behavior while avoiding state leakage across runs.

### Description
- Added a module-scoped run-log sink in `Private/Logging.ps1` with `Set-VideoScreenshotLogFile`, `Get-VideoScreenshotLogFile`, and `Clear-VideoScreenshotLogFile`, and made `Write-Message` fall back to that sink when `-LogFile` is omitted while preserving explicit `-LogFile` precedence.
- Extended `Start-VideoBatch` with `LogFile` and `NoLogFile` parameters, resolve a collision-safe default file name under `SaveFolder` when omitted, create parent directories best-effort, set the module sink at run start, and clear it in a `finally` block.
- Documented the behavior in `README.md` and `CHANGELOG.md`, bumped module `ModuleVersion` to `3.4.0` in `Videoscreenshot.psd1`, and added `tests/powershell/.../Logging.Tests.ps1` plus small test harness updates to stub the new sink helpers.

### Testing
- Ran static/sanity checks: `git diff --check` and a Python-based brace-balance check for modified PowerShell/test files; both passed.
- Added Pester coverage (`tests/powershell/modules/Media/Videoscreenshot/Logging.Tests.ps1`) for explicit `-LogFile`, module-scoped default routing, empty-`-LogFile` opt-out, warning-only write failures, default `Start-VideoBatch` log creation, and `-NoLogFile` opt-out; tests were added but `Invoke-Pester` was not executed in this environment because `pwsh` is not installed.
- Changes committed as `feat(videoscreenshot): add per-run log files` and include the code, docs, changelog, manifest version bump, and tests referenced above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cfca669988325bb8fca534770bd09)