### PR TITLE
feat(videoscreenshot): add -RetryUnplayable to re-attempt stale Skipped/NotPlayable resume entries

### DIFF
--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -8,6 +8,19 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-03
+### Added
+- **`-RetryUnplayable` switch** on `Start-VideoBatch`: opt in to re-attempt previously logged `Skipped`/`NotPlayable` videos instead of keeping stale pre-flight exclusions in the resume skip set. This recovers processed logs written by older probe versions that could falsely classify playable videos as unplayable.
+
+### Changed
+- `Get-ResumeIndex` now accepts `-RetryUnplayable` and leaves only `Skipped`/`NotPlayable` rows retry-eligible when requested; default resume behavior is unchanged, and `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` remain retry-eligible by default.
+
+### Docs
+- Documented the `-RetryUnplayable` recovery flow and the manual processed-log purge workaround for stale `NotPlayable` rows.
+
+### Tests
+- Expanded processed-log and `Start-VideoBatch` pre-flight coverage for default `NotPlayable` skipping, opt-in `NotPlayable` retry, and preserved retry behavior for other statuses.
+
 ## [3.5.0] - 2026-06-03
 ### Added
 - **Scene-change frame selection**: `Start-VideoBatch` now accepts `-FrameSelection SceneChange` and `-SceneChangeThreshold` to capture slideshow-style sources by detected content changes rather than fixed VLC `--scene-ratio` intervals.

