### PR TITLE
Fix path resolution for module imports

### DIFF
--- a/src/powershell/file-management/FileDistributor.ps1
+++ b/src/powershell/file-management/FileDistributor.ps1
@@ -333,15 +333,19 @@ foreach ($module in $requiredModules) {
     $modulePath = $module.Path
     $moduleName = $module.Name
 
-    if (-not (Test-Path -LiteralPath $modulePath)) {
+    # Resolve the path to normalize it and verify it exists
+    $resolvedPath = $null
+    try {
+        $resolvedPath = (Resolve-Path -LiteralPath $modulePath -ErrorAction Stop).Path
+    } catch {
         Write-Error "FATAL: Required module '$moduleName' not found at: $modulePath" -ErrorAction Stop
         exit 1
     }
 
     try {
-        Import-Module -Name $modulePath -Force -ErrorAction Stop
+        Import-Module -Name $resolvedPath -Force -ErrorAction Stop
     } catch {
-        Write-Error "FATAL: Failed to import module '$moduleName' from: $modulePath`nError: $($_.Exception.Message)" -ErrorAction Stop
+        Write-Error "FATAL: Failed to import module '$moduleName' from: $resolvedPath`nError: $($_.Exception.Message)" -ErrorAction Stop
         exit 1
     }
 }


### PR DESCRIPTION
Use Resolve-Path to normalize module paths (resolving .. to actual parent directory) before importing. This ensures:
1. Paths are properly resolved and absolute
2. Missing modules are caught early with clear path in error message
3. Import-Module receives valid absolute paths

Fixes issue where relative paths with .. were not being resolved correctly, causing module import failures even when modules existed.

https://claude.ai/code/session_01Q3FxphT8PKkPUCEA5MVumY