### PR TITLE
Update Black target Python version to 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py312']
+target-version = ['py313']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
## Summary
Updated the Black code formatter configuration to target Python 3.13 instead of Python 3.12.

## Changes
- Updated `target-version` in `pyproject.toml` from `py312` to `py313`

## Details
This change updates the Black formatter's target Python version to align with Python 3.13. Black uses the target version to determine which syntax features and formatting rules to apply. This ensures the codebase is formatted according to Python 3.13 standards and conventions.

https://claude.ai/code/session_01PiJXUX7EXEivT8tcK2cGLx