--- a/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
+++ b/src/powershell/modules/Media/Videoscreenshot/CHANGELOG.md
@@ -14,6 +14,7 @@ The project follows [Semantic Versioning](https://semver.org) and the structure 
 
 ### Changed
 - `Get-ResumeIndex` now accepts `-RetryUnplayable` and leaves only `Skipped`/`NotPlayable` rows retry-eligible when requested; default resume behavior is unchanged, and `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` remain retry-eligible by default.
+- `-RetryUnplayable` is appended to the `Start-VideoBatch` parameter list so existing positional bindings for `-LogFile` and later parameters are preserved.
 
 ### Docs
 - Documented the `-RetryUnplayable` recovery flow and the manual processed-log purge workaround for stale `NotPlayable` rows.

--- a/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Private/Processed.Log.ps1
@@ -20,7 +20,8 @@ function Resolve-VideoPath {
 function Convert-ProcessedLogLineToResumePath {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Line
+        [Parameter(Mandatory)][string]$Line,
+        [switch]$RetryUnplayable
     )
 
     if ([string]::IsNullOrWhiteSpace($Line)) { return $null }
@@ -33,7 +34,7 @@ function Convert-ProcessedLogLineToResumePath {
     $isTsv = $columns.Count -gt 1
     $status = if ($isTsv) { $columns[1] } else { 'Processed' }
     $reason = if ($columns.Count -ge 3) { $columns[2] } else { '' }
-    $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status $status -Reason $reason -LegacyEntry:(-not $isTsv)
+    $shouldSkip = Test-ProcessedLogEntryShouldSkip -Status $status -Reason $reason -LegacyEntry:(-not $isTsv) -RetryUnplayable:$RetryUnplayable
 
     if (-not $shouldSkip -or [string]::IsNullOrWhiteSpace($rawPath)) { return $null }
 
@@ -50,7 +51,8 @@ function Test-ProcessedLogEntryShouldSkip {
     param(
         [Parameter(Mandatory)][string]$Status,
         [string]$Reason = '',
-        [switch]$LegacyEntry
+        [switch]$LegacyEntry,
+        [switch]$RetryUnplayable
     )
 
     if ($LegacyEntry) { return $true }
@@ -63,7 +65,10 @@ function Test-ProcessedLogEntryShouldSkip {
     }
 
     if ($normalizedStatus.Equals('Skipped', [StringComparison]::OrdinalIgnoreCase)) {
-        return $normalizedReason.Equals('NotPlayable', [StringComparison]::OrdinalIgnoreCase)
+        if ($normalizedReason.Equals('NotPlayable', [StringComparison]::OrdinalIgnoreCase)) {
+            return (-not $RetryUnplayable)
+        }
+        return $false
     }
 
     return $false
@@ -80,19 +85,23 @@ function Test-ProcessedLogEntryShouldSkip {
 
   TSV rows are status-aware: only successful `Processed` rows, excluding
   `Processed`/`NoFrames`, and deliberate `Skipped`/`NotPlayable` rows are added to
-  the resume skip set. Retry-eligible rows such as `Failed`, `TimedOutProcessed`,
-  `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` are not skipped. Legacy
-  single-column rows are treated as successful `Processed` entries for backward
-  compatibility.
+  the resume skip set by default. Retry-eligible rows such as `Failed`,
+  `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError`
+  are not skipped. Legacy single-column rows are treated as successful
+  `Processed` entries for backward compatibility.
 .PARAMETER Path
   Path to the processed log. The file may be missing (returns an empty set).
+.PARAMETER RetryUnplayable
+  Leave `Skipped`/`NotPlayable` rows out of the skip set so they are re-attempted
+  on the next resume run.
 .OUTPUTS
   [System.Collections.Generic.HashSet[string]]
 #>
 function Get-ResumeIndex {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Path
+        [Parameter(Mandatory)][string]$Path,
+        [switch]$RetryUnplayable
     )
     # Case-insensitive by default on Windows; keeps behavior stable cross-platform.
     $set = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
@@ -102,7 +111,7 @@ function Get-ResumeIndex {
     }
     try {
         Get-Content -LiteralPath $Path -ErrorAction Stop | ForEach-Object {
-            $full = Convert-ProcessedLogLineToResumePath -Line $_
+            $full = Convert-ProcessedLogLineToResumePath -Line $_ -RetryUnplayable:$RetryUnplayable
             if (-not [string]::IsNullOrWhiteSpace($full)) {
                 [void]$set.Add($full)
             }

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -28,8 +28,6 @@ empty string or use -NoLogFile to keep console-only output.
 Disable the per-run log file while keeping console stream behavior unchanged.
 .PARAMETER ResumeFile
 Optional file path/name to resume after.
-.PARAMETER RetryUnplayable
-Re-attempt previously logged Skipped/NotPlayable videos instead of keeping them in the resume skip set. Use after upgrading from a version that could false-skip playable videos during -VerifyVideos.
 .PARAMETER MaxPerVideoSeconds
 Hard cap per video (seconds). Overrides TimeLimitSeconds when > 0.
 .PARAMETER StartupGraceSeconds
@@ -74,6 +72,8 @@ Full path to vlc.exe. Use when VLC is not on PATH (e.g. "D:\Program Files\VideoL
 Pass --no-audio to VLC. Use when the VLC audio plugin crashes on your system (e.g. libmmdevice_plugin.dll access violation).
 .PARAMETER DeduplicateFrames
 After each video capture, remove consecutive duplicate frames whose file bytes are identical. One frame per distinct image is kept. Default off; enable for image/slideshow MP4 conversions that produce long runs of identical frames (e.g. picconvert output). Frame counts and status logging reflect the kept frames after de-dup runs.
+.PARAMETER RetryUnplayable
+Re-attempt previously logged Skipped/NotPlayable videos instead of keeping them in the resume skip set. Use after upgrading from a version that could false-skip playable videos during -VerifyVideos.
 
 .EXAMPLE
 Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -UseVlcSnapshots -RunCropper -PythonScriptPath .\src\python\media\crop_colours.py
@@ -90,7 +90,6 @@ function Start-VideoBatch {
         # Resume, processed logging, and run logging
         [string]$ProcessedLogPath,
         [string]$ResumeFile,
-        [switch]$RetryUnplayable,
         [AllowEmptyString()]
         [string]$LogFile,
         [switch]$NoLogFile,
@@ -124,7 +123,8 @@ function Start-VideoBatch {
 
         [string]$VlcExe,
         [switch]$NoAudio,
-        [switch]$DeduplicateFrames
+        [switch]$DeduplicateFrames,
+        [switch]$RetryUnplayable
     )
 
     # Enforce pwsh 7+ at runtime (friendly error if invoked directly)

--- a/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
+++ b/src/powershell/modules/Media/Videoscreenshot/Public/Start-VideoBatch.ps1
@@ -28,6 +28,8 @@ empty string or use -NoLogFile to keep console-only output.
 Disable the per-run log file while keeping console stream behavior unchanged.
 .PARAMETER ResumeFile
 Optional file path/name to resume after.
+.PARAMETER RetryUnplayable
+Re-attempt previously logged Skipped/NotPlayable videos instead of keeping them in the resume skip set. Use after upgrading from a version that could false-skip playable videos during -VerifyVideos.
 .PARAMETER MaxPerVideoSeconds
 Hard cap per video (seconds). Overrides TimeLimitSeconds when > 0.
 .PARAMETER StartupGraceSeconds
@@ -88,6 +90,7 @@ function Start-VideoBatch {
         # Resume, processed logging, and run logging
         [string]$ProcessedLogPath,
         [string]$ResumeFile,
+        [switch]$RetryUnplayable,
         [AllowEmptyString()]
         [string]$LogFile,
         [switch]$NoLogFile,
@@ -195,7 +198,7 @@ function Start-VideoBatch {
         # Warn about ignored capture-related parameters if supplied
         $captureParams = @('SourceFolder', 'UseVlcSnapshots', 'FramesPerSecond', 'TimeLimitSeconds', 'MaxPerVideoSeconds',
             'GdiFullscreen', 'VlcStartupTimeoutSeconds', 'VerifyVideos', 'VideoProbeTimeoutSeconds', 'IncludeExtensions',
-            'FrameSelection', 'SceneChangeThreshold', 'ClearSnapshotsBeforeRun', 'VideoLimit', 'ResumeFile', 'ProcessedLogPath')
+            'FrameSelection', 'SceneChangeThreshold', 'ClearSnapshotsBeforeRun', 'VideoLimit', 'ResumeFile', 'ProcessedLogPath', 'RetryUnplayable')
         $ignored = @()
         foreach ($n in $captureParams) {
             if ($PSBoundParameters.ContainsKey($n)) { $ignored += $n }
@@ -320,7 +323,7 @@ function Start-VideoBatch {
     }
     # Always produce a usable HashSet for O(1) membership checks; log diagnostics.
     try {
-        $processedSet = Get-ResumeIndex -Path $processedLog
+        $processedSet = Get-ResumeIndex -Path $processedLog -RetryUnplayable:$RetryUnplayable
     }
     catch {
         Write-Message -Level Warn -Message ("Resume index read failed ('{0}'): {1}" -f $processedLog, $_.Exception.Message)

--- a/src/powershell/modules/Media/Videoscreenshot/README.md
+++ b/src/powershell/modules/Media/Videoscreenshot/README.md
@@ -29,6 +29,10 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
    ```powershell
    Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -ProcessedLogPath .\shots\.processed_videos.txt
    ```
+   If an older `-VerifyVideos` run falsely logged playable files as `Skipped`/`NotPlayable`, re-attempt them with:
+   ```powershell
+   Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -RetryUnplayable
+   ```
 6. **Scene-change extraction for slideshows** – capture a frame when the picture changes instead of every fixed frame interval.
    ```powershell
    Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FrameSelection SceneChange -SceneChangeThreshold 0.35
@@ -54,6 +58,7 @@ Start-VideoBatch -SourceFolder .\videos -SaveFolder .\shots -FramesPerSecond 2 -
 - `ReprocessCropped` (switch): Force re-crop even if images were processed before.
 - `KeepExistingCrops` (switch): Preserve existing crops when reprocessing.
 - `ProcessedLogPath` (string): Location of the processed/resume log under `SaveFolder` by default.
+- `RetryUnplayable` (switch): Re-attempt `Skipped`/`NotPlayable` rows from the processed log on this run. Default off, so confirmed-unplayable videos remain skipped unless you explicitly request recovery.
 - `LogFile` (string): Optional run-log path for timestamped module messages. When omitted, `Start-VideoBatch` creates `videoscreenshot_<yyyyMMdd_HHmmss>_<RunGuid>.log` under `SaveFolder`. Pass an empty string to opt out.
 - `NoLogFile` (switch): Disable the run log file while keeping console output unchanged.
 
@@ -75,7 +80,7 @@ catch {
 - Enable `-IncludeExtensions` to skip unsupported formats early and speed up discovery.
 - Processed logs allow resumable runs—point `-ProcessedLogPath` at fast storage to avoid lock contention.
 - Run logs are enabled by default under `SaveFolder`; use `-LogFile` for a central logs directory or `-NoLogFile` for console-only smoke tests.
-- Use `-VerifyVideos` (`-PreflightProbe`/`-SkipUnplayable`) to skip corrupt or unsupported files before launching the main VLC capture session; tune the bounded probe with `-VideoProbeTimeoutSeconds` (default `10`). The probe no longer false-skips chatty codecs (AV1/VP9) due to the pipe-buffer deadlock fix.
+- Use `-VerifyVideos` (`-PreflightProbe`/`-SkipUnplayable`) to skip corrupt or unsupported files before launching the main VLC capture session; tune the bounded probe with `-VideoProbeTimeoutSeconds` (default `10`). The probe no longer false-skips chatty codecs (AV1/VP9) due to the pipe-buffer deadlock fix. If an older run already wrote stale `Skipped`/`NotPlayable` rows, rerun with `-RetryUnplayable` after upgrading.
 - Cropper runs can be CPU intensive; use `-VideoLimit`/`-TimeLimitSeconds` to batch work into smaller chunks.
 
 ## Usage
@@ -203,7 +208,7 @@ Start-VideoBatch `
 ```
 * -IncludeExtensions overrides the discovery set (defaults come from module config).
 * `-VerifyVideos` attempts a lightweight, bounded `Test-VideoPlayable` check before the main VLC session. `-PreflightProbe` and `-SkipUnplayable` are aliases for the same switch. The probe no longer redirects stdout/stderr — VLC writes to a temp sidecar logfile — so chatty-but-playable videos (e.g. AV1/VP9 clips with verbose startup output) are no longer falsely reported as `NotPlayable`.
-* If the probe returns false or times out, the video is logged as `Skipped`/`NotPlayable` in the processed log and skipped on later resume runs. Probe errors are logged as `Skipped`/`VideoProbeError` and retried on resume.
+* If the probe returns false or times out, the video is logged as `Skipped`/`NotPlayable` in the processed log and skipped on later resume runs. Probe errors are logged as `Skipped`/`VideoProbeError` and retried on resume. Use `-RetryUnplayable` on a recovery run to re-attempt stale `NotPlayable` rows after upgrading from a version that could false-skip playable videos.
 * `-VideoProbeTimeoutSeconds` controls the force-kill deadline for the probe; omit it to use `VideoProbeTimeoutSeconds` from module config (default `10`).
 
 #### What the cropper flags do
@@ -241,7 +246,8 @@ The module tracks which videos have been handled so future runs can skip work.
 - Entries are normalized to absolute provider paths at import time.
 - On Windows, matching is case-insensitive to minimize false mismatches.
 - Resume parsing is status-aware for TSV rows: successful `Processed` rows are skipped, except `Processed`/`NoFrames`, which is retried for compatibility with older logs.
-- `Skipped`/`NotPlayable` rows remain skipped because they represent deliberate pre-flight exclusions; `Failed`, `TimedOutProcessed`, and `Skipped`/`VideoProbeError` rows are retried automatically on the next run.
+- `Skipped`/`NotPlayable` rows remain skipped by default because they represent deliberate pre-flight exclusions; add `-RetryUnplayable` to leave those rows out of the skip set and re-attempt them on the next run.
+- `Failed`, `TimedOutProcessed`, `Processed`/`NoFrames`, and `Skipped`/`VideoProbeError` rows are retried automatically on the next run.
 - New zero-frame captures are written as `Failed`/`NoFrames` so the log accurately marks them as incomplete and retry-eligible.
 - Mixing TSV and legacy lines in the same file is supported; legacy single-column rows are treated as successful `Processed` rows and skipped as before; new writes use TSV.
 
@@ -373,6 +379,7 @@ On Windows (example):
   TSV (`<FullPath>\t<Status>[\t<Reason>]`) **and** legacy single-column (`<FullPath>`) lines. Paths are
   normalized to absolute; on Windows matching is case-insensitive. You can also point to an existing file
   via `-ProcessedLogPath`. `Start-VideoBatch` honors `-ResumeFile` by skipping items up to that file.
+- **False `NotPlayable` skips after an older `-VerifyVideos` run**: upgrade to the fixed module, then rerun with `-RetryUnplayable` so `Skipped`/`NotPlayable` rows are not included in the resume skip set. Zero-flag workaround: edit `<SaveFolder>\.processed_videos.txt` (or your `-ProcessedLogPath`) and delete only the lines whose status/reason columns are `Skipped` and `NotPlayable`, then rerun normally.
 - **Crash: “There is no Runspace available to run scripts in this thread.”**
   This was caused by emitting PowerShell debug output from background stream handlers.
   Fixed in earlier patch releases; update to the latest version.

--- a/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
+++ b/src/powershell/modules/Media/Videoscreenshot/Videoscreenshot.psd1
@@ -1,6 +1,6 @@
 @{
   RootModule        = 'Videoscreenshot.psm1'
-  ModuleVersion     = '3.5.0'
+  ModuleVersion     = '3.6.0'
   GUID              = '7a5f7b2d-5d7b-4b63-9f25-ef6d6b4f9b2f'
   Author            = 'Manoj Bhaskaran'
   CompanyName       = ''
@@ -15,7 +15,8 @@
   PrivateData       = @{
     PSData = @{
       Tags         = @('video','vlc','gdi','screenshots','crop','python','images','automation')
-      ReleaseNotes = '3.5.0: Add opt-in scene-change frame selection via FFmpeg with configurable threshold/backend defaults and VLC ratio fallback when FFmpeg is unavailable.
+      ReleaseNotes = '3.6.0: Add -RetryUnplayable to re-attempt stale Skipped/NotPlayable resume-log entries after probe false-skips.
+3.5.0: Add opt-in scene-change frame selection via FFmpeg with configurable threshold/backend defaults and VLC ratio fallback when FFmpeg is unavailable.
 3.4.1: Remove Private/IO.Helpers.ps1; resolve Test-FolderWritable and Add-ContentWithRetry from Core/FileOperations and replace inline Get-Command availability checks with Test-CommandAvailable from Core/ErrorHandling.
 3.4.0: Add opt-out per-run logging for Start-VideoBatch via default SaveFolder logs, -LogFile override, and -NoLogFile opt-out. Write-Message now honors a module-scoped sink so helper messages land in the same run log.'
     }

--- a/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Processed.Log.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Get-ResumeIndex processed-log status handling' {
         }
     }
 
-    It 'skips only true successes and deliberately unplayable videos' {
+    It 'skips only true successes and deliberately unplayable videos by default' {
         $processed = Join-Path $script:TempRoot 'processed.mp4'
         $notPlayable = Join-Path $script:TempRoot 'not-playable.mp4'
         $failed = Join-Path $script:TempRoot 'failed.mp4'
@@ -47,6 +47,34 @@ Describe 'Get-ResumeIndex processed-log status handling' {
 
         $index.Contains((Resolve-VideoPath -Path $processed)) | Should -BeTrue
         $index.Contains((Resolve-VideoPath -Path $notPlayable)) | Should -BeTrue
+        $index.Contains((Resolve-VideoPath -Path $failed)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $noFrames)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $probeError)) | Should -BeFalse
+        $index.Contains((Resolve-VideoPath -Path $timedOut)) | Should -BeFalse
+    }
+
+
+    It 'retries NotPlayable entries when RetryUnplayable is set while preserving other status behavior' {
+        $processed = Join-Path $script:TempRoot 'processed.mp4'
+        $notPlayable = Join-Path $script:TempRoot 'not-playable.mp4'
+        $failed = Join-Path $script:TempRoot 'failed.mp4'
+        $noFrames = Join-Path $script:TempRoot 'no-frames.mp4'
+        $probeError = Join-Path $script:TempRoot 'probe-error.mp4'
+        $timedOut = Join-Path $script:TempRoot 'timed-out.mp4'
+
+        Set-Content -LiteralPath $script:LogPath -Value @(
+            "$processed`tProcessed`t`t2026-05-31T00:00:00.000Z",
+            "$notPlayable`tSkipped`tNotPlayable`t2026-05-31T00:00:00.000Z",
+            "$failed`tFailed`tVLC crashed`t2026-05-31T00:00:00.000Z",
+            "$noFrames`tProcessed`tNoFrames`t2026-05-31T00:00:00.000Z",
+            "$probeError`tSkipped`tVideoProbeError`t2026-05-31T00:00:00.000Z",
+            "$timedOut`tTimedOutProcessed`tCapReached`t2026-05-31T00:00:00.000Z"
+        )
+
+        $index = Get-ResumeIndex -Path $script:LogPath -RetryUnplayable
+
+        $index.Contains((Resolve-VideoPath -Path $processed)) | Should -BeTrue
+        $index.Contains((Resolve-VideoPath -Path $notPlayable)) | Should -BeFalse
         $index.Contains((Resolve-VideoPath -Path $failed)) | Should -BeFalse
         $index.Contains((Resolve-VideoPath -Path $noFrames)) | Should -BeFalse
         $index.Contains((Resolve-VideoPath -Path $probeError)) | Should -BeFalse

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.Preflight.Tests.ps1
@@ -37,7 +37,7 @@ BeforeAll {
     }
     function Test-FolderWritable { param([string]$Path) New-Item -ItemType Directory -Path $Path -Force | Out-Null; return $true }
     function Test-CommandAvailable { param([string]$CommandName) $null -ne (Get-Command $CommandName -ErrorAction SilentlyContinue) }
-    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Get-ResumeIndex { param([string]$Path, [switch]$RetryUnplayable) $script:LastRetryUnplayable = [bool]$RetryUnplayable; [System.Collections.Generic.HashSet[string]]::new() }
     function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
     function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
     function Write-ProcessedLog {
@@ -60,6 +60,7 @@ Describe 'Start-VideoBatch -VerifyVideos pre-flight' {
         $script:ProbeCalls = @()
         $script:ProcessedLogCalls = @()
         $script:StartVlcCalls = 0
+        $script:LastRetryUnplayable = $null
 
         $script:SourceFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-source-{0}" -f [System.Guid]::NewGuid().ToString('N'))
         $script:SaveFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("video-save-{0}" -f [System.Guid]::NewGuid().ToString('N'))
@@ -87,5 +88,11 @@ Describe 'Start-VideoBatch -VerifyVideos pre-flight' {
         $script:ProcessedLogCalls | Should -HaveCount 1
         $script:ProcessedLogCalls[0].Status | Should -Be 'Skipped'
         $script:ProcessedLogCalls[0].Reason | Should -Be 'NotPlayable'
+    }
+
+    It 'passes RetryUnplayable through to the resume index builder' {
+        Start-VideoBatch -SourceFolder $script:SourceFolder -SaveFolder $script:SaveFolder -VlcExe $script:FakeVlc -RetryUnplayable -IncludeExtensions '.webm'
+
+        $script:LastRetryUnplayable | Should -BeTrue
     }
 }

--- a/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Start-VideoBatch.ProcessedLog.Tests.ps1
@@ -37,7 +37,7 @@ BeforeAll {
         }
     }
     function Test-FolderWritable { param([string]$Path) New-Item -ItemType Directory -Path $Path -Force | Out-Null; return $true }
-    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Get-ResumeIndex { param([string]$Path, [switch]$RetryUnplayable) $script:LastRetryUnplayable = [bool]$RetryUnplayable; [System.Collections.Generic.HashSet[string]]::new() }
     function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
     function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
     function Write-ProcessedLog {

--- a/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
+++ b/tests/powershell/modules/Media/Videoscreenshot/Video.SceneChange.Tests.ps1
@@ -47,7 +47,7 @@ BeforeAll {
     }
     function Test-FolderWritable { param([string]$Path) New-Item -ItemType Directory -Path $Path -Force | Out-Null; return $true }
     function Test-CommandAvailable { param([string]$CommandName) return $false }
-    function Get-ResumeIndex { param([string]$Path) [System.Collections.Generic.HashSet[string]]::new() }
+    function Get-ResumeIndex { param([string]$Path, [switch]$RetryUnplayable) $script:LastRetryUnplayable = [bool]$RetryUnplayable; [System.Collections.Generic.HashSet[string]]::new() }
     function Resolve-VideoPath { param([string]$Path) [System.IO.Path]::GetFullPath($Path) }
     function Initialize-PidRegistry { param($Context, [string]$SaveFolder, [string]$RunGuid) Join-Path $SaveFolder 'pids.txt' }
     function Unregister-RunPid { param($Context, [int]$ProcessId) $script:UnregisterRunPidCalls++ }


### PR DESCRIPTION
### Motivation
- Recover from false `Skipped`/`NotPlayable` pre-flight probe skips by allowing an opt-in resume run to re-attempt those videos instead of permanently skipping them.

### Description
- Add a `-RetryUnplayable` switch to `Start-VideoBatch` and expose it in the parameter help and ignored-parameter warnings. 
- Wire `-RetryUnplayable` through to `Get-ResumeIndex` so `Convert-ProcessedLogLineToResumePath` / `Test-ProcessedLogEntryShouldSkip` treat `Skipped`/`NotPlayable` rows as retry-eligible when the switch is supplied. 
- Update `Private/Processed.Log.ps1` to accept a `-RetryUnplayable` flag and change skip logic accordingly. 
- Bump module `ModuleVersion` to `3.6.0`, update `Videoscreenshot.psd1` `ReleaseNotes`, and add a `3.6.0` entry to the module `CHANGELOG.md`. 
- Document the new recovery flow and `-RetryUnplayable` usage in `README.md`. 
- Expand Pester coverage: add tests that verify default `NotPlayable` skipping, opt-in `-RetryUnplayable` behavior, and that `Start-VideoBatch` passes the flag through to the resume index builder (mocks updated to accept the new parameter).

### Testing
- Ran repository checks (`git diff --check`) and made sure updated files are staged/committed; static edits validated by local diffs. 
- Attempted to run PowerShell/Pester tests but the environment lacks `pwsh`, so Pester suites could not be executed here; unit test files were updated to cover the new behavior. 
- Manual code inspection and automated search were used to verify the new flag is propagated (`Start-VideoBatch` -> `Get-ResumeIndex`) and that help/docs (`README.md`, `CHANGELOG.md`, manifest) were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203e0baf3c8325b911ec2034843f00)