### PR TITLE
Add Python environment rebuild on requirements file changes

### DIFF
--- a/src/powershell/git/Invoke-PostMergeHook.ps1
+++ b/src/powershell/git/Invoke-PostMergeHook.ps1
@@ -576,4 +576,33 @@ foreach ($rel in $deletedFiles) {
     }
 }
 
+# 5) Rebuild Python environment if requirements files changed.
+$reqFiles = @('requirements.txt', 'requirements.lock')
+$reqChanged = $modifiedFiles | Where-Object { $reqFiles -contains $_ }
+if ($reqChanged) {
+    Write-Message ("Requirements changed ({0}); rebuilding Python environment." -f ($reqChanged -join ', ')) -ToHost
+    $reqLock = Join-Path $script:RepoPath 'requirements.lock'
+    if (Test-Path -LiteralPath $reqLock) {
+        try {
+            $pipResult = & pip install -r $reqLock 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-Message "Python environment rebuilt successfully."
+                Write-Host "Python environment rebuilt successfully."
+            }
+            else {
+                Write-Message ("pip install failed (exit {0}): {1}" -f $LASTEXITCODE, ($pipResult -join ' '))
+                Write-Warning "pip install failed. Check logs for details."
+            }
+        }
+        catch {
+            Write-Message ("pip install error: {0}" -f $_)
+            Write-Warning "pip install encountered an error. Check logs for details."
+        }
+    }
+    else {
+        Write-Message "requirements.lock not found; skipping pip install."
+        Write-Warning "requirements.lock not found at expected path: $reqLock"
+    }
+}
+
 Write-Message "post-merge script execution completed."


### PR DESCRIPTION
## Summary
Added automatic Python environment rebuilding to the post-merge hook when requirements files are modified. This ensures developers have up-to-date dependencies after pulling changes that affect the Python environment.

## Key Changes
- Added detection of changes to `requirements.txt` and `requirements.lock` files in the post-merge hook
- Automatically runs `pip install -r requirements.lock` when requirements files are detected as modified
- Includes comprehensive error handling with logging for pip installation failures
- Provides user-facing warnings when the requirements.lock file is missing or pip install fails
- Gracefully handles cases where requirements.lock doesn't exist by logging a warning instead of failing

## Implementation Details
- Checks both `requirements.txt` and `requirements.lock` for modifications
- Uses the existing `requirements.lock` file as the source of truth for reproducible installs
- Captures pip output and exit codes to provide detailed error messages
- Logs all operations to the message log while also displaying key information to the user via `Write-Host` and `Write-Warning`
- Integrates seamlessly with the existing post-merge hook structure and messaging patterns

https://claude.ai/code/session_01CEvctxusrfCeHQgBXu3g6T