### PR TITLE
feat(videoscreenshot): add scene-change frame extraction

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,18 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-06-03
+### Added
+- **Scene-change frame selection**: `Start-VideoBatch` now accepts `-FrameSelection SceneChange` and `-SceneChangeThreshold` to capture slideshow-style sources by detected content changes rather than fixed VLC `--scene-ratio` intervals.
+- **FFmpeg scene-change backend**: new `Private/Video.SceneChange.ps1` helper builds and runs FFmpeg `select` filter captures while preserving the existing `<video-name>_NNNNN.png` output prefix convention.
+- **Configurable scene-change defaults**: `Get-DefaultConfig` now exposes `FrameSelection` plus `SceneChange.Threshold`, `SceneChange.Backend`, `SceneChange.IncludeFirstFrame`, and `SceneChange.FfmpegArgs`.
+
+### Changed
+- Scene-change mode bypasses VLC entirely when `ffmpeg` is available; when FFmpeg is unavailable, the entrypoint warns and falls back to the existing VLC ratio snapshot path without failing the batch.
+
+### Tests
+- New `tests/.../Video.SceneChange.Tests.ps1` covers FFmpeg argument construction, default ratio-mode preservation, FFmpeg scene-change routing, and graceful VLC fallback when FFmpeg is unavailable.
+
 ## [3.4.1] - 2026-06-01
 ### Changed
 - **Remove `Private/IO.Helpers.ps1`**: `Add-ContentWithRetry` and `Test-FolderWritable` are now resolved from `Core/FileOperations`. The module manifest declares `FileOperations >= 1.0.3` and `ErrorHandling >= 1.1.1` in `RequiredModules`.

--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -16,9 +16,10 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ### Changed
 - Scene-change mode bypasses VLC entirely when `ffmpeg` is available; when FFmpeg is unavailable, the entrypoint warns and falls back to the existing VLC ratio snapshot path without failing the batch.
+- FFmpeg scene-change accounting now treats overwritten matching frame files as captured frames by comparing before/after frame metadata, preventing retry runs from being misclassified as `NoFrames` when `-y` rewrites existing `${ScenePrefix}%05d.png` files.
 
 ### Tests
-- New `tests/.../Video.SceneChange.Tests.ps1` covers FFmpeg argument construction, default ratio-mode preservation, FFmpeg scene-change routing, and graceful VLC fallback when FFmpeg is unavailable.
+- New `tests/.../Video.SceneChange.Tests.ps1` covers FFmpeg argument construction, overwritten-frame accounting, default ratio-mode preservation, FFmpeg scene-change routing, and graceful VLC fallback when FFmpeg is unavailable.
 
 ## [3.4.1] - 2026-06-01
 ### Changed

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Config.ps1
@@ -22,6 +22,7 @@
               SnapshotDurationSlackFactor, SnapshotMinimumTimeoutSeconds,
               SnapshotTerminationExtraSeconds, StopVlcWaitMs, WaitProcessTimeoutSeconds
     - Discovery: VideoExtensions
+    - Frame selection: FrameSelection, SceneChange
     - GDI: GdiCaptureDefaultSeconds
     - Python: RequiredPackages (used by Invoke-Cropper preflight)
 .NOTES
@@ -121,6 +122,26 @@ function Get-DefaultConfig {
         # MaxPerVideoSeconds nor TimeLimitSeconds is provided. This ensures
         # finite capture sessions by default. Typical range: 5–30 s.
         GdiCaptureDefaultSeconds        = 10
+
+        # =========================
+        # Frame selection
+        # =========================
+
+        # Default capture strategy for Start-VideoBatch. 'Ratio' preserves the
+        # existing VLC --scene-ratio cadence; 'SceneChange' opts into FFmpeg's
+        # select=gt(scene,threshold) path to capture one frame per detected
+        # picture change. The public cmdlet defaults to Ratio unless overridden.
+        FrameSelection                  = 'Ratio'
+
+        SceneChange                     = @{
+            # FFmpeg scene scores are normalized from 0.0 to 1.0. Lower values
+            # detect smaller changes; higher values emit fewer frames. 0.35 is a
+            # conservative slideshow-friendly default.
+            Threshold         = 0.35
+            Backend           = 'ffmpeg'
+            IncludeFirstFrame = $true
+            FfmpegArgs        = @('-hide_banner', '-loglevel', 'error', '-nostdin', '-y')
+        }
 
         # =========================
         # VLC process logging

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
@@ -48,6 +48,45 @@ function Get-FfmpegSceneChangeArgs {
     return $args
 }
 
+function Get-SnapshotFrameInventory {
+    param(
+        [Parameter(Mandatory)][string]$SaveFolder,
+        [Parameter(Mandatory)][string]$ScenePrefix
+    )
+
+    $inventory = @{}
+    Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $inventory[$_.FullName] = [pscustomobject]@{
+                Length                = [int64]$_.Length
+                LastWriteTimeUtcTicks = [int64]$_.LastWriteTimeUtc.Ticks
+            }
+        }
+    return $inventory
+}
+
+function Get-SnapshotChangedFrameCount {
+    param(
+        [Parameter(Mandatory)][hashtable]$Before,
+        [Parameter(Mandatory)][hashtable]$After
+    )
+
+    $changed = 0
+    foreach ($path in $After.Keys) {
+        if (-not $Before.ContainsKey($path)) {
+            $changed++
+            continue
+        }
+
+        $pre = $Before[$path]
+        $post = $After[$path]
+        if ($pre.Length -ne $post.Length -or $pre.LastWriteTimeUtcTicks -ne $post.LastWriteTimeUtcTicks) {
+            $changed++
+        }
+    }
+    return $changed
+}
+
 function Invoke-FfmpegSceneChangeCapture {
     param(
         [Parameter(Mandatory)][string]$FfmpegExe,
@@ -68,7 +107,12 @@ function Invoke-FfmpegSceneChangeCapture {
         throw "SaveFolder not found: $SaveFolder"
     }
 
-    $preCount = (Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
+    # Capture both count and metadata before launching FFmpeg. Scene-change runs
+    # intentionally use -y, so retrying a prefix can overwrite *_00001.png etc.
+    # without increasing the directory count. Metadata comparison lets callers
+    # treat overwritten frames as successful captures instead of Failed/NoFrames.
+    $preInventory = Get-SnapshotFrameInventory -SaveFolder $SaveFolder -ScenePrefix $ScenePrefix
+    $preCount = $preInventory.Count
     $outputPattern = Join-Path $SaveFolder ("{0}%05d.png" -f $ScenePrefix)
     $args = Get-FfmpegSceneChangeArgs -VideoPath $VideoPath -OutputPattern $outputPattern -Threshold $Threshold -StopAtSeconds $StopAtSeconds -IncludeFirstFrame $IncludeFirstFrame -BaseArgs $BaseArgs
 
@@ -109,9 +153,14 @@ function Invoke-FfmpegSceneChangeCapture {
         throw ("ffmpeg scene-change capture failed (ExitCode={0}). STDERR: {1}" -f $process.ExitCode, $stderr)
     }
 
-    $postCount = (Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
+    $postInventory = Get-SnapshotFrameInventory -SaveFolder $SaveFolder -ScenePrefix $ScenePrefix
+    $postCount = $postInventory.Count
+    $countDelta = [int]($postCount - $preCount)
+    $changedCount = Get-SnapshotChangedFrameCount -Before $preInventory -After $postInventory
     [pscustomobject]@{
-        FramesDelta        = [int]($postCount - $preCount)
+        FramesDelta        = [int]([Math]::Max($countDelta, $changedCount))
+        FilesChanged       = [int]$changedCount
+        FileCountDelta     = [int]$countDelta
         ElapsedSeconds     = [double]$elapsedSeconds
         HitMaxSeconds      = $false
         ProcessAliveAtExit = $false

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
@@ -37,15 +37,15 @@ function Get-FfmpegSceneChangeArgs {
         "select='gt(scene,$thresholdText)'"
     }
 
-    $args = @()
-    if ($BaseArgs) { $args += $BaseArgs }
-    $args += @('-i', $VideoPath)
+    $ffmpegArgs = @()
+    if ($BaseArgs) { $ffmpegArgs += $BaseArgs }
+    $ffmpegArgs += @('-i', $VideoPath)
     if ($StopAtSeconds -gt 0) {
         $durationText = $StopAtSeconds.ToString('0.###', [Globalization.CultureInfo]::InvariantCulture)
-        $args += @('-t', $durationText)
+        $ffmpegArgs += @('-t', $durationText)
     }
-    $args += @('-vf', $selector, '-vsync', 'vfr', $OutputPattern)
-    return $args
+    $ffmpegArgs += @('-vf', $selector, '-vsync', 'vfr', $OutputPattern)
+    return $ffmpegArgs
 }
 
 function Get-SnapshotFrameInventory {
@@ -114,11 +114,11 @@ function Invoke-FfmpegSceneChangeCapture {
     $preInventory = Get-SnapshotFrameInventory -SaveFolder $SaveFolder -ScenePrefix $ScenePrefix
     $preCount = $preInventory.Count
     $outputPattern = Join-Path $SaveFolder ("{0}%05d.png" -f $ScenePrefix)
-    $args = Get-FfmpegSceneChangeArgs -VideoPath $VideoPath -OutputPattern $outputPattern -Threshold $Threshold -StopAtSeconds $StopAtSeconds -IncludeFirstFrame $IncludeFirstFrame -BaseArgs $BaseArgs
+    $ffmpegArgs = Get-FfmpegSceneChangeArgs -VideoPath $VideoPath -OutputPattern $outputPattern -Threshold $Threshold -StopAtSeconds $StopAtSeconds -IncludeFirstFrame $IncludeFirstFrame -BaseArgs $BaseArgs
 
     $psi = [Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = $FfmpegExe
-    foreach ($arg in $args) { $null = $psi.ArgumentList.Add($arg) }
+    foreach ($arg in $ffmpegArgs) { $null = $psi.ArgumentList.Add($arg) }
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
@@ -127,15 +127,15 @@ function Invoke-FfmpegSceneChangeCapture {
     $process = [Diagnostics.Process]::new()
     $process.StartInfo = $psi
     $startedAt = Get-Date
-    Write-Debug ("Starting ffmpeg scene-change capture: {0} {1}" -f $FfmpegExe, ([string]::Join(' ', $args)))
+    Write-Debug ("Starting ffmpeg scene-change capture: {0} {1}" -f $FfmpegExe, ([string]::Join(' ', $ffmpegArgs)))
     $null = $process.Start()
 
     $timedOut = $false
     if ($TimeoutSeconds -gt 0) {
         if (-not $process.WaitForExit([int]($TimeoutSeconds * 1000))) {
             $timedOut = $true
-            try { $process.Kill($true) } catch { }
-            try { $process.WaitForExit(1000) | Out-Null } catch { }
+            try { $process.Kill($true) } catch { Write-Debug ("Unable to kill timed-out ffmpeg process: {0}" -f $_.Exception.Message) }
+            try { $process.WaitForExit(1000) | Out-Null } catch { Write-Debug ("Unable to wait for timed-out ffmpeg process exit: {0}" -f $_.Exception.Message) }
         }
     }
     else {
@@ -165,7 +165,7 @@ function Invoke-FfmpegSceneChangeCapture {
         HitMaxSeconds      = $false
         ProcessAliveAtExit = $false
         Backend            = 'ffmpeg'
-        Arguments          = [string[]]$args
+        Arguments          = [string[]]$ffmpegArgs
         StdOut             = $stdout
         StdErr             = $stderr
     }

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Video.SceneChange.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+  FFmpeg-backed scene-change snapshot extraction helpers.
+.DESCRIPTION
+  Provides the opt-in scene-change frame-selection path used by Start-VideoBatch.
+  The helper keeps the same output prefix convention as VLC scene snapshots so
+  downstream counting, resume, de-duplication, and cropper steps can remain
+  unchanged.
+#>
+
+function Get-FfmpegCommand {
+    try {
+        $cmd = Get-Command -Name ffmpeg -ErrorAction Stop
+        return $cmd.Source
+    }
+    catch {
+        Write-Debug 'Get-FfmpegCommand: ffmpeg not found on PATH.'
+        return $null
+    }
+}
+
+function Get-FfmpegSceneChangeArgs {
+    param(
+        [Parameter(Mandatory)][string]$VideoPath,
+        [Parameter(Mandatory)][string]$OutputPattern,
+        [ValidateRange(0, 1)][double]$Threshold = 0.35,
+        [double]$StopAtSeconds = 0,
+        [bool]$IncludeFirstFrame = $true,
+        [string[]]$BaseArgs = @('-hide_banner', '-nostdin', '-y')
+    )
+
+    $thresholdText = $Threshold.ToString('0.###', [Globalization.CultureInfo]::InvariantCulture)
+    $selector = if ($IncludeFirstFrame) {
+        "select='eq(n,0)+gt(scene,$thresholdText)'"
+    }
+    else {
+        "select='gt(scene,$thresholdText)'"
+    }
+
+    $args = @()
+    if ($BaseArgs) { $args += $BaseArgs }
+    $args += @('-i', $VideoPath)
+    if ($StopAtSeconds -gt 0) {
+        $durationText = $StopAtSeconds.ToString('0.###', [Globalization.CultureInfo]::InvariantCulture)
+        $args += @('-t', $durationText)
+    }
+    $args += @('-vf', $selector, '-vsync', 'vfr', $OutputPattern)
+    return $args
+}
+
+function Invoke-FfmpegSceneChangeCapture {
+    param(
+        [Parameter(Mandatory)][string]$FfmpegExe,
+        [Parameter(Mandatory)][string]$VideoPath,
+        [Parameter(Mandatory)][string]$SaveFolder,
+        [Parameter(Mandatory)][string]$ScenePrefix,
+        [ValidateRange(0, 1)][double]$Threshold = 0.35,
+        [double]$StopAtSeconds = 0,
+        [int]$TimeoutSeconds = 0,
+        [bool]$IncludeFirstFrame = $true,
+        [string[]]$BaseArgs = @('-hide_banner', '-nostdin', '-y')
+    )
+
+    if (-not (Test-Path -LiteralPath $VideoPath -PathType Leaf)) {
+        throw "VideoPath not found: $VideoPath"
+    }
+    if (-not (Test-Path -LiteralPath $SaveFolder -PathType Container)) {
+        throw "SaveFolder not found: $SaveFolder"
+    }
+
+    $preCount = (Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
+    $outputPattern = Join-Path $SaveFolder ("{0}%05d.png" -f $ScenePrefix)
+    $args = Get-FfmpegSceneChangeArgs -VideoPath $VideoPath -OutputPattern $outputPattern -Threshold $Threshold -StopAtSeconds $StopAtSeconds -IncludeFirstFrame $IncludeFirstFrame -BaseArgs $BaseArgs
+
+    $psi = [Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $FfmpegExe
+    foreach ($arg in $args) { $null = $psi.ArgumentList.Add($arg) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $psi
+    $startedAt = Get-Date
+    Write-Debug ("Starting ffmpeg scene-change capture: {0} {1}" -f $FfmpegExe, ([string]::Join(' ', $args)))
+    $null = $process.Start()
+
+    $timedOut = $false
+    if ($TimeoutSeconds -gt 0) {
+        if (-not $process.WaitForExit([int]($TimeoutSeconds * 1000))) {
+            $timedOut = $true
+            try { $process.Kill($true) } catch { }
+            try { $process.WaitForExit(1000) | Out-Null } catch { }
+        }
+    }
+    else {
+        $process.WaitForExit()
+    }
+
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $elapsedSeconds = [Math]::Max(0.001, ((Get-Date) - $startedAt).TotalSeconds)
+
+    if ($timedOut) {
+        throw ("ffmpeg scene-change capture timed out after {0} second(s). STDERR: {1}" -f $TimeoutSeconds, $stderr)
+    }
+    if ($process.ExitCode -ne 0) {
+        throw ("ffmpeg scene-change capture failed (ExitCode={0}). STDERR: {1}" -f $process.ExitCode, $stderr)
+    }
+
+    $postCount = (Get-ChildItem -Path $SaveFolder -Filter "${ScenePrefix}*.png" -File -ErrorAction SilentlyContinue | Measure-Object).Count
+    [pscustomobject]@{
+        FramesDelta        = [int]($postCount - $preCount)
+        ElapsedSeconds     = [double]$elapsedSeconds
+        HitMaxSeconds      = $false
+        ProcessAliveAtExit = $false
+        Backend            = 'ffmpeg'
+        Arguments          = [string[]]$args
+        StdOut             = $stdout
+        StdErr             = $stderr
+    }
+}

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -34,6 +34,11 @@ Hard cap per video (seconds). Overrides TimeLimitSeconds when > 0.
 Extra seconds added to snapshot wait to absorb VLC startup.
 .PARAMETER UseVlcSnapshots
 Use VLC scene snapshots; otherwise use GDI capture.
+.PARAMETER FrameSelection
+Frame extraction strategy. Ratio preserves the existing fixed VLC --scene-ratio cadence.
+SceneChange uses FFmpeg scene detection when available and falls back to VLC ratio snapshots with a warning when FFmpeg is missing.
+.PARAMETER SceneChangeThreshold
+FFmpeg scene detection threshold (0.0-1.0) used with -FrameSelection SceneChange.
 .PARAMETER GdiFullscreen
 With GDI capture, request fullscreen/top-most playback.
 .PARAMETER VlcStartupTimeoutSeconds
@@ -92,6 +97,10 @@ function Start-VideoBatch {
         [ValidateRange(0, 60)][int]$StartupGraceSeconds = 2,
 
         [switch]$UseVlcSnapshots,
+        [ValidateSet('Ratio', 'SceneChange')]
+        [string]$FrameSelection = 'Ratio',
+        [ValidateRange(0, 1)]
+        [double]$SceneChangeThreshold = 0.35,
         [switch]$GdiFullscreen,
         [int]$VlcStartupTimeoutSeconds = 10,
         # Optional validation / discovery flexibility
@@ -119,9 +128,21 @@ function Start-VideoBatch {
     Assert-Pwsh7OrThrow
 
     # Policy: helpers throw; only this function emits user-facing messages.
-    $mode = ($CropOnly ? 'Crop-only' : ($UseVlcSnapshots ? 'VLC snapshots' : 'GDI+ desktop'))
     $runGuid = [Guid]::NewGuid().ToString('N').Substring(0, 8)
     $context = New-VideoRunContext -RequestedFps $FramesPerSecond -SaveFolder $SaveFolder -RunGuid $runGuid
+    if (-not $PSBoundParameters.ContainsKey('FrameSelection') -and $context.Config -and $context.Config.FrameSelection) {
+        $FrameSelection = [string]$context.Config.FrameSelection
+    }
+    if (-not $PSBoundParameters.ContainsKey('SceneChangeThreshold') -and $context.Config -and $context.Config.SceneChange -and $null -ne $context.Config.SceneChange.Threshold) {
+        $SceneChangeThreshold = [double]$context.Config.SceneChange.Threshold
+    }
+    $useSceneChange = ($FrameSelection -eq 'SceneChange')
+    $sceneChangeBackend = 'ffmpeg'
+    if ($context.Config -and $context.Config.SceneChange -and -not [string]::IsNullOrWhiteSpace([string]$context.Config.SceneChange.Backend)) {
+        $sceneChangeBackend = ([string]$context.Config.SceneChange.Backend).ToLowerInvariant()
+    }
+    if ($useSceneChange) { $UseVlcSnapshots = $true }
+    $mode = ($CropOnly ? 'Crop-only' : ($useSceneChange ? 'Scene-change snapshots' : ($UseVlcSnapshots ? 'VLC snapshots' : 'GDI+ desktop')))
 
     if ($CropOnly -and -not $PSBoundParameters.ContainsKey('SaveFolder')) {
         throw "CropOnly requires -SaveFolder pointing to the folder containing images to crop."
@@ -174,7 +195,7 @@ function Start-VideoBatch {
         # Warn about ignored capture-related parameters if supplied
         $captureParams = @('SourceFolder', 'UseVlcSnapshots', 'FramesPerSecond', 'TimeLimitSeconds', 'MaxPerVideoSeconds',
             'GdiFullscreen', 'VlcStartupTimeoutSeconds', 'VerifyVideos', 'VideoProbeTimeoutSeconds', 'IncludeExtensions',
-            'ClearSnapshotsBeforeRun', 'VideoLimit', 'ResumeFile', 'ProcessedLogPath')
+            'FrameSelection', 'SceneChangeThreshold', 'ClearSnapshotsBeforeRun', 'VideoLimit', 'ResumeFile', 'ProcessedLogPath')
         $ignored = @()
         foreach ($n in $captureParams) {
             if ($PSBoundParameters.ContainsKey($n)) { $ignored += $n }
@@ -236,33 +257,58 @@ function Start-VideoBatch {
         Write-Message -Level Error -Message "SourceFolder not found: $SourceFolder"
         throw "Invalid SourceFolder."
     }
-    $resolvedVlcExe = if (-not [string]::IsNullOrWhiteSpace($VlcExe)) {
-        if (Test-Path -LiteralPath $VlcExe -PathType Leaf) {
-            $VlcExe
-        }
-        elseif (Test-Path -LiteralPath $VlcExe -PathType Container) {
-            # A directory was given — try appending vlc.exe
-            $candidate = Join-Path $VlcExe 'vlc.exe'
-            if (Test-Path -LiteralPath $candidate -PathType Leaf) { $candidate } else {
-                Write-Message -Level Error -Message "vlc.exe not found inside directory: $VlcExe"
-                throw "VLC missing."
+    $resolvedFfmpegExe = $null
+    if ($useSceneChange) {
+        if ($sceneChangeBackend -eq 'ffmpeg') {
+            if (Get-Command Get-FfmpegCommand -ErrorAction SilentlyContinue) {
+                $resolvedFfmpegExe = Get-FfmpegCommand
+            }
+            else {
+                try { $resolvedFfmpegExe = (Get-Command ffmpeg -ErrorAction Stop).Source } catch { $resolvedFfmpegExe = $null }
+            }
+            if ([string]::IsNullOrWhiteSpace($resolvedFfmpegExe)) {
+                Write-Message -Level Warn -Message "FrameSelection=SceneChange requested but ffmpeg was not found on PATH; falling back to VLC --scene-ratio snapshots."
+            }
+            else {
+                Write-Message -Level Info -Message ("FrameSelection=SceneChange using ffmpeg backend (threshold={0})" -f $SceneChangeThreshold)
             }
         }
         else {
-            Write-Message -Level Error -Message "VlcExe not found: $VlcExe"
-            throw "VLC missing."
+            Write-Message -Level Warn -Message ("FrameSelection=SceneChange backend '{0}' is not available; falling back to VLC --scene-ratio snapshots." -f $sceneChangeBackend)
         }
     }
-    elseif (Test-CommandAvailable -CommandName 'vlc') {
-        (Get-Command vlc).Source
-    }
-    else {
-        # Check the default VLC install location on Windows
-        $defaultVlc = Join-Path $env:ProgramFiles 'VideoLAN\VLC\vlc.exe'
-        if (Test-Path -LiteralPath $defaultVlc) { $defaultVlc }
+
+    $requiresVlc = $VerifyVideos -or (-not $useSceneChange) -or [string]::IsNullOrWhiteSpace($resolvedFfmpegExe)
+    $resolvedVlcExe = $null
+    if ($requiresVlc) {
+        $resolvedVlcExe = if (-not [string]::IsNullOrWhiteSpace($VlcExe)) {
+            if (Test-Path -LiteralPath $VlcExe -PathType Leaf) {
+                $VlcExe
+            }
+            elseif (Test-Path -LiteralPath $VlcExe -PathType Container) {
+                # A directory was given — try appending vlc.exe
+                $candidate = Join-Path $VlcExe 'vlc.exe'
+                if (Test-Path -LiteralPath $candidate -PathType Leaf) { $candidate } else {
+                    Write-Message -Level Error -Message "vlc.exe not found inside directory: $VlcExe"
+                    throw "VLC missing."
+                }
+            }
+            else {
+                Write-Message -Level Error -Message "VlcExe not found: $VlcExe"
+                throw "VLC missing."
+            }
+        }
+        elseif (Test-CommandAvailable -CommandName 'vlc') {
+            (Get-Command vlc).Source
+        }
         else {
-            Write-Message -Level Error -Message "VLC (vlc.exe) not found in PATH. Use -VlcExe to specify the path."
-            throw "VLC missing."
+            # Check the default VLC install location on Windows
+            $defaultVlc = Join-Path $env:ProgramFiles 'VideoLAN\VLC\vlc.exe'
+            if (Test-Path -LiteralPath $defaultVlc) { $defaultVlc }
+            else {
+                Write-Message -Level Error -Message "VLC (vlc.exe) not found in PATH. Use -VlcExe to specify the path."
+                throw "VLC missing."
+            }
         }
     }
     # Resolve processed log path and read processed/resume set (P0)
@@ -416,17 +462,7 @@ function Start-VideoBatch {
         $stopAfter = [double]$capSeconds
 
         try {
-            $p = Start-Vlc -Context $context `
-                -VideoPath $video.FullName `
-                -SaveFolder $SaveFolder `
-                -UseVlcSnapshots:$UseVlcSnapshots `
-                -RequestedFps $FramesPerSecond `
-                -StopAtSeconds $stopAfter `
-                -GdiFullscreen:$GdiFullscreen `
-                -StartupTimeoutSeconds $VlcStartupTimeoutSeconds `
-                -VlcExe $resolvedVlcExe `
-                -NoAudio:$NoAudio
-
+            $baseWait = $null
             if ($UseVlcSnapshots) {
                 $baseWait = if ($capSeconds -gt 0) {
                     [int]$capSeconds
@@ -446,19 +482,66 @@ function Start-VideoBatch {
                     }
                 }
                 $waitSeconds = [int]([Math]::Max(1, $baseWait + [int]$StartupGraceSeconds))
-                Write-Debug ("TRACE Start-VideoBatch: about to call Wait-ForSnapshotFrames (MaxSeconds={0}, Prefix={1}, CapSeconds={2})" -f $waitSeconds, $scenePrefix, $capSeconds)
-                $snapStats = Wait-ForSnapshotFrames -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -MaxSeconds $waitSeconds -Process $p `
-                    -IdleTimeoutSeconds ([int]$context.Config.SnapshotIdleTimeoutSeconds) `
-                    -WarmUpSeconds ([int]$context.Config.SnapshotIdleWarmUpSeconds)
-                $snapType = if ($null -ne $snapStats) { $snapStats.GetType().FullName } else { '<null>' }
-                $snapStr = if ($null -ne $snapStats) { $snapStats.ToString() } else { '<null>' }
-                Write-Debug ("TRACE Start-VideoBatch: Wait-ForSnapshotFrames returned type={0} tostring={1}" -f $snapType, $snapStr)
-                if ($null -ne $snapStats -and $snapStats.HitMaxSeconds -and $snapStats.ProcessAliveAtExit) {
-                    $retainVlcLog = $true
-                    Write-Message -Level Warn -Message ("VLC snapshot cap hit while playback was still active for: {0}; marking as timeout/truncation so resume can retry." -f $video.FullName)
+
+                if ($useSceneChange -and -not [string]::IsNullOrWhiteSpace($resolvedFfmpegExe)) {
+                    $includeFirstFrame = $true
+                    $ffmpegBaseArgs = @('-hide_banner', '-loglevel', 'error', '-nostdin', '-y')
+                    if ($context.Config.SceneChange) {
+                        if ($null -ne $context.Config.SceneChange.IncludeFirstFrame) { $includeFirstFrame = [bool]$context.Config.SceneChange.IncludeFirstFrame }
+                        if ($context.Config.SceneChange.FfmpegArgs) { $ffmpegBaseArgs = [string[]]$context.Config.SceneChange.FfmpegArgs }
+                    }
+                    Write-Debug ("TRACE Start-VideoBatch: about to call Invoke-FfmpegSceneChangeCapture (MaxSeconds={0}, Prefix={1}, Threshold={2})" -f $waitSeconds, $scenePrefix, $SceneChangeThreshold)
+                    $snapStats = Invoke-FfmpegSceneChangeCapture `
+                        -FfmpegExe $resolvedFfmpegExe `
+                        -VideoPath $video.FullName `
+                        -SaveFolder $SaveFolder `
+                        -ScenePrefix $scenePrefix `
+                        -Threshold $SceneChangeThreshold `
+                        -StopAtSeconds $stopAfter `
+                        -TimeoutSeconds $waitSeconds `
+                        -IncludeFirstFrame $includeFirstFrame `
+                        -BaseArgs $ffmpegBaseArgs
+                    $snapType = if ($null -ne $snapStats) { $snapStats.GetType().FullName } else { '<null>' }
+                    $snapStr = if ($null -ne $snapStats) { $snapStats.ToString() } else { '<null>' }
+                    Write-Debug ("TRACE Start-VideoBatch: Invoke-FfmpegSceneChangeCapture returned type={0} tostring={1}" -f $snapType, $snapStr)
+                }
+                else {
+                    $p = Start-Vlc -Context $context `
+                        -VideoPath $video.FullName `
+                        -SaveFolder $SaveFolder `
+                        -UseVlcSnapshots:$UseVlcSnapshots `
+                        -RequestedFps $FramesPerSecond `
+                        -StopAtSeconds $stopAfter `
+                        -GdiFullscreen:$GdiFullscreen `
+                        -StartupTimeoutSeconds $VlcStartupTimeoutSeconds `
+                        -VlcExe $resolvedVlcExe `
+                        -NoAudio:$NoAudio
+
+                    Write-Debug ("TRACE Start-VideoBatch: about to call Wait-ForSnapshotFrames (MaxSeconds={0}, Prefix={1}, CapSeconds={2})" -f $waitSeconds, $scenePrefix, $capSeconds)
+                    $snapStats = Wait-ForSnapshotFrames -SaveFolder $SaveFolder -ScenePrefix $scenePrefix -MaxSeconds $waitSeconds -Process $p `
+                        -IdleTimeoutSeconds ([int]$context.Config.SnapshotIdleTimeoutSeconds) `
+                        -WarmUpSeconds ([int]$context.Config.SnapshotIdleWarmUpSeconds)
+                    $snapType = if ($null -ne $snapStats) { $snapStats.GetType().FullName } else { '<null>' }
+                    $snapStr = if ($null -ne $snapStats) { $snapStats.ToString() } else { '<null>' }
+                    Write-Debug ("TRACE Start-VideoBatch: Wait-ForSnapshotFrames returned type={0} tostring={1}" -f $snapType, $snapStr)
+                    if ($null -ne $snapStats -and $snapStats.HitMaxSeconds -and $snapStats.ProcessAliveAtExit) {
+                        $retainVlcLog = $true
+                        Write-Message -Level Warn -Message ("VLC snapshot cap hit while playback was still active for: {0}; marking as timeout/truncation so resume can retry." -f $video.FullName)
+                    }
                 }
             }
             else {
+                $p = Start-Vlc -Context $context `
+                    -VideoPath $video.FullName `
+                    -SaveFolder $SaveFolder `
+                    -UseVlcSnapshots:$UseVlcSnapshots `
+                    -RequestedFps $FramesPerSecond `
+                    -StopAtSeconds $stopAfter `
+                    -GdiFullscreen:$GdiFullscreen `
+                    -StartupTimeoutSeconds $VlcStartupTimeoutSeconds `
+                    -VlcExe $resolvedVlcExe `
+                    -NoAudio:$NoAudio
+
                 $dur = if ($capSeconds -gt 0) { [int]$capSeconds } else { [int]$context.Config.GdiCaptureDefaultSeconds }
                 Write-Debug ("TRACE Start-VideoBatch: about to call Invoke-GdiCapture (DurationSeconds={0}, FPS={1}, Prefix={2})" -f $dur, $FramesPerSecond, $scenePrefix)
                 $gdiStats = Invoke-GdiCapture -DurationSeconds $dur -Fps $FramesPerSecond -SaveFolder $SaveFolder -ScenePrefix $scenePrefix

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -29,12 +29,18 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
    ```powershell
    Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -ProcessedLogPath .\shots\.processed_videos.txt
    ```
+6. **Scene-change extraction for slideshows** – capture a frame when the picture changes instead of every fixed frame interval.
+   ```powershell
+   Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FrameSelection SceneChange -SceneChangeThreshold 0.35
+   ```
 
 ## Parameters
 - `SourceFolder` (string, required for capture): Root folder containing input videos.
 - `SaveFolder` (string, required): Destination folder for captured frames or cropper input.
 - `FramesPerSecond` (int, default module config): Target capture rate (1–60).
-- `UseVlcSnapshots` (switch): Enable VLC scene snapshots; omit to use GDI capture.
+- `UseVlcSnapshots` (switch): Enable VLC scene snapshots; omit to use GDI capture. This is implied when `-FrameSelection SceneChange` is selected.
+- `FrameSelection` (`Ratio` or `SceneChange`, default `Ratio`): Choose the frame extraction strategy. `Ratio` preserves the current fixed VLC `--scene-ratio` cadence. `SceneChange` uses FFmpeg scene-change detection when `ffmpeg` is on PATH, then falls back to the VLC ratio path with a warning when FFmpeg is unavailable.
+- `SceneChangeThreshold` (double, default config value `0.35`): FFmpeg scene threshold for `-FrameSelection SceneChange`; lower values emit more frames, higher values emit fewer frames.
 - `GdiFullscreen` (switch): Ask VLC to run fullscreen/top-most during GDI capture.
 - `TimeLimitSeconds` (int, default config): Per-video capture duration; `0` uses module default.
 - `VideoLimit` (int, default `0`): Maximum number of videos to process (0 = all).
@@ -64,6 +70,7 @@ catch {
 
 ## Performance Considerations
 - VLC snapshot mode generally outperforms GDI capture; prefer `-UseVlcSnapshots` when VLC is available.
+- For image/slideshow-to-video inputs, prefer `-FrameSelection SceneChange` to reduce oversampling of static segments. FFmpeg (`ffmpeg` on PATH) is the preferred backend; when it is missing, the module logs a warning and preserves the existing VLC `--scene-ratio` behavior.
 - Set `FramesPerSecond` conservatively for long runs to reduce I/O and disk usage.
 - Enable `-IncludeExtensions` to skip unsupported formats early and speed up discovery.
 - Processed logs allow resumable runs—point `-ProcessedLogPath` at fast storage to avoid lock contention.
@@ -99,6 +106,26 @@ Use VLC’s scene snapshot filter to write frames directly to disk:
 Import-Module .\src\powershell\module\Videoscreenshot\Videoscreenshot.psd1
 Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots
 ```
+
+### Scene-change snapshot mode (FFmpeg backend)
+
+Use `-FrameSelection SceneChange` when the source is slideshow-like content and you want one frame per distinct picture rather than one frame every fixed decoded-frame interval:
+
+```powershell
+Import-Module .\src\powershell\module\Videoscreenshot\Videoscreenshot.psd1
+Start-VideoBatch `
+  -SourceFolder .\videos `
+  -SaveFolder .\shots `
+  -FrameSelection SceneChange `
+  -SceneChangeThreshold 0.35
+```
+
+Notes:
+- The default remains `-FrameSelection Ratio`, which uses the existing VLC `--scene-ratio` behavior.
+- Scene-change mode prefers `ffmpeg` on PATH and uses its `select` scene-detection filter. The default filter includes the first frame and subsequent frames whose scene score is above the threshold.
+- If `ffmpeg` is unavailable, `Start-VideoBatch` warns and falls back to VLC snapshot ratio extraction instead of failing the run.
+- Output names keep the same `<video-name>_NNNNN.png` prefix convention used by VLC snapshots, so counting, resume logging, `-DeduplicateFrames`, and cropper processing continue to compose unchanged.
+- Defaults can be tuned through `Get-DefaultConfig`: `FrameSelection`, `SceneChange.Threshold`, `SceneChange.Backend`, `SceneChange.IncludeFirstFrame`, and `SceneChange.FfmpegArgs`.
 
 ### Run logs
 

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -125,6 +125,7 @@ Notes:
 - Scene-change mode prefers `ffmpeg` on PATH and uses its `select` scene-detection filter. The default filter includes the first frame and subsequent frames whose scene score is above the threshold.
 - If `ffmpeg` is unavailable, `Start-VideoBatch` warns and falls back to VLC snapshot ratio extraction instead of failing the run.
 - Output names keep the same `<video-name>_NNNNN.png` prefix convention used by VLC snapshots, so counting, resume logging, `-DeduplicateFrames`, and cropper processing continue to compose unchanged.
+- Scene-change mode may overwrite existing files with the same prefix during retry runs because FFmpeg is invoked with `-y`; the module compares before/after frame metadata so overwritten frames are still counted as a successful capture. Use `-ClearSnapshotsBeforeRun` when you want to discard old frames before retrying a video.
 - Defaults can be tuned through `Get-DefaultConfig`: `FrameSelection`, `SceneChange.Threshold`, `SceneChange.Backend`, `SceneChange.IncludeFirstFrame`, and `SceneChange.FfmpegArgs`.
 
 ### Run logs

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.4.1'
+  ModuleVersion     = '3.5.0'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -15,7 +15,8 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.4.1: Remove Private/IO.Helpers.ps1; resolve Test-FolderWritable and Add-ContentWithRetry from Core/FileOperations and replace inline Get-Command availability checks with Test-CommandAvailable from Core/ErrorHandling.
+      ReleaseNotes = '3.5.0: Add opt-in scene-change frame selection via FFmpeg with configurable threshold/backend defaults and VLC ratio fallback when FFmpeg is unavailable.
+3.4.1: Remove Private/IO.Helpers.ps1; resolve Test-FolderWritable and Add-ContentWithRetry from Core/FileOperations and replace inline Get-Command availability checks with Test-CommandAvailable from Core/ErrorHandling.
 3.4.0: Add opt-out per-run logging for Start-VideoBatch via default SaveFolder logs, -LogFile override, and -NoLogFile opt-out. Write-Message now honors a module-scoped sink so helper messages land in the same run log.'
     }
   }

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
@@ -101,6 +101,32 @@ Describe 'Get-FfmpegSceneChangeArgs' {
     }
 }
 
+
+Describe 'Get-SnapshotChangedFrameCount' {
+    It 'counts overwritten matching files whose metadata changed even when the file count is unchanged' {
+        $before = @{
+            '/tmp/slides_00001.png' = [pscustomobject]@{ Length = 10; LastWriteTimeUtcTicks = 100 }
+            '/tmp/slides_00002.png' = [pscustomobject]@{ Length = 20; LastWriteTimeUtcTicks = 200 }
+        }
+        $after = @{
+            '/tmp/slides_00001.png' = [pscustomobject]@{ Length = 10; LastWriteTimeUtcTicks = 101 }
+            '/tmp/slides_00002.png' = [pscustomobject]@{ Length = 20; LastWriteTimeUtcTicks = 200 }
+        }
+
+        Get-SnapshotChangedFrameCount -Before $before -After $after | Should -Be 1
+    }
+
+    It 'counts newly-created matching files as changed frames' {
+        $before = @{}
+        $after = @{
+            '/tmp/slides_00001.png' = [pscustomobject]@{ Length = 10; LastWriteTimeUtcTicks = 100 }
+            '/tmp/slides_00002.png' = [pscustomobject]@{ Length = 20; LastWriteTimeUtcTicks = 200 }
+        }
+
+        Get-SnapshotChangedFrameCount -Before $before -After $after | Should -Be 2
+    }
+}
+
 Describe 'Start-VideoBatch frame selection' {
     BeforeEach {
         $script:Messages = @()

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
@@ -1,0 +1,158 @@
+<#
+.SYNOPSIS
+Pester tests for scene-change frame selection.
+#>
+
+BeforeAll {
+    $script:SceneChangePath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Private' 'Video.SceneChange.ps1'
+    $script:StartPath = Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'src' 'powershell' 'modules' 'Media' 'Videoscreenshot' 'Public' 'Start-VideoBatch.ps1'
+    foreach ($path in @($script:SceneChangePath, $script:StartPath)) {
+        if (-not (Test-Path -LiteralPath $path)) { throw "Required file not found: $path" }
+        . $path
+    }
+
+    function Assert-Pwsh7OrThrow { }
+    function Set-VideoScreenshotLogFile { param([AllowEmptyString()][string]$Path) }
+    function Clear-VideoScreenshotLogFile { }
+    function Write-Message {
+        param([string]$Level, [string]$Message)
+        $script:Messages += [pscustomobject]@{ Level = $Level; Message = $Message }
+    }
+    function New-VideoRunContext {
+        param([int]$RequestedFps, [string]$SaveFolder, [string]$RunGuid)
+        [pscustomobject]@{
+            Version      = 'test'
+            Config       = @{
+                VideoExtensions                 = @('.mp4')
+                VideoProbeTimeoutSeconds        = 1
+                SnapshotFallbackTimeoutSeconds  = 1
+                SnapshotDurationSlackFactor     = 2.0
+                SnapshotMinimumTimeoutSeconds   = 2
+                SnapshotDurationGraceSeconds    = 1
+                SnapshotIdleTimeoutSeconds      = 0
+                SnapshotIdleWarmUpSeconds       = 0
+                GdiCaptureDefaultSeconds        = 1
+                FrameSelection                  = 'Ratio'
+                SceneChange                     = @{
+                    Threshold         = 0.35
+                    Backend           = 'ffmpeg'
+                    IncludeFirstFrame = $true
+                    FfmpegArgs        = @('-hide_banner', '-loglevel', 'error', '-nostdin', '-y')
+                }
+            }
+            RunGuid      = $RunGuid
+            SaveFolder   = $SaveFolder
+            RequestedFps = $RequestedFps
+        }
+    }
+    function Test-FolderWritable { param([string]$Path) New-Item -ItemType Directory -Path $Path -Force | Out-Null; return $true }
+    function Test-CommandAvailable { param([string]$CommandName) return $false }
+    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
+    function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
+    function Write-ProcessedLog { param([string]$Path, [string]$VideoPath, [string]$Status, [string]$Reason = '') }
+    function Get-VideoDuration { param([string]$Path) return 1 }
+    function Wait-ForSnapshotFrames {
+        param([string]$SaveFolder, [string]$ScenePrefix, [int]$MaxSeconds, $Process, [int]$IdleTimeoutSeconds, [int]$WarmUpSeconds)
+        $script:WaitSnapshotCalls++
+        Set-Content -LiteralPath (Join-Path $SaveFolder ("{0}00001.png" -f $ScenePrefix)) -Value 'png' -NoNewline
+        [pscustomobject]@{ FramesDelta = 1; ElapsedSeconds = 1; HitMaxSeconds = $false; ProcessAliveAtExit = $false }
+    }
+    function Start-Vlc {
+        $script:StartVlcCalls++
+        [pscustomobject]@{ Id = 123 }
+    }
+    function Stop-Vlc { param($Context, $Process) $script:StopVlcCalls++ }
+    function Invoke-GdiCapture { throw 'Invoke-GdiCapture should not be called in these tests.' }
+    function Get-FfmpegCommand { return $script:FfmpegCommand }
+    function Invoke-FfmpegSceneChangeCapture {
+        param(
+            [string]$FfmpegExe,
+            [string]$VideoPath,
+            [string]$SaveFolder,
+            [string]$ScenePrefix,
+            [double]$Threshold,
+            [double]$StopAtSeconds,
+            [int]$TimeoutSeconds,
+            [bool]$IncludeFirstFrame,
+            [string[]]$BaseArgs
+        )
+        $script:FfmpegCalls += [pscustomobject]@{
+            FfmpegExe         = $FfmpegExe
+            Threshold         = $Threshold
+            TimeoutSeconds    = $TimeoutSeconds
+            IncludeFirstFrame = $IncludeFirstFrame
+            BaseArgs          = $BaseArgs
+        }
+        Set-Content -LiteralPath (Join-Path $SaveFolder ("{0}00001.png" -f $ScenePrefix)) -Value 'png' -NoNewline
+        [pscustomobject]@{ FramesDelta = 1; ElapsedSeconds = 1; HitMaxSeconds = $false; ProcessAliveAtExit = $false; Backend = 'ffmpeg' }
+    }
+}
+
+Describe 'Get-FfmpegSceneChangeArgs' {
+    It 'builds an ffmpeg select filter with the threshold and output pattern' {
+        $args = Get-FfmpegSceneChangeArgs -VideoPath '/tmp/input.mp4' -OutputPattern '/tmp/out/video_%05d.png' -Threshold 0.42 -StopAtSeconds 12
+
+        $args | Should -Contain '-vf'
+        $args | Should -Contain "select='eq(n,0)+gt(scene,0.42)'"
+        $args | Should -Contain '-t'
+        $args | Should -Contain '12'
+        $args[-1] | Should -Be '/tmp/out/video_%05d.png'
+    }
+}
+
+Describe 'Start-VideoBatch frame selection' {
+    BeforeEach {
+        $script:Messages = @()
+        $script:FfmpegCalls = @()
+        $script:StartVlcCalls = 0
+        $script:StopVlcCalls = 0
+        $script:WaitSnapshotCalls = 0
+        $script:FfmpegCommand = $null
+
+        $script:SourceFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-scene-source-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        $script:SaveFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-scene-save-{0}" -f [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:SourceFolder, $script:SaveFolder -Force | Out-Null
+        $script:VideoPath = Join-Path $script:SourceFolder 'slides.mp4'
+        Set-Content -LiteralPath $script:VideoPath -Value 'fake video' -NoNewline
+        $script:FakeVlc = Join-Path $script:SourceFolder 'vlc.exe'
+        Set-Content -LiteralPath $script:FakeVlc -Value 'fake vlc' -NoNewline
+    }
+
+    AfterEach {
+        foreach ($path in @($script:SourceFolder, $script:SaveFolder)) {
+            if ($path -and (Test-Path -LiteralPath $path -ErrorAction SilentlyContinue)) {
+                Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'preserves ratio mode by default' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -UseVlcSnapshots -VlcExe $script:FakeVlc
+
+        $script:StartVlcCalls | Should -Be 1
+        $script:WaitSnapshotCalls | Should -Be 1
+        $script:FfmpegCalls | Should -HaveCount 0
+    }
+
+    It 'routes scene-change mode to ffmpeg when available' {
+        $script:FfmpegCommand = '/usr/bin/ffmpeg'
+
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -FrameSelection SceneChange -SceneChangeThreshold 0.25
+
+        $script:FfmpegCalls | Should -HaveCount 1
+        $script:FfmpegCalls[0].FfmpegExe | Should -Be '/usr/bin/ffmpeg'
+        $script:FfmpegCalls[0].Threshold | Should -Be 0.25
+        $script:StartVlcCalls | Should -Be 0
+        $script:WaitSnapshotCalls | Should -Be 0
+    }
+
+    It 'warns and falls back to VLC ratio snapshots when ffmpeg is unavailable' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -FrameSelection SceneChange -VlcExe $script:FakeVlc
+
+        $script:FfmpegCalls | Should -HaveCount 0
+        $script:StartVlcCalls | Should -Be 1
+        $script:WaitSnapshotCalls | Should -Be 1
+        ($script:Messages | Where-Object { $_.Level -eq 'Warn' -and $_.Message -match 'ffmpeg was not found' }) | Should -HaveCount 1
+    }
+}

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
@@ -92,13 +92,13 @@ BeforeAll {
 
 Describe 'Get-FfmpegSceneChangeArgs' {
     It 'builds an ffmpeg select filter with the threshold and output pattern' {
-        $args = Get-FfmpegSceneChangeArgs -VideoPath '/tmp/input.mp4' -OutputPattern '/tmp/out/video_%05d.png' -Threshold 0.42 -StopAtSeconds 12
+        $ffmpegArgs = Get-FfmpegSceneChangeArgs -VideoPath '/tmp/input.mp4' -OutputPattern '/tmp/out/video_%05d.png' -Threshold 0.42 -StopAtSeconds 12
 
-        $args | Should -Contain '-vf'
-        $args | Should -Contain "select='eq(n,0)+gt(scene,0.42)'"
-        $args | Should -Contain '-t'
-        $args | Should -Contain '12'
-        $args[-1] | Should -Be '/tmp/out/video_%05d.png'
+        $ffmpegArgs | Should -Contain '-vf'
+        $ffmpegArgs | Should -Contain "select='eq(n,0)+gt(scene,0.42)'"
+        $ffmpegArgs | Should -Contain '-t'
+        $ffmpegArgs | Should -Contain '12'
+        $ffmpegArgs[-1] | Should -Be '/tmp/out/video_%05d.png'
     }
 }
 

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
@@ -50,6 +50,7 @@ BeforeAll {
     function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
     function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
     function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
+    function Unregister-RunPid { param($Context, [int]$ProcessId) $script:UnregisterRunPidCalls++ }
     function Write-ProcessedLog { param([string]$Path, [string]$VideoPath, [string]$Status, [string]$Reason = '') }
     function Get-VideoDuration { param([string]$Path) return 1 }
     function Wait-ForSnapshotFrames {
@@ -133,6 +134,7 @@ Describe 'Start-VideoBatch frame selection' {
         $script:FfmpegCalls = @()
         $script:StartVlcCalls = 0
         $script:StopVlcCalls = 0
+        $script:UnregisterRunPidCalls = 0
         $script:WaitSnapshotCalls = 0
         $script:FfmpegCommand = $null
 
@@ -158,6 +160,7 @@ Describe 'Start-VideoBatch frame selection' {
 
         $script:StartVlcCalls | Should -Be 1
         $script:WaitSnapshotCalls | Should -Be 1
+        $script:UnregisterRunPidCalls | Should -Be 1
         $script:FfmpegCalls | Should -HaveCount 0
     }
 
@@ -179,6 +182,7 @@ Describe 'Start-VideoBatch frame selection' {
         $script:FfmpegCalls | Should -HaveCount 0
         $script:StartVlcCalls | Should -Be 1
         $script:WaitSnapshotCalls | Should -Be 1
+        $script:UnregisterRunPidCalls | Should -Be 1
         ($script:Messages | Where-Object { $_.Level -eq 'Warn' -and $_.Message -match 'ffmpeg was not found' }) | Should -HaveCount 1
     }
 }


### PR DESCRIPTION
### Motivation
- Provide an alternative frame-extraction strategy for slideshow / image-heavy videos that selects frames on scene changes instead of a fixed `--scene-ratio` cadence. 
- Prefer an FFmpeg-based backend when available to reduce oversampling of static segments while falling back to the existing VLC snapshot mode when FFmpeg is not present. 

### Description
- Add `Private/Video.SceneChange.ps1` with `Get-FfmpegCommand`, `Get-FfmpegSceneChangeArgs`, and `Invoke-FfmpegSceneChangeCapture` to build/run FFmpeg `select`-filter captures and return snapshot-compatible stats. 
- Add `-FrameSelection` (`Ratio`|`SceneChange`) and `-SceneChangeThreshold` parameters to `Start-VideoBatch`, wire config-driven defaults from `Get-DefaultConfig`, and route SceneChange runs to FFmpeg when found, otherwise warn and fall back to VLC snapshots. 
- Update `Get-DefaultConfig` to expose `FrameSelection` and `SceneChange` defaults, bump module `ModuleVersion` to `3.5.0`, and update `CHANGELOG.md` / `README.md` with usage and notes. 
- Add Pester tests `tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1` covering FFmpeg arg construction, default ratio behavior, FFmpeg routing, and graceful VLC fallback. 

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Added Pester coverage for the new scene-change helpers and entrypoint routing, but running `Invoke-Pester` was not possible in this environment because `pwsh` is not installed. 
- Static edits include the manifest bump to `3.5.0` and changelog/README updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203235ec6c832588248e9d7660f209)